### PR TITLE
Fix sentry error - Cannot read properties of null (reading 'us')

### DIFF
--- a/src/app/post-verification/invited-user/invited-user.page.ts
+++ b/src/app/post-verification/invited-user/invited-user.page.ts
@@ -95,7 +95,7 @@ export class InvitedUserPage implements OnInit {
     this.eou$ = from(this.authService.getEou());
 
     this.eou$.subscribe((eou) => {
-      this.fg.controls.fullName.setValue(eou.us.full_name);
+      this.fg.controls.fullName.setValue(eou?.us?.full_name);
     });
   }
 


### PR DESCRIPTION
Sentry link - https://sentry.io/organizations/fyle-technologies-private-limi/issues/3065970118/?project=5622998&query=is%3Aunresolved

Could not repro but this should fix the error