### PR TITLE
Fix logic for deleting expenses

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -40,11 +40,13 @@
         <ion-icon [src]="'../../../assets/svg/fy-chat-2.svg'" slot="icon-only"></ion-icon>
       </ion-button>
       <ng-container
-        *ngIf="(reviewList?.length || mode === 'edit') && canDeleteExpense && !(isUnifyCcceExpensesSettingsEnabled && isCccExpense) && etxn$|async as etxn"
+        *ngIf="(reviewList?.length || mode === 'edit') && !(isUnifyCcceExpensesSettingsEnabled && isCccExpense) && etxn$|async as etxn"
       >
-        <ion-button class="add-edit-expense--header-btn-container__btn" (click)="deleteExpense(etxn.tx.report_id)">
-          <ion-icon [src]="'../../../assets/svg/fy-delete.svg'" slot="icon-only"></ion-icon>
-        </ion-button>
+        <ng-container *ngIf="canRemoveFromReport || (!isRedirectedFromReport && !etxn.tx.report_id)">
+          <ion-button class="add-edit-expense--header-btn-container__btn" (click)="deleteExpense(etxn.tx.report_id)">
+            <ion-icon [src]="'../../../assets/svg/fy-delete.svg'" slot="icon-only"></ion-icon>
+          </ion-button>
+        </ng-container>
       </ng-container>
 
       <ng-container *ngIf="etxn$|async as etxn">

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -312,7 +312,9 @@ export class AddEditExpensePage implements OnInit {
 
   taxGroupsOptions$: Observable<{ label: string; value: any }[]>;
 
-  canDeleteExpense = true;
+  isRedirectedFromReport = false;
+
+  canRemoveFromReport = false;
 
   isUnifyCcceExpensesSettingsEnabled: boolean;
 
@@ -952,9 +954,8 @@ export class AddEditExpensePage implements OnInit {
   }
 
   ngOnInit() {
-    if (this.activatedRoute.snapshot.params.remove_from_report) {
-      this.canDeleteExpense = this.activatedRoute.snapshot.params.remove_from_report === 'true';
-    }
+    this.isRedirectedFromReport = this.activatedRoute.snapshot.params.remove_from_report ? true : false;
+    this.canRemoveFromReport = this.activatedRoute.snapshot.params.remove_from_report === 'true';
   }
 
   getFormValidationErrors() {
@@ -4132,15 +4133,13 @@ export class AddEditExpensePage implements OnInit {
 
   async deleteExpense(reportId?: string) {
     const id = this.activatedRoute.snapshot.params.id;
-    const removeExpenseFromReport = this.activatedRoute.snapshot.params.remove_from_report;
-
-    const header = reportId && removeExpenseFromReport ? 'Remove Expense' : 'Delete Expense';
+    const header = reportId && this.isRedirectedFromReport ? 'Remove Expense' : 'Delete Expense';
     const body =
-      reportId && removeExpenseFromReport
+      reportId && this.isRedirectedFromReport
         ? 'Are you sure you want to remove this expense from this report?'
         : 'Are you sure you want to delete this expense?';
-    const ctaText = reportId && removeExpenseFromReport ? 'Remove' : 'Delete';
-    const ctaLoadingText = reportId && removeExpenseFromReport ? 'Removing' : 'Deleting';
+    const ctaText = reportId && this.isRedirectedFromReport ? 'Remove' : 'Delete';
+    const ctaLoadingText = reportId && this.isRedirectedFromReport ? 'Removing' : 'Deleting';
 
     const deletePopover = await this.popoverController.create({
       component: FyDeleteDialogComponent,
@@ -4152,7 +4151,7 @@ export class AddEditExpensePage implements OnInit {
         ctaText,
         ctaLoadingText,
         deleteMethod: () => {
-          if (reportId && removeExpenseFromReport) {
+          if (reportId && this.isRedirectedFromReport) {
             return this.reportService.removeTransaction(reportId, id);
           }
           return this.transactionService.delete(id);

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
@@ -37,10 +37,12 @@
       <ion-button class="add-edit-mileage--header-btn-container__btn" (click)="openCommentsModal()">
         <ion-icon [src]="'../../../assets/svg/fy-chat-2.svg'" slot="icon-only"></ion-icon>
       </ion-button>
-      <ng-container *ngIf="canDeleteExpense && etxn$|async as etxn">
-        <ion-button class="add-edit-mileage--header-btn-container__btn" (click)="deleteExpense(etxn.tx.report_id)">
-          <ion-icon [src]="'../../../assets/svg/fy-delete.svg'" slot="icon-only"></ion-icon>
-        </ion-button>
+      <ng-container *ngIf="etxn$|async as etxn">
+        <ng-container *ngIf="canRemoveFromReport || (!isRedirectedFromReport && !etxn.tx.report_id)">
+          <ion-button class="add-edit-mileage--header-btn-container__btn" (click)="deleteExpense(etxn.tx.report_id)">
+            <ion-icon [src]="'../../../assets/svg/fy-delete.svg'" slot="icon-only"></ion-icon>
+          </ion-button>
+        </ng-container>
       </ng-container>
     </ion-buttons>
   </ion-toolbar>

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -202,7 +202,9 @@ export class AddEditMileagePage implements OnInit {
 
   billableDefaultValue: boolean;
 
-  canDeleteExpense = true;
+  isRedirectedFromReport = false;
+
+  canRemoveFromReport = false;
 
   constructor(
     private router: Router,
@@ -248,9 +250,8 @@ export class AddEditMileagePage implements OnInit {
   }
 
   ngOnInit() {
-    if (this.activatedRoute.snapshot.params.remove_from_report) {
-      this.canDeleteExpense = this.activatedRoute.snapshot.params.remove_from_report === 'true';
-    }
+    this.isRedirectedFromReport = this.activatedRoute.snapshot.params.remove_from_report ? true : false;
+    this.canRemoveFromReport = this.activatedRoute.snapshot.params.remove_from_report === 'true';
   }
 
   goToPrev() {
@@ -2437,15 +2438,14 @@ export class AddEditMileagePage implements OnInit {
 
   async deleteExpense(reportId?: string) {
     const id = this.activatedRoute.snapshot.params.id;
-    const removeExpenseFromReport = this.activatedRoute.snapshot.params.remove_from_report;
 
-    const header = reportId && removeExpenseFromReport ? 'Remove Mileage' : 'Delete Mileage';
+    const header = reportId && this.isRedirectedFromReport ? 'Remove Mileage' : 'Delete Mileage';
     const body =
-      reportId && removeExpenseFromReport
+      reportId && this.isRedirectedFromReport
         ? 'Are you sure you want to remove this mileage expense from this report?'
         : 'Are you sure you want to delete this mileage expense?';
-    const ctaText = reportId && removeExpenseFromReport ? 'Remove' : 'Delete';
-    const ctaLoadingText = reportId && removeExpenseFromReport ? 'Removing' : 'Deleting';
+    const ctaText = reportId && this.isRedirectedFromReport ? 'Remove' : 'Delete';
+    const ctaLoadingText = reportId && this.isRedirectedFromReport ? 'Removing' : 'Deleting';
 
     const deletePopover = await this.popoverController.create({
       component: FyDeleteDialogComponent,
@@ -2457,7 +2457,7 @@ export class AddEditMileagePage implements OnInit {
         ctaText,
         ctaLoadingText,
         deleteMethod: () => {
-          if (reportId && removeExpenseFromReport) {
+          if (reportId && this.isRedirectedFromReport) {
             return this.reportService.removeTransaction(reportId, id);
           }
           return this.transactionService.delete(id);

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
@@ -36,10 +36,12 @@
       <ion-button class="add-edit-per-diem--header-btn-container__btn" (click)="openCommentsModal()">
         <ion-icon [src]="'../../../assets/svg/fy-chat-2.svg'" slot="icon-only"></ion-icon>
       </ion-button>
-      <ng-container *ngIf="canDeleteExpense && etxn$|async as etxn">
-        <ion-button class="add-edit-per-diem--header-btn-container__btn" (click)="deleteExpense(etxn.tx.report_id)">
-          <ion-icon [src]="'../../../assets/svg/fy-delete.svg'" slot="icon-only"></ion-icon>
-        </ion-button>
+      <ng-container *ngIf="etxn$|async as etxn">
+        <ng-container *ngIf="canRemoveFromReport || (!isRedirectedFromReport && !etxn.tx.report_id)">
+          <ion-button class="add-edit-per-diem--header-btn-container__btn" (click)="deleteExpense(etxn.tx.report_id)">
+            <ion-icon [src]="'../../../assets/svg/fy-delete.svg'" slot="icon-only"></ion-icon>
+          </ion-button>
+        </ng-container>
       </ng-container>
     </ion-buttons>
   </ion-toolbar>

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -186,7 +186,9 @@ export class AddEditPerDiemPage implements OnInit {
 
   billableDefaultValue: boolean;
 
-  canDeleteExpense = true;
+  isRedirectedFromReport = false;
+
+  canRemoveFromReport = false;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -232,9 +234,8 @@ export class AddEditPerDiemPage implements OnInit {
   }
 
   ngOnInit() {
-    if (this.activatedRoute.snapshot.params.remove_from_report) {
-      this.canDeleteExpense = this.activatedRoute.snapshot.params.remove_from_report === 'true';
-    }
+    this.isRedirectedFromReport = this.activatedRoute.snapshot.params.remove_from_report ? true : false;
+    this.canRemoveFromReport = this.activatedRoute.snapshot.params.remove_from_report === 'true';
   }
 
   async showClosePopup() {
@@ -2250,15 +2251,13 @@ export class AddEditPerDiemPage implements OnInit {
 
   async deleteExpense(reportId?: string) {
     const id = this.activatedRoute.snapshot.params.id;
-    const removeExpenseFromReport = this.activatedRoute.snapshot.params.remove_from_report;
-
-    const header = reportId && removeExpenseFromReport ? 'Remove Per Diem' : 'Delete  Per Diem';
+    const header = reportId && this.isRedirectedFromReport ? 'Remove Per Diem' : 'Delete  Per Diem';
     const body =
-      reportId && removeExpenseFromReport
+      reportId && this.isRedirectedFromReport
         ? 'Are you sure you want to remove this Per Diem expense from this report?'
         : 'Are you sure you want to delete this Per Diem expense?';
-    const ctaText = reportId && removeExpenseFromReport ? 'Remove' : 'Delete';
-    const ctaLoadingText = reportId && removeExpenseFromReport ? 'Removing' : 'Deleting';
+    const ctaText = reportId && this.isRedirectedFromReport ? 'Remove' : 'Delete';
+    const ctaLoadingText = reportId && this.isRedirectedFromReport ? 'Removing' : 'Deleting';
 
     const deletePopover = await this.popoverController.create({
       component: FyDeleteDialogComponent,
@@ -2270,7 +2269,7 @@ export class AddEditPerDiemPage implements OnInit {
         ctaText,
         ctaLoadingText,
         deleteMethod: () => {
-          if (reportId && removeExpenseFromReport) {
+          if (reportId && this.isRedirectedFromReport) {
             return this.reportService.removeTransaction(reportId, id);
           }
           return this.transactionService.delete(id);


### PR DESCRIPTION
Slack thread - https://fylein.slack.com/archives/CFGRGRY2X/p1649840010266779

The issue:
- When clicking on `Potential Duplicates` task and selecting expense, we saw an option to delete the expense even if it was already a part of report. 
- While redirecting to expense from `View Report`, we pass a `remove_from_report` query param which was not passed here and so we were trying to delete expense from report instead of removing it which is an illegal action.

Solution:
- Hide the delete icon when redirection from duplicate task like we do in the web app

Approach:
- We show the delete icon in two cases - when the report has more than one expense and we can remove it from the report or when we want to delete an unreported expense
- I have added two new member vars - `isRedirectedFromReport` and `canRemoveFromReport` whose purpose can be understood from their names. 
- So, the new condition is - SHOW DELETE ICON if we can remove the expense from report OR (we are NOT redirected from view report page AND the expense is NOT a part of any report)