### PR TITLE
Save cropped image as jpeg

### DIFF
--- a/src/app/fyle/capture-receipt/crop-receipt/crop-receipt.component.html
+++ b/src/app/fyle/capture-receipt/crop-receipt/crop-receipt.component.html
@@ -19,6 +19,7 @@
       [maintainAspectRatio]="false"
       (imageLoaded)="imageLoaded()"
       class="crop-receipt__cropper"
+      format="jpeg"
     ></image-cropper>
   </div>
 </ion-content>


### PR DESCRIPTION
This solves the `Incorrect Padding` and `CORS error` issues