### PR TITLE
#automate_report_submission: Changes in mileage/per-diem and other changes

### DIFF
--- a/src/app/core/services/tasks.service.ts
+++ b/src/app/core/services/tasks.service.ts
@@ -55,8 +55,8 @@ export class TasksService {
   ) {
     this.userEventService.onTaskCacheClear(() => {
       this.reportService.getReportAutoSubmissionDetails().subscribe((autoSubmissionReportDetails) => {
-        const isAutomateReportSubmissionEnabled = !!autoSubmissionReportDetails?.data?.next_at;
-        this.getTasks(isAutomateReportSubmissionEnabled).subscribe(noop);
+        const isReportAutoSubmissionScheduled = !!autoSubmissionReportDetails?.data?.next_at;
+        this.getTasks(isReportAutoSubmissionScheduled).subscribe(noop);
       });
     });
   }
@@ -291,12 +291,12 @@ export class TasksService {
     return filterPills;
   }
 
-  getTasks(isAutomateReportSubmissionEnabled = false, filters?: TaskFilters): Observable<DashboardTask[]> {
+  getTasks(isReportAutoSubmissionScheduled = false, filters?: TaskFilters): Observable<DashboardTask[]> {
     return forkJoin({
       potentialDuplicates: this.getPotentialDuplicatesTasks(),
       sentBackReports: this.getSentBackReportTasks(),
-      unreportedExpenses: this.getUnreportedExpensesTasks(isAutomateReportSubmissionEnabled),
-      unsubmittedReports: this.getUnsubmittedReportsTasks(isAutomateReportSubmissionEnabled),
+      unreportedExpenses: this.getUnreportedExpensesTasks(isReportAutoSubmissionScheduled),
+      unsubmittedReports: this.getUnsubmittedReportsTasks(isReportAutoSubmissionScheduled),
       draftExpenses: this.getDraftExpensesTasks(),
       teamReports: this.getTeamReportsTasks(),
       sentBackAdvances: this.getSentBackAdvanceTasks(),
@@ -513,9 +513,9 @@ export class TasksService {
     return [task];
   }
 
-  private getUnsubmittedReportsTasks(isAutomateReportSubmissionEnabled = false) {
-    //Unsubmitted reports task should not be shown if report auto-submission is enabled
-    if (isAutomateReportSubmissionEnabled) {
+  private getUnsubmittedReportsTasks(isReportAutoSubmissionScheduled = false) {
+    //Unsubmitted reports task should not be shown if report auto-submission is scheduled
+    if (isReportAutoSubmissionScheduled) {
       return of([]);
     }
 
@@ -538,9 +538,9 @@ export class TasksService {
     });
   }
 
-  private getUnreportedExpensesTasks(isAutomateReportSubmissionEnabled = false) {
-    //Unreported expenses task should not be shown if report auto submission is enabled
-    if (isAutomateReportSubmissionEnabled) {
+  private getUnreportedExpensesTasks(isReportAutoSubmissionScheduled = false) {
+    //Unreported expenses task should not be shown if report auto submission is scheduled
+    if (isReportAutoSubmissionScheduled) {
       return of([]);
     }
 

--- a/src/app/core/services/tasks.service.ts
+++ b/src/app/core/services/tasks.service.ts
@@ -54,7 +54,10 @@ export class TasksService {
     private advancesRequestService: AdvanceRequestService
   ) {
     this.userEventService.onTaskCacheClear(() => {
-      this.getTasks().subscribe(noop);
+      this.reportService.getReportAutoSubmissionDetails().subscribe((autoSubmissionReportDetails) => {
+        const isAutomateReportSubmissionEnabled = !!autoSubmissionReportDetails?.data?.next_at;
+        this.getTasks(isAutomateReportSubmissionEnabled).subscribe(noop);
+      });
     });
   }
 
@@ -288,12 +291,12 @@ export class TasksService {
     return filterPills;
   }
 
-  getTasks(filters?: TaskFilters): Observable<DashboardTask[]> {
+  getTasks(isAutomateReportSubmissionEnabled = false, filters?: TaskFilters): Observable<DashboardTask[]> {
     return forkJoin({
       potentialDuplicates: this.getPotentialDuplicatesTasks(),
       sentBackReports: this.getSentBackReportTasks(),
-      unreportedExpenses: this.getUnreportedExpensesTasks(),
-      unsubmittedReports: this.getUnsubmittedReportsTasks(),
+      unreportedExpenses: this.getUnreportedExpensesTasks(isAutomateReportSubmissionEnabled),
+      unsubmittedReports: this.getUnsubmittedReportsTasks(isAutomateReportSubmissionEnabled),
       draftExpenses: this.getDraftExpensesTasks(),
       teamReports: this.getTeamReportsTasks(),
       sentBackAdvances: this.getSentBackAdvanceTasks(),
@@ -510,7 +513,12 @@ export class TasksService {
     return [task];
   }
 
-  private getUnsubmittedReportsTasks() {
+  private getUnsubmittedReportsTasks(isAutomateReportSubmissionEnabled = false) {
+    //Unsubmitted reports task should not be shown if report auto-submission is enabled
+    if (isAutomateReportSubmissionEnabled) {
+      return of([]);
+    }
+
     return forkJoin({
       reportsStats: this.getUnsubmittedReportsStats(),
       homeCurrency: this.offlineService.getHomeCurrency(),
@@ -530,7 +538,12 @@ export class TasksService {
     });
   }
 
-  private getUnreportedExpensesTasks() {
+  private getUnreportedExpensesTasks(isAutomateReportSubmissionEnabled = false) {
+    //Unreported expenses task should not be shown if report auto submission is enabled
+    if (isAutomateReportSubmissionEnabled) {
+      return of([]);
+    }
+
     const queryParams = { rp_state: 'in.(DRAFT,APPROVER_PENDING,APPROVER_INQUIRY)' };
 
     const openReports$ = this.reportService.getAllExtendedReports({ queryParams }).pipe(

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -15,7 +15,7 @@ import {
   throwError,
 } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
-import { TitleCasePipe, DatePipe } from '@angular/common';
+import { TitleCasePipe } from '@angular/common';
 import {
   catchError,
   concatMap,
@@ -379,8 +379,7 @@ export class AddEditExpensePage implements OnInit {
     private snackbarProperties: SnackbarPropertiesService,
     public platform: Platform,
     private titleCasePipe: TitleCasePipe,
-    private handleDuplicates: HandleDuplicatesService,
-    private datePipe: DatePipe
+    private handleDuplicates: HandleDuplicatesService
   ) {}
 
   @HostListener('keydown')

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
@@ -518,6 +518,7 @@
                           [label]="etxn.tx.report_id ? 'Report' : 'Add to Report'"
                           [options]="reports"
                           formControlName="report"
+                          [autoSubmissionReportName]="autoSubmissionReportName$|async"
                         ></app-fy-add-to-report>
                       </div>
                     </ng-container>

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -198,6 +198,8 @@ export class AddEditMileagePage implements OnInit {
 
   canRemoveFromReport = false;
 
+  autoSubmissionReportName$: Observable<string>;
+
   constructor(
     private router: Router,
     private activatedRoute: ActivatedRoute,
@@ -1309,6 +1311,8 @@ export class AddEditMileagePage implements OnInit {
         }
       })
     );
+
+    this.autoSubmissionReportName$ = this.reportService.getAutoSubmissionReportName();
 
     const selectedCustomInputs$ = this.etxn$.pipe(
       switchMap((etxn) =>

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
@@ -568,6 +568,7 @@
                                 [label]="fg.controls.add_to_new_report.value ? 'Report' : 'Add to Report'"
                                 [options]="reports"
                                 formControlName="report"
+                                [autoSubmissionReportName]="autoSubmissionReportName$|async"
                               ></app-fy-add-to-report>
                             </div>
                           </ng-container>

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -179,6 +179,8 @@ export class AddEditPerDiemPage implements OnInit {
 
   canRemoveFromReport = false;
 
+  autoSubmissionReportName$: Observable<string>;
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private offlineService: OfflineService,
@@ -1444,6 +1446,8 @@ export class AddEditPerDiemPage implements OnInit {
         }
       })
     );
+
+    this.autoSubmissionReportName$ = this.reportService.getAutoSubmissionReportName();
   }
 
   generateEtxnFromFg(etxn$, standardisedCustomProperties$) {

--- a/src/app/fyle/dashboard/tasks/tasks.component.ts
+++ b/src/app/fyle/dashboard/tasks/tasks.component.ts
@@ -86,14 +86,19 @@ export class TasksComponent implements OnInit {
   }
 
   init() {
-    this.tasks$ = this.loadData$.pipe(
-      switchMap((taskFilters) => this.taskService.getTasks(taskFilters)),
-      shareReplay(1)
-    );
-
     this.autoSubmissionReportDate$ = this.reportService
       .getReportAutoSubmissionDetails()
       .pipe(map((autoSubmissionReportDetails) => autoSubmissionReportDetails?.data?.next_at));
+
+    this.tasks$ = combineLatest({
+      taskFilters: this.loadData$,
+      autoSubmissionReportDate: this.autoSubmissionReportDate$,
+    }).pipe(
+      switchMap(({ taskFilters, autoSubmissionReportDate }) =>
+        this.taskService.getTasks(!!autoSubmissionReportDate, taskFilters)
+      ),
+      shareReplay(1)
+    );
 
     this.tasks$.subscribe((tasks) => {
       this.trackTasks(tasks);

--- a/src/app/fyle/dashboard/tasks/tasks.component.ts
+++ b/src/app/fyle/dashboard/tasks/tasks.component.ts
@@ -111,6 +111,13 @@ export class TasksComponent implements OnInit {
     }).subscribe(({ tasks, autoSubmissionReportDate }) => {
       const isIncompleteExpensesTaskShown = tasks.some((task) => task.header.includes('Incomplete expense'));
       const paramFilters = this.activatedRoute.snapshot.queryParams.tasksFilters;
+
+      /*
+       * Show the auto-submission info card at the top of tasks page only if an auto-submission is scheduled
+       * and incomplete expenses task is not shown (else it'll be shown with that task)
+       * and hide it if the user is navigating to tasks section from teams section
+       * Since we don't have tasks for team advances, have added a check only for team reports filter
+       */
       this.showReportAutoSubmissionInfoCard =
         autoSubmissionReportDate && !isIncompleteExpensesTaskShown && paramFilters !== 'team_reports';
     });

--- a/src/app/fyle/dashboard/tasks/tasks.component.ts
+++ b/src/app/fyle/dashboard/tasks/tasks.component.ts
@@ -110,7 +110,9 @@ export class TasksComponent implements OnInit {
       autoSubmissionReportDate: this.autoSubmissionReportDate$,
     }).subscribe(({ tasks, autoSubmissionReportDate }) => {
       const isIncompleteExpensesTaskShown = tasks.some((task) => task.header.includes('Incomplete expense'));
-      this.showReportAutoSubmissionInfoCard = autoSubmissionReportDate && !isIncompleteExpensesTaskShown;
+      const paramFilters = this.activatedRoute.snapshot.queryParams.tasksFilters;
+      this.showReportAutoSubmissionInfoCard =
+        autoSubmissionReportDate && !isIncompleteExpensesTaskShown && paramFilters !== 'team_reports';
     });
 
     const paramFilters = this.activatedRoute.snapshot.queryParams.tasksFilters;

--- a/src/app/shared/components/fy-add-to-report/fy-add-to-report.component.ts
+++ b/src/app/shared/components/fy-add-to-report/fy-add-to-report.component.ts
@@ -91,6 +91,7 @@ export class FyAddToReportComponent implements OnInit, ControlValueAccessor {
     //If Report auto submission is scheduled, 'None' option won't be shown in reports list
     if (this.autoSubmissionReportName) {
       this.showNullOption = false;
+      this.label = 'Expense Report';
     }
   }
 


### PR DESCRIPTION
Changes:
- Update the add to report modal in mileage/per-diem expenses if auto submission is scheduled
- Do not show auto-submission info card in teams section (We dont have team advances tasks so it'll be shown there)
- Hide unreported expenses and unsubmitted reports task if auto submission is scheduled
- Change report field name to `Expense Report` if auto submission is enabled