### PR TITLE
FYLE-1zgmktc: Unify ccc and expenses - Expenses card changes in list view

### DIFF
--- a/src/app/shared/components/expenses-card/expenses-card.component.html
+++ b/src/app/shared/components/expenses-card/expenses-card.component.html
@@ -215,7 +215,11 @@
                 <span class="expenses-card--amount">{{
                   expense.tx_amount || expense?.tx_extracted_data?.amount || 0 | humanizeCurrency: homeCurrency:2:true
                 }}</span>
-                <mat-icon class="expenses-card--icon" svgIcon="{{ paymentModeIcon }}"></mat-icon>
+                <mat-icon
+                  *ngIf="expense.source_account_type === 'PERSONAL_ACCOUNT' && !expense.tx_skip_reimbursement"
+                  class="expenses-card--icon"
+                  svgIcon="fy-reimbursable"
+                ></mat-icon>
               </div>
 
               <div

--- a/src/app/shared/components/expenses-card/expenses-card.component.ts
+++ b/src/app/shared/components/expenses-card/expenses-card.component.ts
@@ -73,8 +73,6 @@ export class ExpensesCardComponent implements OnInit {
 
   foreignCurrencySymbol = '';
 
-  paymentModeIcon: string;
-
   isScanInProgress: boolean;
 
   isProjectEnabled$: Observable<boolean>;
@@ -281,24 +279,6 @@ export class ExpensesCardComponent implements OnInit {
     this.getReceipt();
 
     this.handleScanStatus();
-
-    this.setOtherData();
-  }
-
-  setOtherData() {
-    if (this.expense.source_account_type === 'PERSONAL_CORPORATE_CREDIT_CARD_ACCOUNT') {
-      if (this.expense.tx_corporate_credit_card_expense_group_id) {
-        this.paymentModeIcon = 'fy-matched';
-      } else {
-        this.paymentModeIcon = 'fy-unmatched';
-      }
-    } else {
-      if (!this.expense.tx_skip_reimbursement) {
-        this.paymentModeIcon = 'fy-reimbursable';
-      } else {
-        this.paymentModeIcon = 'fy-non-reimbursable';
-      }
-    }
   }
 
   getScanningReceiptCard(expense: Expense): boolean {


### PR DESCRIPTION
### Changes

- The reimbursable icon is shown for expenses which are `Paid by me`

![Screenshot 2022-01-25 at 7 03 35 PM](https://user-images.githubusercontent.com/31147415/150986511-67c63085-9980-4846-b4c1-1113430c3f11.png)
