### PR TITLE
Disable backup and obfuscate bytecode

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -12,8 +12,18 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+          // Enables code shrinking, obfuscation, and optimization for only
+          // your project's release build type.
+          minifyEnabled true
+          // Enables resource shrinking, which is performed by the
+          // Android Gradle plugin.
+          shrinkResources true
+          // Includes the default ProGuard rules files that are packaged with
+          // the Android Gradle plugin. To learn more, go to the section about
+          // R8 configuration files.
+          proguardFiles getDefaultProguardFile(
+          'proguard-android-optimize.txt'),
+          'proguard-rules.pro'
         }
     }
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -12,15 +12,8 @@ android {
     }
     buildTypes {
         release {
-          // Enables code shrinking, obfuscation, and optimization for only
-          // your project's release build type.
           minifyEnabled true
-          // Enables resource shrinking, which is performed by the
-          // Android Gradle plugin.
           shrinkResources true
-          // Includes the default ProGuard rules files that are packaged with
-          // the Android Gradle plugin. To learn more, go to the section about
-          // R8 configuration files.
           proguardFiles getDefaultProguardFile(
           'proguard-android-optimize.txt'),
           'proguard-rules.pro'

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -20,7 +20,8 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-// Basic proguard rules
+# Basic proguard rules
+
 -optimizations !code/simplification/arithmetic
 -keepattributes <em>Annotation</em>
 -keepattributes InnerClasses
@@ -30,15 +31,19 @@
 -forceprocessing
 -optimizationpasses 5
 -overloadaggressively
-// Removing logging code
+
+# Removing logging code
+
 -assumenosideeffects class android.util.Log {
-public static *** d();
-public static *** v();
-public static *** i();
-public static *** w();
-public static *** e();
+  public static *** d();
+  public static *** v();
+  public static *** i();
+  public static *** w();
+  public static *** e();
 }
-// Crashlytics code as given below which one can exclude
+
+# Crashlytics code as given below which one can exclude
+
 -keep class com.crashlytics.** { *; }
 -keep class com.crashlytics.android.**
 -keepattributes SourceFile,LineNumberTable

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -19,3 +19,26 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+// Basic proguard rules
+-optimizations !code/simplification/arithmetic
+-keepattributes <em>Annotation</em>
+-keepattributes InnerClasses
+-keepattributes EnclosingMethod
+-keep class *<em>.R$</em>
+-dontskipnonpubliclibraryclasses
+-forceprocessing
+-optimizationpasses 5
+-overloadaggressively
+// Removing logging code
+-assumenosideeffects class android.util.Log {
+public static *** d();
+public static *** v();
+public static *** i();
+public static *** w();
+public static *** e();
+}
+// Crashlytics code as given below which one can exclude
+-keep class com.crashlytics.** { *; }
+-keep class com.crashlytics.android.**
+-keepattributes SourceFile,LineNumberTable

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="com.ionicframework.fyle595781">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
Issue - Application backup might contain sensitive information private data of the app into their PC
Docs - https://developer.android.com/guide/topics/manifest/application-element#:~:text=for%20more%20information.-,android%3AallowBackup,via%20adb.%20The%20default%20value%20of%20this%20attribute%20is%20true.,-Note%3A%20If%20your

Issue - Application is vulnerable to reverse engineering without any obfuscation
Docs - https://developer.android.com/studio/build/shrink-code#groovy