### PR TITLE
#payment_mode_configurations - Minor changes

### DIFF
--- a/src/app/core/models/org_user_settings.model.ts
+++ b/src/app/core/models/org_user_settings.model.ts
@@ -130,6 +130,8 @@ export interface PersonalCardsSettings {
 }
 
 export interface PaymentModeSettings {
+  allowed: boolean;
+  enabled: boolean;
   allowed_payment_modes: AccountType[];
 }
 

--- a/src/app/core/services/offline.service.ts
+++ b/src/app/core/services/offline.service.ts
@@ -27,7 +27,6 @@ import { ExpenseField } from '../models/v1/expense-field.model';
 import { OrgUserSettings } from '../models/org_user_settings.model';
 import { TaxGroupService } from './tax-group.service';
 import { AccountType } from '../enums/account-type.enum';
-import { LaunchDarklyService } from './launch-darkly.service';
 
 const orgUserSettingsCacheBuster$ = new Subject<void>();
 
@@ -54,8 +53,7 @@ export class OfflineService {
     private orgUserService: OrgUserService,
     private deviceService: DeviceService,
     private expenseFieldsService: ExpenseFieldsService,
-    private taxGroupService: TaxGroupService,
-    private launchDarklyService: LaunchDarklyService
+    private taxGroupService: TaxGroupService
   ) {}
 
   @Cacheable()
@@ -442,21 +440,6 @@ export class OfflineService {
   getAllowedPaymentModes(): Observable<AccountType[]> {
     return this.getOrgUserSettings().pipe(
       map((orgUserSettings) => orgUserSettings?.payment_mode_settings?.allowed_payment_modes)
-    );
-  }
-
-  @Cacheable()
-  checkIfPaymentModeConfigurationsIsEnabled() {
-    return forkJoin({
-      isPaymentModeConfigurationsEnabled: this.launchDarklyService.checkIfPaymentModeConfigurationsIsEnabled(),
-      orgUserSettings: this.getOrgUserSettings(),
-    }).pipe(
-      map(
-        ({ isPaymentModeConfigurationsEnabled, orgUserSettings }) =>
-          isPaymentModeConfigurationsEnabled &&
-          orgUserSettings.payment_mode_settings.allowed &&
-          orgUserSettings.payment_mode_settings.enabled
-      )
     );
   }
 

--- a/src/app/core/services/offline.service.ts
+++ b/src/app/core/services/offline.service.ts
@@ -27,6 +27,7 @@ import { ExpenseField } from '../models/v1/expense-field.model';
 import { OrgUserSettings } from '../models/org_user_settings.model';
 import { TaxGroupService } from './tax-group.service';
 import { AccountType } from '../enums/account-type.enum';
+import { LaunchDarklyService } from './launch-darkly.service';
 
 const orgUserSettingsCacheBuster$ = new Subject<void>();
 
@@ -53,7 +54,8 @@ export class OfflineService {
     private orgUserService: OrgUserService,
     private deviceService: DeviceService,
     private expenseFieldsService: ExpenseFieldsService,
-    private taxGroupService: TaxGroupService
+    private taxGroupService: TaxGroupService,
+    private launchDarklyService: LaunchDarklyService
   ) {}
 
   @Cacheable()
@@ -440,6 +442,21 @@ export class OfflineService {
   getAllowedPaymentModes(): Observable<AccountType[]> {
     return this.getOrgUserSettings().pipe(
       map((orgUserSettings) => orgUserSettings?.payment_mode_settings?.allowed_payment_modes)
+    );
+  }
+
+  @Cacheable()
+  checkIfPaymentModeConfigurationsIsEnabled() {
+    return forkJoin({
+      isPaymentModeConfigurationsEnabled: this.launchDarklyService.checkIfPaymentModeConfigurationsIsEnabled(),
+      orgUserSettings: this.getOrgUserSettings(),
+    }).pipe(
+      map(
+        ({ isPaymentModeConfigurationsEnabled, orgUserSettings }) =>
+          isPaymentModeConfigurationsEnabled &&
+          orgUserSettings.payment_mode_settings.allowed &&
+          orgUserSettings.payment_mode_settings.enabled
+      )
     );
   }
 

--- a/src/app/core/services/payment-modes.service.spec.ts
+++ b/src/app/core/services/payment-modes.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { ViewExpenseService } from './view-expense.service';
+import { PaymentModesService } from './payment-modes.service';
 
-xdescribe('ViewExpenseService', () => {
-  let service: ViewExpenseService;
+xdescribe('PaymentModesService', () => {
+  let service: PaymentModesService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(ViewExpenseService);
+    service = TestBed.inject(PaymentModesService);
   });
 
   it('should be created', () => {

--- a/src/app/core/services/payment-modes.service.ts
+++ b/src/app/core/services/payment-modes.service.ts
@@ -35,7 +35,7 @@ export class PaymentModesService {
   shouldPaymentModeBeShown(etxn: Expense, expenseType: ExpenseType): Observable<boolean> {
     return forkJoin({
       allowedPaymentModes: this.offlineService.getAllowedPaymentModes(),
-      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.checkIfPaymentModeConfigurationsIsEnabled(),
     }).pipe(
       map(({ allowedPaymentModes, isPaymentModeConfigurationsEnabled }) => {
         const isMileageOrPerDiemExpense = [ExpenseType.MILEAGE, ExpenseType.PER_DIEM].includes(expenseType);

--- a/src/app/core/services/view-expense.service.ts
+++ b/src/app/core/services/view-expense.service.ts
@@ -24,6 +24,15 @@ export class ViewExpenseService {
           allowedPaymentModes = allowedPaymentModes.filter(
             (allowedPaymentMode) => allowedPaymentMode !== AccountType.CCC
           );
+
+          /*
+           * For mileage and per-diem expenses, since default payment mode is PERSONAL_ACCOUNT,
+           * we don't show Payment Mode field if COMPANY_ACCOUNT and PERSONAL_ADVANCE_ACCOUNT
+           * are not present
+           */
+          if (!allowedPaymentModes.length) {
+            return false;
+          }
         }
         if (isPaymentModeConfigurationsEnabled && allowedPaymentModes.length === 1) {
           const etxnAccountType = this.accountsService.getEtxnAccountType(etxn);

--- a/src/app/core/services/view-expense.service.ts
+++ b/src/app/core/services/view-expense.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { AccountsService } from './accounts.service';
 import { OfflineService } from './offline.service';
-import { LaunchDarklyService } from './launch-darkly.service';
 import { Expense } from '../models/expense.model';
 import { map } from 'rxjs/operators';
 import { forkJoin, Observable } from 'rxjs';
@@ -12,16 +11,12 @@ import { AccountType } from '../enums/account-type.enum';
   providedIn: 'root',
 })
 export class ViewExpenseService {
-  constructor(
-    private accountsService: AccountsService,
-    private offlineService: OfflineService,
-    private launchDarklyService: LaunchDarklyService
-  ) {}
+  constructor(private accountsService: AccountsService, private offlineService: OfflineService) {}
 
   shouldPaymentModeBeShown(etxn: Expense, expenseType: ExpenseType): Observable<boolean> {
     return forkJoin({
       allowedPaymentModes: this.offlineService.getAllowedPaymentModes(),
-      isPaymentModeConfigurationsEnabled: this.launchDarklyService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
     }).pipe(
       map(({ allowedPaymentModes, isPaymentModeConfigurationsEnabled }) => {
         const isMileageOrPerDiemExpense = [ExpenseType.MILEAGE, ExpenseType.PER_DIEM].includes(expenseType);

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -103,6 +103,7 @@ import { AccountOption } from 'src/app/core/models/account-option.model';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
 import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 import { ExpenseType } from 'src/app/core/enums/expense-type.enum';
+import { PaymentModesService } from 'src/app/core/services/payment-modes.service';
 
 @Component({
   selector: 'app-add-edit-expense',
@@ -382,7 +383,8 @@ export class AddEditExpensePage implements OnInit {
     public platform: Platform,
     private titleCasePipe: TitleCasePipe,
     private handleDuplicates: HandleDuplicatesService,
-    private launchDarklyService: LaunchDarklyService
+    private launchDarklyService: LaunchDarklyService,
+    private paymentModesService: PaymentModesService
   ) {}
 
   @HostListener('keydown')
@@ -1011,7 +1013,7 @@ export class AddEditExpensePage implements OnInit {
       orgSettings: this.offlineService.getOrgSettings(),
       etxn: this.etxn$,
       allowedPaymentModes: this.offlineService.getAllowedPaymentModes(),
-      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.paymentModesService.checkIfPaymentModeConfigurationsIsEnabled(),
       isPaidByCompanyHidden: this.launchDarklyService.checkIfPaidByCompanyIsHidden(),
     }).pipe(
       map(
@@ -1403,7 +1405,7 @@ export class AddEditExpensePage implements OnInit {
     const defaultPaymentMode$ = forkJoin({
       paymentModes: this.paymentModes$,
       orgUserSettings: this.orgUserSettings$,
-      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.paymentModesService.checkIfPaymentModeConfigurationsIsEnabled(),
     }).pipe(
       map(({ paymentModes, orgUserSettings, isPaymentModeConfigurationsEnabled }) => {
         //If the user is creating expense from Corporate cards page, the default payment mode should be CCC
@@ -2638,7 +2640,7 @@ export class AddEditExpensePage implements OnInit {
 
     forkJoin({
       paymentModes: this.paymentModes$,
-      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.paymentModesService.checkIfPaymentModeConfigurationsIsEnabled(),
     }).subscribe(({ paymentModes, isPaymentModeConfigurationsEnabled }) => {
       // Hide payment mode if Unify CCC is enabled and it is a CCC expense
       const hidePaymentModeForCCCExpense = this.isUnifyCcceExpensesSettingsEnabled && this.isCccExpense;

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1011,7 +1011,7 @@ export class AddEditExpensePage implements OnInit {
       orgSettings: this.offlineService.getOrgSettings(),
       etxn: this.etxn$,
       allowedPaymentModes: this.offlineService.getAllowedPaymentModes(),
-      isPaymentModeConfigurationsEnabled: this.launchDarklyService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
       isPaidByCompanyHidden: this.launchDarklyService.checkIfPaidByCompanyIsHidden(),
     }).pipe(
       map(
@@ -1403,7 +1403,7 @@ export class AddEditExpensePage implements OnInit {
     const defaultPaymentMode$ = forkJoin({
       paymentModes: this.paymentModes$,
       orgUserSettings: this.orgUserSettings$,
-      isPaymentModeConfigurationsEnabled: this.launchDarklyService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
     }).pipe(
       map(({ paymentModes, orgUserSettings, isPaymentModeConfigurationsEnabled }) => {
         //If the user is creating expense from Corporate cards page, the default payment mode should be CCC
@@ -2638,7 +2638,7 @@ export class AddEditExpensePage implements OnInit {
 
     forkJoin({
       paymentModes: this.paymentModes$,
-      isPaymentModeConfigurationsEnabled: this.launchDarklyService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
     }).subscribe(({ paymentModes, isPaymentModeConfigurationsEnabled }) => {
       // Hide payment mode if Unify CCC is enabled and it is a CCC expense
       const hidePaymentModeForCCCExpense = this.isUnifyCcceExpensesSettingsEnabled && this.isCccExpense;

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -62,6 +62,7 @@ import { AccountOption } from 'src/app/core/models/account-option.model';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
 import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 import { ExpenseType } from 'src/app/core/enums/expense-type.enum';
+import { PaymentModesService } from 'src/app/core/services/payment-modes.service';
 
 @Component({
   selector: 'app-add-edit-mileage',
@@ -236,7 +237,8 @@ export class AddEditMileagePage implements OnInit {
     private modalProperties: ModalPropertiesService,
     private matSnackBar: MatSnackBar,
     private snackbarProperties: SnackbarPropertiesService,
-    private launchDarklyService: LaunchDarklyService
+    private launchDarklyService: LaunchDarklyService,
+    private paymentModesService: PaymentModesService
   ) {}
 
   get showSaveAndNext() {
@@ -527,7 +529,7 @@ export class AddEditMileagePage implements OnInit {
       orgSettings: this.offlineService.getOrgSettings(),
       etxn: this.etxn$,
       allowedPaymentModes: this.offlineService.getAllowedPaymentModes(),
-      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.paymentModesService.checkIfPaymentModeConfigurationsIsEnabled(),
       isPaidByCompanyHidden: this.launchDarklyService.checkIfPaidByCompanyIsHidden(),
     }).pipe(
       map(
@@ -1019,7 +1021,7 @@ export class AddEditMileagePage implements OnInit {
 
     forkJoin({
       paymentModes: this.paymentModes$,
-      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.paymentModesService.checkIfPaymentModeConfigurationsIsEnabled(),
     }).subscribe(
       ({ paymentModes, isPaymentModeConfigurationsEnabled }) =>
         (this.showPaymentMode = !isPaymentModeConfigurationsEnabled || paymentModes.length > 1)

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -527,7 +527,7 @@ export class AddEditMileagePage implements OnInit {
       orgSettings: this.offlineService.getOrgSettings(),
       etxn: this.etxn$,
       allowedPaymentModes: this.offlineService.getAllowedPaymentModes(),
-      isPaymentModeConfigurationsEnabled: this.launchDarklyService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
       isPaidByCompanyHidden: this.launchDarklyService.checkIfPaidByCompanyIsHidden(),
     }).pipe(
       map(
@@ -1019,7 +1019,7 @@ export class AddEditMileagePage implements OnInit {
 
     forkJoin({
       paymentModes: this.paymentModes$,
-      isPaymentModeConfigurationsEnabled: this.launchDarklyService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
     }).subscribe(
       ({ paymentModes, isPaymentModeConfigurationsEnabled }) =>
         (this.showPaymentMode = !isPaymentModeConfigurationsEnabled || paymentModes.length > 1)

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -61,6 +61,7 @@ import { FyCurrencyPipe } from 'src/app/shared/pipes/fy-currency.pipe';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
 import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 import { ExpenseType } from 'src/app/core/enums/expense-type.enum';
+import { PaymentModesService } from 'src/app/core/services/payment-modes.service';
 
 @Component({
   selector: 'app-add-edit-per-diem',
@@ -216,7 +217,8 @@ export class AddEditPerDiemPage implements OnInit {
     private modalProperties: ModalPropertiesService,
     private matSnackBar: MatSnackBar,
     private snackbarProperties: SnackbarPropertiesService,
-    private launchDarklyService: LaunchDarklyService
+    private launchDarklyService: LaunchDarklyService,
+    private paymentModesService: PaymentModesService
   ) {}
 
   get minPerDiemDate() {
@@ -495,7 +497,7 @@ export class AddEditPerDiemPage implements OnInit {
       orgSettings: this.offlineService.getOrgSettings(),
       etxn: this.etxn$,
       allowedPaymentModes: this.offlineService.getAllowedPaymentModes(),
-      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.paymentModesService.checkIfPaymentModeConfigurationsIsEnabled(),
       isPaidByCompanyHidden: this.launchDarklyService.checkIfPaidByCompanyIsHidden(),
     }).pipe(
       map(
@@ -908,7 +910,7 @@ export class AddEditPerDiemPage implements OnInit {
 
     forkJoin({
       paymentModes: this.paymentModes$,
-      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.paymentModesService.checkIfPaymentModeConfigurationsIsEnabled(),
     }).subscribe(
       ({ paymentModes, isPaymentModeConfigurationsEnabled }) =>
         (this.showPaymentMode = !isPaymentModeConfigurationsEnabled || paymentModes.length > 1)

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -495,7 +495,7 @@ export class AddEditPerDiemPage implements OnInit {
       orgSettings: this.offlineService.getOrgSettings(),
       etxn: this.etxn$,
       allowedPaymentModes: this.offlineService.getAllowedPaymentModes(),
-      isPaymentModeConfigurationsEnabled: this.launchDarklyService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
       isPaidByCompanyHidden: this.launchDarklyService.checkIfPaidByCompanyIsHidden(),
     }).pipe(
       map(
@@ -908,7 +908,7 @@ export class AddEditPerDiemPage implements OnInit {
 
     forkJoin({
       paymentModes: this.paymentModes$,
-      isPaymentModeConfigurationsEnabled: this.launchDarklyService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
     }).subscribe(
       ({ paymentModes, isPaymentModeConfigurationsEnabled }) =>
         (this.showPaymentMode = !isPaymentModeConfigurationsEnabled || paymentModes.length > 1)

--- a/src/app/fyle/view-expense/view-expense.page.ts
+++ b/src/app/fyle/view-expense/view-expense.page.ts
@@ -26,7 +26,7 @@ import { ExpenseView } from 'src/app/core/models/expense-view.enum';
 import { ExtendedStatus } from 'src/app/core/models/extended_status.model';
 import { CustomField } from 'src/app/core/models/custom_field.model';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
-import { ViewExpenseService } from 'src/app/core/services/view-expense.service';
+import { PaymentModesService } from 'src/app/core/services/payment-modes.service';
 import { ExpenseType } from 'src/app/core/enums/expense-type.enum';
 
 @Component({
@@ -124,7 +124,7 @@ export class ViewExpensePage implements OnInit {
     private modalProperties: ModalPropertiesService,
     private trackingService: TrackingService,
     private corporateCreditCardExpenseService: CorporateCreditCardExpenseService,
-    private viewExpenseService: ViewExpenseService
+    private paymentModesService: PaymentModesService
   ) {}
 
   get ExpenseView() {
@@ -340,7 +340,7 @@ export class ViewExpensePage implements OnInit {
       this.showPaymentMode = true;
     } else {
       this.etxn$
-        .pipe(switchMap((etxn) => this.viewExpenseService.shouldPaymentModeBeShown(etxn, ExpenseType.EXPENSE)))
+        .pipe(switchMap((etxn) => this.paymentModesService.shouldPaymentModeBeShown(etxn, ExpenseType.EXPENSE)))
         .subscribe((shouldPaymentModeBeShown) => (this.showPaymentMode = shouldPaymentModeBeShown));
     }
 

--- a/src/app/fyle/view-expense/view-expense.page.ts
+++ b/src/app/fyle/view-expense/view-expense.page.ts
@@ -27,6 +27,8 @@ import { ExtendedStatus } from 'src/app/core/models/extended_status.model';
 import { CustomField } from 'src/app/core/models/custom_field.model';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
 import { ViewExpenseService } from 'src/app/core/services/view-expense.service';
+import { ExpenseType } from 'src/app/core/enums/expense-type.enum';
+
 @Component({
   selector: 'app-view-expense',
   templateUrl: './view-expense.page.html',
@@ -338,7 +340,7 @@ export class ViewExpensePage implements OnInit {
       this.showPaymentMode = true;
     } else {
       this.etxn$
-        .pipe(switchMap((etxn) => this.viewExpenseService.shouldPaymentModeBeShown(etxn)))
+        .pipe(switchMap((etxn) => this.viewExpenseService.shouldPaymentModeBeShown(etxn, ExpenseType.EXPENSE)))
         .subscribe((shouldPaymentModeBeShown) => (this.showPaymentMode = shouldPaymentModeBeShown));
     }
 

--- a/src/app/fyle/view-mileage/view-mileage.page.ts
+++ b/src/app/fyle/view-mileage/view-mileage.page.ts
@@ -22,7 +22,7 @@ import { getCurrencySymbol } from '@angular/common';
 import { ExpenseView } from 'src/app/core/models/expense-view.enum';
 import { ExtendedStatus } from 'src/app/core/models/extended_status.model';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
-import { ViewExpenseService } from 'src/app/core/services/view-expense.service';
+import { PaymentModesService } from 'src/app/core/services/payment-modes.service';
 import { ExpenseType } from 'src/app/core/enums/expense-type.enum';
 
 @Component({
@@ -100,7 +100,7 @@ export class ViewMileagePage implements OnInit {
     private modalController: ModalController,
     private modalProperties: ModalPropertiesService,
     private trackingService: TrackingService,
-    private viewExpenseService: ViewExpenseService
+    private paymentModesService: PaymentModesService
   ) {}
 
   get ExpenseView() {
@@ -358,7 +358,7 @@ export class ViewMileagePage implements OnInit {
       this.extendedMileage$
         .pipe(
           switchMap((extendedMileage) =>
-            this.viewExpenseService.shouldPaymentModeBeShown(extendedMileage, ExpenseType.MILEAGE)
+            this.paymentModesService.shouldPaymentModeBeShown(extendedMileage, ExpenseType.MILEAGE)
           )
         )
         .subscribe((shouldPaymentModeBeShown) => (this.showPaymentMode = shouldPaymentModeBeShown));

--- a/src/app/fyle/view-mileage/view-mileage.page.ts
+++ b/src/app/fyle/view-mileage/view-mileage.page.ts
@@ -23,6 +23,7 @@ import { ExpenseView } from 'src/app/core/models/expense-view.enum';
 import { ExtendedStatus } from 'src/app/core/models/extended_status.model';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
 import { ViewExpenseService } from 'src/app/core/services/view-expense.service';
+import { ExpenseType } from 'src/app/core/enums/expense-type.enum';
 
 @Component({
   selector: 'app-view-mileage',
@@ -355,7 +356,11 @@ export class ViewMileagePage implements OnInit {
       this.showPaymentMode = true;
     } else {
       this.extendedMileage$
-        .pipe(switchMap((extendedMileage) => this.viewExpenseService.shouldPaymentModeBeShown(extendedMileage)))
+        .pipe(
+          switchMap((extendedMileage) =>
+            this.viewExpenseService.shouldPaymentModeBeShown(extendedMileage, ExpenseType.MILEAGE)
+          )
+        )
         .subscribe((shouldPaymentModeBeShown) => (this.showPaymentMode = shouldPaymentModeBeShown));
     }
 

--- a/src/app/fyle/view-per-diem/view-per-diem.page.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.ts
@@ -23,6 +23,7 @@ import { ExpenseView } from 'src/app/core/models/expense-view.enum';
 import { ExtendedStatus } from 'src/app/core/models/extended_status.model';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
 import { ViewExpenseService } from 'src/app/core/services/view-expense.service';
+import { ExpenseType } from 'src/app/core/enums/expense-type.enum';
 
 @Component({
   selector: 'app-view-per-diem',
@@ -261,7 +262,11 @@ export class ViewPerDiemPage implements OnInit {
       this.showPaymentMode = true;
     } else {
       this.extendedPerDiem$
-        .pipe(switchMap((extendedPerDiem) => this.viewExpenseService.shouldPaymentModeBeShown(extendedPerDiem)))
+        .pipe(
+          switchMap((extendedPerDiem) =>
+            this.viewExpenseService.shouldPaymentModeBeShown(extendedPerDiem, ExpenseType.PER_DIEM)
+          )
+        )
         .subscribe((shouldPaymentModeBeShown) => (this.showPaymentMode = shouldPaymentModeBeShown));
     }
 

--- a/src/app/fyle/view-per-diem/view-per-diem.page.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.ts
@@ -22,7 +22,7 @@ import { getCurrencySymbol } from '@angular/common';
 import { ExpenseView } from 'src/app/core/models/expense-view.enum';
 import { ExtendedStatus } from 'src/app/core/models/extended_status.model';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
-import { ViewExpenseService } from 'src/app/core/services/view-expense.service';
+import { PaymentModesService } from 'src/app/core/services/payment-modes.service';
 import { ExpenseType } from 'src/app/core/enums/expense-type.enum';
 
 @Component({
@@ -96,7 +96,7 @@ export class ViewPerDiemPage implements OnInit {
     private modalController: ModalController,
     private modalProperties: ModalPropertiesService,
     private trackingService: TrackingService,
-    private viewExpenseService: ViewExpenseService
+    private paymentModesService: PaymentModesService
   ) {}
 
   get ExpenseView() {
@@ -264,7 +264,7 @@ export class ViewPerDiemPage implements OnInit {
       this.extendedPerDiem$
         .pipe(
           switchMap((extendedPerDiem) =>
-            this.viewExpenseService.shouldPaymentModeBeShown(extendedPerDiem, ExpenseType.PER_DIEM)
+            this.paymentModesService.shouldPaymentModeBeShown(extendedPerDiem, ExpenseType.PER_DIEM)
           )
         )
         .subscribe((shouldPaymentModeBeShown) => (this.showPaymentMode = shouldPaymentModeBeShown));

--- a/src/app/shared/components/capture-receipt/capture-receipt.component.ts
+++ b/src/app/shared/components/capture-receipt/capture-receipt.component.ts
@@ -167,7 +167,7 @@ export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit
   ): Observable<ExtendedAccount> {
     return forkJoin({
       allowedPaymentModes: this.offlineService.getAllowedPaymentModes(),
-      isPaymentModeConfigurationsEnabled: this.launchDarklyService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
       isPaidByCompanyHidden: this.launchDarklyService.checkIfPaidByCompanyIsHidden(),
     }).pipe(
       map(({ allowedPaymentModes, isPaymentModeConfigurationsEnabled, isPaidByCompanyHidden }) => {

--- a/src/app/shared/components/capture-receipt/capture-receipt.component.ts
+++ b/src/app/shared/components/capture-receipt/capture-receipt.component.ts
@@ -19,6 +19,7 @@ import { ExtendedAccount } from 'src/app/core/models/extended-account.model';
 import { StorageService } from 'src/app/core/services/storage.service';
 import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
+import { PaymentModesService } from 'src/app/core/services/payment-modes.service';
 
 type Image = Partial<{
   source: string;
@@ -72,7 +73,8 @@ export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit
     private popoverController: PopoverController,
     private loaderService: LoaderService,
     private launchDarklyService: LaunchDarklyService,
-    private storageService: StorageService
+    private storageService: StorageService,
+    private paymentModesService: PaymentModesService
   ) {}
 
   setupNetworkWatcher() {
@@ -167,7 +169,7 @@ export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit
   ): Observable<ExtendedAccount> {
     return forkJoin({
       allowedPaymentModes: this.offlineService.getAllowedPaymentModes(),
-      isPaymentModeConfigurationsEnabled: this.offlineService.checkIfPaymentModeConfigurationsIsEnabled(),
+      isPaymentModeConfigurationsEnabled: this.paymentModesService.checkIfPaymentModeConfigurationsIsEnabled(),
       isPaidByCompanyHidden: this.launchDarklyService.checkIfPaidByCompanyIsHidden(),
     }).pipe(
       map(({ allowedPaymentModes, isPaymentModeConfigurationsEnabled, isPaidByCompanyHidden }) => {


### PR DESCRIPTION
Changes in this pr
- Check if payment_mode_settings is allowed and enabled and the LD flag is set before using the new flow
- Do not show PERSONAL_ACCOUNT payment mode in view mileage/per-diem if it is the only possible option. Since, we dont allow CCC in mileage/per-diem, this will happen only when ADVANNCE nad COMPANY both accounts are not present like when allowed_payment_modes is["PCCC"] or ["PCCC, PA"] or ["PA", "PCCC"]