### PR TITLE
Fix ios camera preview preview not working sometimes

### DIFF
--- a/src/app/fyle/camera-overlay/camera-overlay.page.html
+++ b/src/app/fyle/camera-overlay/camera-overlay.page.html
@@ -1,1 +1,1 @@
-<app-capture-receipt class="full-height" [isModal]="false"></app-capture-receipt>
+<app-capture-receipt #captureReceipt class="full-height" [isModal]="false"></app-capture-receipt>

--- a/src/app/fyle/camera-overlay/camera-overlay.page.ts
+++ b/src/app/fyle/camera-overlay/camera-overlay.page.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { CaptureReceiptComponent } from 'src/app/shared/components/capture-receipt/capture-receipt.component';
 
 @Component({
   selector: 'app-camera-overlay',
@@ -6,7 +7,17 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./camera-overlay.page.scss'],
 })
 export class CameraOverlayPage implements OnInit {
+  @ViewChild('captureReceipt') captureReceipt: CaptureReceiptComponent;
+
   constructor() {}
 
   ngOnInit() {}
+
+  ionViewWillEnter() {
+    this.captureReceipt.setUpAndStartCamera();
+  }
+
+  ionViewWillLeave() {
+    this.captureReceipt.stopCamera();
+  }
 }

--- a/src/app/shared/components/capture-receipt/capture-receipt.component.ts
+++ b/src/app/shared/components/capture-receipt/capture-receipt.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnDestroy, OnInit, Input, AfterViewInit } from '@angular/core';
+import { Component, EventEmitter, OnInit, Input } from '@angular/core';
 import { CameraPreview, CameraPreviewOptions, CameraPreviewPictureOptions } from '@capacitor-community/camera-preview';
 import { Capacitor } from '@capacitor/core';
 import { ModalController, NavController, PopoverController } from '@ionic/angular';
@@ -28,7 +28,7 @@ type Image = Partial<{
   templateUrl: './capture-receipt.component.html',
   styleUrls: ['./capture-receipt.component.scss'],
 })
-export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit {
+export class CaptureReceiptComponent implements OnInit {
   @Input() isModal = false;
 
   @Input() allowGalleryUploads = true;
@@ -518,13 +518,5 @@ export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit
         this.galleryUpload();
       }
     });
-  }
-
-  ngAfterViewInit() {
-    this.setUpAndStartCamera();
-  }
-
-  ngOnDestroy() {
-    this.stopCamera();
   }
 }

--- a/src/app/shared/components/capture-receipt/capture-receipt.component.ts
+++ b/src/app/shared/components/capture-receipt/capture-receipt.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Input } from '@angular/core';
+import { Component, EventEmitter, OnDestroy, OnInit, Input, AfterViewInit } from '@angular/core';
 import { CameraPreview, CameraPreviewOptions, CameraPreviewPictureOptions } from '@capacitor-community/camera-preview';
 import { Capacitor } from '@capacitor/core';
 import { ModalController, NavController, PopoverController } from '@ionic/angular';
@@ -28,7 +28,7 @@ type Image = Partial<{
   templateUrl: './capture-receipt.component.html',
   styleUrls: ['./capture-receipt.component.scss'],
 })
-export class CaptureReceiptComponent implements OnInit {
+export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() isModal = false;
 
   @Input() allowGalleryUploads = true;
@@ -518,5 +518,17 @@ export class CaptureReceiptComponent implements OnInit {
         this.galleryUpload();
       }
     });
+  }
+
+  ngAfterViewInit() {
+    if (this.isModal) {
+      this.setUpAndStartCamera();
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.isModal) {
+      this.stopCamera();
+    }
   }
 }


### PR DESCRIPTION
- BR link - https://app.clickup.com/t/2np4ufy
- The issue is because, `ngAfterViewInit()` is not getting called sometimes when we use instafyle, save the expense and open the camera again. 
- I've replaced angular llifecycle hooks with the ones provided by ionic - `ionViewWillEnter()` and `ionViewWillLeave()`. This is what ionic recommends as well - [Ref](https://ionicframework.com/docs/angular/lifecycle#:~:text=When%20an%20app,a%20page%20%22popped%22.)