### PR TITLE
Add device info in mixpanel events

### DIFF
--- a/src/app/core/services/tracking.service.ts
+++ b/src/app/core/services/tracking.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { AuthService } from './auth.service';
 import { DeviceService } from '../../core/services/device.service';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -72,8 +73,9 @@ export class TrackingService {
           platform: deviceInfo.platform,
           webViewVersion: deviceInfo.webViewVersion,
         },
-        appVersion: deviceInfo.appVersion,
+        appVersion: environment.LIVE_UPDATE_APP_VERSION,
       };
+
       if (this.tracking) {
         this.tracking.track(action, properties);
       }

--- a/src/app/core/services/tracking.service.ts
+++ b/src/app/core/services/tracking.service.ts
@@ -64,6 +64,15 @@ export class TrackingService {
         ...properties,
         Asset: 'Mobile',
         DeviceType: deviceInfo.platform,
+        deviceInfo: {
+          manufacturer: deviceInfo.manufacturer,
+          model: deviceInfo.model,
+          operatingSystem: deviceInfo.operatingSystem,
+          osVersion: deviceInfo.osVersion,
+          platform: deviceInfo.platform,
+          webViewVersion: deviceInfo.webViewVersion,
+        },
+        appVersion: deviceInfo.appVersion,
       };
       if (this.tracking) {
         this.tracking.track(action, properties);


### PR DESCRIPTION
Sample values for my device

```
manufacturer:"OnePlus"
model:"AC2001"
operatingSystem:"android"
OVersion:"11"
platform:"android"
webViewVersion:"102.0.5005.125"
```

We can get the actual device name from the manufacturer + model details
Added the os, platform and webview version details just for additional debugging
I've also added app version to all mixpanel events, so we dont need to refer the db everytime