### PR TITLE
Fix Whitelisted URLs issue in both ios and android

### DIFF
--- a/android/app/src/main/res/xml/config.xml
+++ b/android/app/src/main/res/xml/config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <widget version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <!-- It doesn't matter what value is added to origin - https://capacitorjs.com/docs/v2/cordova/using-cordova-plugins#:~:text=Capacitor%20does%20not%20support%20Cordova,things%20like%20hooks%20are%20unnecessary -->
-  <access origin="http://*.google.com" />
+  <access origin="https://app.fylehq.com" />
   
   <feature name="GooglePlus">
     <param name="android-package" value="nl.xservices.plugins.GooglePlus"/>

--- a/ios/App/App/config.xml
+++ b/ios/App/App/config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <widget version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <!-- It doesn't matter what value is added to origin - https://capacitorjs.com/docs/v2/cordova/using-cordova-plugins#:~:text=Capacitor%20does%20not%20support%20Cordova,things%20like%20hooks%20are%20unnecessary -->
-  <access origin="http://*.google.com" />
+  <access origin="https://app.fylehq.com" />
   
   <feature name="DecimalKeyboard">
     <param name="ios-package" value="CDVDecimalKeyboard" onload="true"/>


### PR DESCRIPTION
It doesn't matter what value is added to origin - https://capacitorjs.com/docs/v2/cordova/using-cordova-plugins#:~:text=Capacitor%20does%20not%20support%20Cordova%20install%20variables%2C%20auto%20configuration%2C%20or%20hooks%2C%20due%20to%20our%20philosophy%20of%20letting%20you%20control%20your%20native%20project%20source%20code%20(meaning%20things%20like%20hooks%20are%20unnecessary).

VAPT DOC - https://www.notion.so/fyleuniverse/Vapt-q1-2022-fa65f76bc48f48f68e2974c07f7738da#40f7e5abb7404dd8aced6dadd7e13f43