### PR TITLE
Fix error where currency is not loaded/updated on stats badges

### DIFF
--- a/src/app/fyle/dashboard/stat-badge/stat-badge.component.ts
+++ b/src/app/fyle/dashboard/stat-badge/stat-badge.component.ts
@@ -1,13 +1,12 @@
-import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { ReportStates } from './report-states';
-import { getCurrencySymbol } from '@angular/common';
 
 @Component({
   selector: 'app-stat-badge',
   templateUrl: './stat-badge.component.html',
   styleUrls: ['./stat-badge.component.scss'],
 })
-export class StatBadgeComponent implements OnInit {
+export class StatBadgeComponent {
   @Input() reportState: ReportStates;
 
   @Input() name: string;
@@ -18,19 +17,13 @@ export class StatBadgeComponent implements OnInit {
 
   @Input() currency: string;
 
+  @Input() currencySymbol: String;
+
   @Input() loading = false;
 
   @Input() expenseState: string;
 
   @Output() badgeClicked = new EventEmitter();
-
-  currencySymbol = '';
-
-  constructor() {}
-
-  ngOnInit() {
-    this.currencySymbol = getCurrencySymbol(this.currency, 'wide');
-  }
 
   onBadgeClicked() {
     if (!this.loading) {

--- a/src/app/fyle/dashboard/stats/stats.component.html
+++ b/src/app/fyle/dashboard/stats/stats.component.html
@@ -10,6 +10,7 @@
         <ion-col class="stats--report-badge-col stats--report-badge-col__left stats--report-badge-col__top" size="6">
           <app-stat-badge
             [currency]="homeCurrency$ | async"
+            [currencySymbol]="currencySymbol$ | async"
             [name]="'Draft'"
             [reportState]="ReportStates.DRAFT"
             [count]="(draftStats$ | async)?.count"
@@ -21,6 +22,7 @@
         <ion-col class="stats--report-badge-col stats--report-badge-col__right stats--report-badge-col__top" size="6">
           <app-stat-badge
             [currency]="homeCurrency$ | async"
+            [currencySymbol]="currencySymbol$ | async"
             [name]="'Reported'"
             [reportState]="ReportStates.APPROVER_PENDING"
             [count]="(reportedStats$ | async)?.count"
@@ -34,6 +36,7 @@
         <ion-col class="stats--report-badge-col stats--report-badge-col__left stats--report-badge-col__bottom" size="6">
           <app-stat-badge
             [currency]="homeCurrency$ | async"
+            [currencySymbol]="currencySymbol$ | async"
             [name]="'Approved'"
             [reportState]="ReportStates.APPROVED"
             [count]="(approvedStats$ | async)?.count"
@@ -48,6 +51,7 @@
         >
           <app-stat-badge
             [currency]="homeCurrency$ | async"
+            [currencySymbol]="currencySymbol$ | async"
             [name]="'Payment Pending'"
             [reportState]="ReportStates.PAYMENT_PENDING"
             [count]="(paymentPendingStats$ | async)?.count"
@@ -66,6 +70,7 @@
         <ion-col class="stats--report-badge-col stats--report-badge-col__left stats--report-badge-col__top" size="6">
           <app-stat-badge
             [currency]="homeCurrency$ | async"
+            [currencySymbol]="currencySymbol$ | async"
             [name]="'Incomplete'"
             [expenseState]="'DRAFT'"
             [count]="(incompleteExpensesStats$ | async)?.count"
@@ -77,6 +82,7 @@
         <ion-col class="stats--report-badge-col stats--report-badge-col__right stats--report-badge-col__top" size="6">
           <app-stat-badge
             [currency]="homeCurrency$ | async"
+            [currencySymbol]="currencySymbol$ | async"
             [name]="'Unreported'"
             [expenseState]="'COMPLETE'"
             [count]="(unreportedExpensesStats$ | async)?.count"


### PR DESCRIPTION
Bug:
- Sometimes, when opening the dashboard, the currency symbols were not present on stats badges
- Also when switching orgs, the currency symbols were not getting updated based on the org currency

What caused this?
- We are passing `currency` as the value emitted by `homeCurrency$` observable to the stats-badge component
- Inside the `stats-badge` component, we are using `currency` to call the `getSymbol()` method inside `ngOnInit`
- But on initialization of child component, since no value is yet emitted by the observable,  the value of `currency` is `null` which in turn gives us an empty symbol. 

Solution:
- Call the `getSymbol()` method whenever the input `currency` value is updated - `ngOnChanges()` or call `getCurrencySymbol()` directly from template with the updated value or use getters and setters
- Instead of checking for new values again and again, I'm instead passing the `currencySymbol` directly from the parent component