### PR TITLE
Fixed - Cannot read properties of null (reading 'corporate_credit_card_settings')

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1016,8 +1016,8 @@ export class AddEditExpensePage implements OnInit {
           orgSettings && orgSettings.advance_account_settings && orgSettings.advance_account_settings.multiple_accounts;
         const isCCCEnabled =
           orgSettings &&
-          orgSettings.corporate_credit_card_settings.allowed &&
-          orgSettings.corporate_credit_card_settings.enabled;
+          orgSettings.corporate_credit_card_settings?.allowed &&
+          orgSettings.corporate_credit_card_settings?.enabled;
         /**
          * When CCC settings is disabled then we shouldn't show CCC as payment mode on add expense form
          * But if already an expense is created as CCC payment mode then on edit of that expense it should be visible
@@ -2674,8 +2674,8 @@ export class AddEditExpensePage implements OnInit {
         switchMap((orgSettings) => this.etxn$.pipe(map((etxn) => ({ etxn, orgSettings })))),
         filter(
           ({ orgSettings, etxn }) =>
-            (orgSettings.corporate_credit_card_settings.allowed &&
-              orgSettings.corporate_credit_card_settings.enabled) ||
+            (orgSettings.corporate_credit_card_settings?.allowed &&
+              orgSettings.corporate_credit_card_settings?.enabled) ||
             etxn.tx.corporate_credit_card_expense_group_id
         ),
         filter(({ etxn }) => etxn.tx.corporate_credit_card_expense_group_id && etxn.tx.txn_dt),

--- a/src/app/fyle/dashboard/stats/stats.component.ts
+++ b/src/app/fyle/dashboard/stats/stats.component.ts
@@ -187,7 +187,7 @@ export class StatsComponent implements OnInit {
     that.initializeReportStats();
     that.initializeExpensesStats();
     that.offlineService.getOrgSettings().subscribe((orgSettings) => {
-      if (orgSettings.corporate_credit_card_settings.enabled) {
+      if (orgSettings.corporate_credit_card_settings?.enabled) {
         this.isUnifyCCCExpensesSettings =
           orgSettings.unify_ccce_expenses_settings &&
           orgSettings.unify_ccce_expenses_settings.allowed &&

--- a/src/app/shared/components/sidemenu/sidemenu.component.ts
+++ b/src/app/shared/components/sidemenu/sidemenu.component.ts
@@ -152,7 +152,7 @@ export class SidemenuComponent implements OnInit {
       {
         title: 'Corporate Cards',
         isVisible:
-          this.orgSettings.corporate_credit_card_settings.enabled &&
+          this.orgSettings.corporate_credit_card_settings?.enabled &&
           !(
             this.orgSettings.unify_ccce_expenses_settings.allowed &&
             this.orgSettings.unify_ccce_expenses_settings.enabled


### PR DESCRIPTION
https://sentry.io/organizations/fyle-technologies-private-limi/issues/3300138618/?project=5622998&referrer=slack

### Changes
- Fixed all such occurrences where `corporate_credit_card_settings` wasn't checked to be present before reading