### PR TITLE
Removal of expense fields from loadOptimise() method of offline service

### DIFF
--- a/src/app/core/services/offline.service.ts
+++ b/src/app/core/services/offline.service.ts
@@ -539,11 +539,10 @@ export class OfflineService {
     const orgSettings$ = this.getOrgSettings();
     const orgUserSettings$ = this.getOrgUserSettings();
     const accounts$ = this.getAccounts();
-    const expenseFieldsMap$ = this.getExpenseFieldsMap();
 
     this.loadAppVersion();
 
-    return forkJoin([orgSettings$, orgUserSettings$, accounts$, expenseFieldsMap$]);
+    return forkJoin([orgSettings$, orgUserSettings$, accounts$]);
   }
 
   getCurrentUser() {

--- a/src/app/shared/components/expenses-card/expenses-card.component.html
+++ b/src/app/shared/components/expenses-card/expenses-card.component.html
@@ -16,7 +16,7 @@
   (press)="onSetMultiselectMode()"
 >
   <div class="expenses-card--divider" *ngIf="!showDt"></div>
-  <ng-container *ngIf="expenseFields$ | async as expenseFields">
+  <ng-container>
     <div class="d-flex">
       <div *ngIf="isSelectionModeEnabled" class="expenses-card--checkbox-container">
         <mat-checkbox class="custom-mat-checkbox expenses-card--checkbox" [checked]="isSelected" disabled>
@@ -181,20 +181,8 @@
             >
               {{ expense.vendorDetails }}
             </div>
-
             <div
-              class="expenses-card--vendor"
-              *ngIf="
-                !(isMileageExpense || isPerDiem) &&
-                !expense.vendorDetails &&
-                expenseFields?.vendor_id[0] &&
-                !expenseFields?.vendor_id[0].is_mandatory
-              "
-            >
-              Unspecified {{ expenseFields?.vendor_id[0].field_name }}
-            </div>
-            <div
-              *ngIf="isProjectEnabled$ | async"
+              *ngIf="expenseFields && isProjectEnabled$ | async"
               class="expenses-card--project"
               [ngClass]="{ 'expenses-card--project__not-filled': !expense.tx_project_name }"
             >

--- a/src/app/shared/components/expenses-card/expenses-card.component.ts
+++ b/src/app/shared/components/expenses-card/expenses-card.component.ts
@@ -76,7 +76,7 @@ export class ExpensesCardComponent implements OnInit {
 
   inlineReceiptDataUrl: string;
 
-  expenseFields$: Observable<Partial<ExpenseFieldsMap>>;
+  expenseFields: Partial<ExpenseFieldsMap>;
 
   receiptIcon: string;
 
@@ -287,7 +287,9 @@ export class ExpensesCardComponent implements OnInit {
     this.expense.isPolicyViolated = this.expense.tx_manual_flag || this.expense.tx_policy_flag;
     this.expense.isCriticalPolicyViolated = this.transactionService.getIsCriticalPolicyViolated(this.expense);
     this.expense.vendorDetails = this.transactionService.getVendorDetails(this.expense);
-    this.expenseFields$ = this.offlineService.getExpenseFieldsMap();
+    this.offlineService.getExpenseFieldsMap().subscribe((expenseFields) => {
+      this.expenseFields = expenseFields;
+    });
 
     this.offlineService
       .getHomeCurrency()


### PR DESCRIPTION
### Offline expense
<img width="396" alt="Screenshot 2022-08-30 at 8 00 26 PM" src="https://user-images.githubusercontent.com/31147415/187467795-0789adaf-cf40-465c-9e50-590591688d20.png">
### When online
<img width="401" alt="Screenshot 2022-08-30 at 8 00 41 PM" src="https://user-images.githubusercontent.com/31147415/187467820-df24d4a9-cf93-4a8f-ae5a-5815893c2b4c.png">
### Normal flow
<img width="394" alt="Screenshot 2022-08-30 at 8 01 23 PM" src="https://user-images.githubusercontent.com/31147415/187467835-980f780a-dfab-422f-9147-dc6a615f6514.png">