### PR TITLE
Show Cost center code instead of id in view expense/mileage/perdiem

### DIFF
--- a/src/app/fyle/view-expense/view-expense.page.html
+++ b/src/app/fyle/view-expense/view-expense.page.html
@@ -344,7 +344,7 @@
                 </ion-col>
                 <ion-col class="view-expense--content-container">
                   <div class="view-expense--label">Cost Center Code</div>
-                  <div class="view-expense--value">{{ etxn.tx_cost_center_id }}</div>
+                  <div class="view-expense--value">{{ etxn.tx_cost_center_code }}</div>
                 </ion-col>
               </ion-row>
             </ion-grid>

--- a/src/app/fyle/view-mileage/view-mileage.page.html
+++ b/src/app/fyle/view-mileage/view-mileage.page.html
@@ -413,7 +413,7 @@
               </ion-col>
               <ion-col class="view-mileage--content-container">
                 <div class="view-mileage--label">Cost Center Code</div>
-                <div class="view-mileage--value">{{ extendedMileage.tx_cost_center_id }}</div>
+                <div class="view-mileage--value">{{ extendedMileage.tx_cost_center_code }}</div>
               </ion-col>
             </ion-row>
           </ion-grid>

--- a/src/app/fyle/view-per-diem/view-per-diem.page.html
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.html
@@ -293,7 +293,7 @@
               </ion-col>
               <ion-col class="view-per-diem--content-container">
                 <div class="view-per-diem--label">Cost Center Code</div>
-                <div class="view-per-diem--value">{{ extendedPerDiem.tx_cost_center_id }}</div>
+                <div class="view-per-diem--value">{{ extendedPerDiem.tx_cost_center_code }}</div>
               </ion-col>
             </ion-row>
           </ion-grid>


### PR DESCRIPTION
Issue: In mobile app, we show cost center id which we assign internally, instead of cost center code which the admin assigns   to the cost center. This will make the behaviour consistent in web and mobile app
BR link: https://app.clickup.com/t/2me4u8a
