### PR TITLE
Fix for Add to report not appearing while creating expense

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -1013,7 +1013,7 @@
       <ng-container *ngIf="isConnected$|async as isConnected">
         <ng-container *ngIf="etxn$|async as etxn">
           <ng-container *ngIf="!(isCriticalPolicyViolated$|async)">
-            <ng-container *ngIf="canRemoveFromReport">
+            <ng-container *ngIf="canRemoveFromReport || !etxn?.tx?.report_id">
               <ng-container *ngIf="reports$|async as reports">
                 <div class="add-edit-expense--internal-block">
                   <app-fy-add-to-report

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
@@ -491,15 +491,17 @@
             <ng-container *ngIf="isConnected$|async">
               <!-- Hide is offline/ critical policy violation/ draft mileage/ only mileage in the report(vm.canAddToReport)-->
               <ng-container *ngIf="reports$|async as reports">
-                <ng-container *ngIf="!(isCriticalPolicyViolated$|async)">
-                  <ng-container *ngIf="canRemoveFromReport">
-                    <div class="add-edit-mileage--internal-block">
-                      <app-fy-add-to-report
-                        [label]="etxn.tx.report_id ? 'Report' : 'Add to Report'"
-                        [options]="reports"
-                        formControlName="report"
-                      ></app-fy-add-to-report>
-                    </div>
+                <ng-container *ngIf="etxn$|async as etxn">
+                  <ng-container *ngIf="!(isCriticalPolicyViolated$|async)">
+                    <ng-container *ngIf="canRemoveFromReport || !etxn?.tx?.report_id">
+                      <div class="add-edit-mileage--internal-block">
+                        <app-fy-add-to-report
+                          [label]="etxn.tx.report_id ? 'Report' : 'Add to Report'"
+                          [options]="reports"
+                          formControlName="report"
+                        ></app-fy-add-to-report>
+                      </div>
+                    </ng-container>
                   </ng-container>
                 </ng-container>
               </ng-container>

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
@@ -559,15 +559,17 @@
 
                   <ng-container *ngIf="isConnected$|async">
                     <ng-container *ngIf="reports$|async as reports">
-                      <ng-container *ngIf="!(isCriticalPolicyViolated$|async)">
-                        <ng-container *ngIf="canRemoveFromReport">
-                          <div class="add-edit-per-diem--internal-block">
-                            <app-fy-add-to-report
-                              [label]="fg.controls.add_to_new_report.value ? 'Report' : 'Add to Report'"
-                              [options]="reports"
-                              formControlName="report"
-                            ></app-fy-add-to-report>
-                          </div>
+                      <ng-container *ngIf="etxn$|async as etxn">
+                        <ng-container *ngIf="!(isCriticalPolicyViolated$|async)">
+                          <ng-container *ngIf="canRemoveFromReport || !etxn?.tx?.report_id">
+                            <div class="add-edit-per-diem--internal-block">
+                              <app-fy-add-to-report
+                                [label]="fg.controls.add_to_new_report.value ? 'Report' : 'Add to Report'"
+                                [options]="reports"
+                                formControlName="report"
+                              ></app-fy-add-to-report>
+                            </div>
+                          </ng-container>
                         </ng-container>
                       </ng-container>
                     </ng-container>


### PR DESCRIPTION
The add to report change went out in the last live update release
There was a case missed when `canRemoveFromReport` was false while creating expenses, this has been fixed