### PR TITLE
Remove ellipsis from org name in sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ ios/App/App/Info.plist
 package-lock.json
 setup.sh
 .env
+.angular

--- a/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.html
+++ b/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.html
@@ -17,7 +17,7 @@
               src="../../../../../assets/svg/organization.svg"
               slot="icon-only"
             ></ion-icon>
-            <div class="text-ellipsis sidemenu-header__content-container__sub-title">{{ activeOrg?.name }}</div>
+            <div class="sidemenu-header__content-container__sub-title">{{ activeOrg?.name }}</div>
           </div>
         </ion-col>
       </ion-row>


### PR DESCRIPTION
Before:
![localhost_8100_enterprise_my_dashboard(iPhone SE)](https://user-images.githubusercontent.com/39493102/156158301-c2aa474e-efb1-40d7-9e6c-8a89c845d2b8.png)

After:
![localhost_8100_enterprise_my_dashboard(iPhone SE) (4)](https://user-images.githubusercontent.com/39493102/156158288-00e96e62-2005-4434-909d-7ffbddc39a72.png)

