### PR TITLE
Fix duplicates in bulk fyle and shrinking image thumbnail

### DIFF
--- a/src/app/core/services/transactions-outbox.service.ts
+++ b/src/app/core/services/transactions-outbox.service.ts
@@ -360,7 +360,7 @@ export class TransactionsOutboxService {
         .then((val) => val)
         .catch((err) => {
           reject(err);
-          throw err;
+          throw Error(err);
         });
       that.transactionService
         .createTxnWithFiles(entry.transaction, from(fileUploadsPromise))

--- a/src/app/core/services/transactions-outbox.service.ts
+++ b/src/app/core/services/transactions-outbox.service.ts
@@ -135,7 +135,7 @@ export class TransactionsOutboxService {
                   vendor: parsedResponse.vendor_name,
                 };
 
-                entry.transaction.extracted_data = extractedData;
+                entry.transaction.extracted_data = extractedData; 
                 entry.transaction.txn_dt = new Date();
 
                 // TODO: add this to allow amout addtion to extracted expense
@@ -360,7 +360,7 @@ export class TransactionsOutboxService {
         .then((val) => val)
         .catch((err) => {
           reject(err);
-          throw Error(err);
+          throw err;
         });
       that.transactionService
         .createTxnWithFiles(entry.transaction, from(fileUploadsPromise))

--- a/src/app/core/services/transactions-outbox.service.ts
+++ b/src/app/core/services/transactions-outbox.service.ts
@@ -135,7 +135,7 @@ export class TransactionsOutboxService {
                   vendor: parsedResponse.vendor_name,
                 };
 
-                entry.transaction.extracted_data = extractedData; 
+                entry.transaction.extracted_data = extractedData;
                 entry.transaction.txn_dt = new Date();
 
                 // TODO: add this to allow amout addtion to extracted expense

--- a/src/app/core/services/transactions-outbox.service.ts
+++ b/src/app/core/services/transactions-outbox.service.ts
@@ -360,6 +360,7 @@ export class TransactionsOutboxService {
         .then((val) => val)
         .catch((err) => {
           reject(err);
+          throw err;
         });
       that.transactionService
         .createTxnWithFiles(entry.transaction, from(fileUploadsPromise))

--- a/src/app/shared/components/expenses-card/expenses-card.component.scss
+++ b/src/app/shared/components/expenses-card/expenses-card.component.scss
@@ -106,6 +106,7 @@
     border-radius: 8px;
     height: 74px;
     padding: 20px;
+    min-width: 74px;
   }
 
   &--receipt-thumbnail-container {


### PR DESCRIPTION
- Fixes the issue where duplicate expenses were created if the receipt upload errors out
- Also fixed the image shrink issue when the expense is still in outbox