### PR TITLE
Add ld flag to disable keyboard plugin

### DIFF
--- a/src/app/core/services/launch-darkly.service.ts
+++ b/src/app/core/services/launch-darkly.service.ts
@@ -47,6 +47,10 @@ export class LaunchDarklyService {
     this.ldClient.on('change', this.updateCache, this);
   }
 
+  checkIfKeyboardPluginIsDisabled() {
+    return this.getVariation('disable_keyboard_plugin', false);
+  }
+
   private updateCache() {
     if (this.ldClient) {
       const latestFlags = this.ldClient.allFlags();

--- a/src/app/core/services/launch-darkly.service.ts
+++ b/src/app/core/services/launch-darkly.service.ts
@@ -47,8 +47,8 @@ export class LaunchDarklyService {
     this.ldClient.on('change', this.updateCache, this);
   }
 
-  checkIfKeyboardPluginIsDisabled() {
-    return this.getVariation('disable_keyboard_plugin', false);
+  checkIfKeyboardPluginIsEnabled() {
+    return this.getVariation('keyboard_plugin_enabled', true);
   }
 
   private updateCache() {

--- a/src/app/shared/components/fy-number/fy-number.component.html
+++ b/src/app/shared/components/fy-number/fy-number.component.html
@@ -1,5 +1,5 @@
 <input
-  *ngIf="isIos"
+  *ngIf="isIos && !isKeyboardPluginDisabled"
   class="fy-number--input"
   [min]="min"
   [disabled]="disabled"
@@ -12,7 +12,7 @@
   decimal-char="."
 />
 <input
-  *ngIf="!isIos"
+  *ngIf="!isIos || isKeyboardPluginDisabled"
   class="fy-number--input"
   [min]="min"
   [disabled]="disabled"

--- a/src/app/shared/components/fy-number/fy-number.component.html
+++ b/src/app/shared/components/fy-number/fy-number.component.html
@@ -1,5 +1,5 @@
 <input
-  *ngIf="isIos && !isKeyboardPluginDisabled"
+  *ngIf="isIos && isKeyboardPluginEnabled; else inputWithoutPlugin"
   class="fy-number--input"
   [min]="min"
   [disabled]="disabled"
@@ -11,14 +11,15 @@
   decimal="true"
   decimal-char="."
 />
-<input
-  *ngIf="!isIos || isKeyboardPluginDisabled"
-  class="fy-number--input"
-  [min]="min"
-  [disabled]="disabled"
-  [formControl]="fc"
-  [placeholder]="placeholder || ''"
-  (blur)="(onBlur)"
-  type="number"
-  inputmode="decimal"
-/>
+<ng-template #inputWithoutPlugin>
+  <input
+    class="fy-number--input"
+    [min]="min"
+    [disabled]="disabled"
+    [formControl]="fc"
+    [placeholder]="placeholder || ''"
+    (blur)="(onBlur)"
+    type="number"
+    inputmode="decimal"
+  />
+</ng-template>

--- a/src/app/shared/components/fy-number/fy-number.component.html
+++ b/src/app/shared/components/fy-number/fy-number.component.html
@@ -1,16 +1,18 @@
-<input
-  *ngIf="isIos && isKeyboardPluginEnabled; else inputWithoutPlugin"
-  class="fy-number--input"
-  [min]="min"
-  [disabled]="disabled"
-  [formControl]="fc"
-  [placeholder]="placeholder || ''"
-  (blur)="(onBlur)"
-  type="text"
-  pattern="[0-9]*"
-  decimal="true"
-  decimal-char="."
-/>
+<ng-container *ngIf="isIos && isKeyboardPluginEnabled; else inputWithoutPlugin">
+  <input
+    class="fy-number--input"
+    [min]="min"
+    [disabled]="disabled"
+    [formControl]="fc"
+    [placeholder]="placeholder || ''"
+    (blur)="(onBlur)"
+    type="text"
+    pattern="[0-9]*"
+    decimal="true"
+    decimal-char="."
+  />
+</ng-container>
+
 <ng-template #inputWithoutPlugin>
   <input
     class="fy-number--input"

--- a/src/app/shared/components/fy-number/fy-number.component.ts
+++ b/src/app/shared/components/fy-number/fy-number.component.ts
@@ -29,7 +29,7 @@ export class FyNumberComponent implements ControlValueAccessor, OnInit, OnDestro
 
   isIos = false;
 
-  isKeyboardPluginDisabled = false;
+  isKeyboardPluginEnabled = true;
 
   private innerValue;
 
@@ -78,8 +78,8 @@ export class FyNumberComponent implements ControlValueAccessor, OnInit, OnDestro
   ngOnInit() {
     this.isIos = this.platform.is('ios');
     this.launchDarklyService
-      .checkIfKeyboardPluginIsDisabled()
-      .subscribe((isKeyboardPluginDisabled) => (this.isKeyboardPluginDisabled = isKeyboardPluginDisabled));
+      .checkIfKeyboardPluginIsEnabled()
+      .subscribe((isKeyboardPluginEnabled) => (this.isKeyboardPluginEnabled = isKeyboardPluginEnabled));
 
     this.fc = new FormControl();
     this.fc.valueChanges.subscribe((value) => {

--- a/src/app/shared/components/fy-number/fy-number.component.ts
+++ b/src/app/shared/components/fy-number/fy-number.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, forwardRef, Input, OnDestroy, OnInit, Output }
 import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Platform } from '@ionic/angular';
 import { noop } from 'rxjs';
+import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 
 @Component({
   selector: 'app-fy-number',
@@ -28,13 +29,15 @@ export class FyNumberComponent implements ControlValueAccessor, OnInit, OnDestro
 
   isIos = false;
 
+  isKeyboardPluginDisabled = false;
+
   private innerValue;
 
   private onTouchedCallback: () => void = noop;
 
   private onChangeCallback: (_: any) => void = noop;
 
-  constructor(private platform: Platform) {}
+  constructor(private platform: Platform, private launchDarklyService: LaunchDarklyService) {}
 
   get value(): any {
     return this.innerValue;
@@ -74,6 +77,10 @@ export class FyNumberComponent implements ControlValueAccessor, OnInit, OnDestro
 
   ngOnInit() {
     this.isIos = this.platform.is('ios');
+    this.launchDarklyService
+      .checkIfKeyboardPluginIsDisabled()
+      .subscribe((isKeyboardPluginDisabled) => (this.isKeyboardPluginDisabled = isKeyboardPluginDisabled));
+
     this.fc = new FormControl();
     this.fc.valueChanges.subscribe((value) => {
       if (typeof value === 'string') {


### PR DESCRIPTION
- BR link - https://app.clickup.com/t/2fkq1y2
- Tested these changes on iphone 13 🟢  for both cases locally
- This will allow all users in regions with period as decimal separator(includes USD) to use third party keyboards, but users in other regions will still have to use ios default keyboard
- Will add a flag in LD after this pr is approved