### PR TITLE
FYLE-2gg3hqk: Removed inconsistency in mobile app while unlinking card from an expense

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -839,15 +839,6 @@ export class AddEditExpensePage implements OnInit {
   }
 
   showFormValidationErrors() {
-    const toastMessage = 'Please enter the required details.';
-    const toastMessageData = {
-      message: toastMessage,
-    };
-    this.matSnackBar.openFromComponent(ToastMessageComponent, {
-      ...this.snackbarProperties.setSnackbarProperties('information', toastMessageData),
-      panelClass: ['msb-info'],
-    });
-    this.trackingService.showToastMessage({ ToastContent: toastMessageData.message });
     this.fg.markAllAsTouched();
     const formContainer = this.formContainer.nativeElement as HTMLElement;
     if (formContainer) {

--- a/src/app/shared/components/capture-receipt/capture-receipt.component.scss
+++ b/src/app/shared/components/capture-receipt/capture-receipt.component.scss
@@ -2,12 +2,10 @@
 
 .capture-receipt {
   &--camera-preview {
-    --background: #{$pure-white};
-    opacity: 0;
+    --background: #{$pure-black};
 
     &__is-active {
       --background: transparent;
-      opacity: 1;
     }
   }
 


### PR DESCRIPTION
### What is the change in behavior?
- Previously, on clicking the `:` button, we showed the mandatory fields to be entered
- In the case of the Web app, we don't require to fill mandatory fields for Unlinking card details or dismiss/marking them as personal
- To fix this inconsistency in the mobile app, after this change:
    - On clicking the dot menu, we show the options available to the user
    - If the user wants to split an expense, they will have to fill the mandatory fields
    - Users will no longer have to fill mandatory fields to unlink card details or dismiss/mark as personal


https://user-images.githubusercontent.com/31147415/179176001-3d1941b3-5030-41f1-abc3-3ecf78e9dad5.mov


