### PR TITLE
Remove audio permissions in android app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -72,7 +72,4 @@
     <!-- Navigator.getUserMedia -->
     <!-- Video -->
     <uses-permission android:name="android.permission.CAMERA" />
-    <!-- Audio -->
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
 </manifest>


### PR DESCRIPTION
🟢 Tested the changes on android

Notion link - https://www.notion.so/fyleuniverse/Vapt-q1-2022-fa65f76bc48f48f68e2974c07f7738da#51f394d497314f4e84cca2d27f329570

The other permissions are added by google play services which we use for showing push notifications - https://stackoverflow.com/questions/32646830/more-permissions-in-uploaded-apk-than-in-manifest-file
