### PR TITLE
Fix `Assert: cannot be animating` error in mobile app

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -231,12 +231,13 @@ export class AppComponent implements OnInit {
         this.previousUrl = this.router.url;
       }
       if (ev instanceof NavigationEnd) {
-        this.menuController.swipeGesture(false);
         if (
           ev.urlAfterRedirects.indexOf('enterprise') > -1 &&
           !(ev.urlAfterRedirects.indexOf('delegated_accounts') > -1)
         ) {
-          this.menuController.swipeGesture(true);
+          setTimeout(() => this.menuController.swipeGesture(true), 500);
+        } else {
+          setTimeout(() => this.menuController.swipeGesture(false), 500);
         }
       }
     });


### PR DESCRIPTION
The error is because we are switching the swipe gesture while the menu controller is closing(animating). So adding a timeout of 500ms so that the swipe gesture is enabled/disabled after the animation

Ps - This also fixes the annoying debuggers we see on the browser while switching routes

Ref - https://github.com/ionic-team/ionic-framework/issues/19000
![image](https://user-images.githubusercontent.com/39493102/157458434-8d59c6c8-e283-4043-acd6-be2ccddc8b81.png)
