### PR TITLE
#automate_report_submission:  Record click events on auto-submission card

### DIFF
--- a/src/app/core/services/tracking.service.ts
+++ b/src/app/core/services/tracking.service.ts
@@ -991,4 +991,8 @@ export class TrackingService {
   captureSingleReceiptTime(properties = {}) {
     this.eventTrack('capture single receipt time', properties);
   }
+
+  autoSubmissionInfoCardClicked(properties = {}) {
+    this.eventTrack('Auto Submission Info Card Clicked', properties);
+  }
 }

--- a/src/app/fyle/dashboard/tasks/auto-submission-info-card/auto-submission-info-card.component.html
+++ b/src/app/fyle/dashboard/tasks/auto-submission-info-card/auto-submission-info-card.component.html
@@ -1,5 +1,5 @@
 <div class="info-card">
-  <div class="info-card__container">
+  <div class="info-card__container" (click)="onCardClicked()">
     <div>Next Auto-Submission of Expense Reports on</div>
     <div class="info-card__date">{{ autoSubmissionReportDate | date: 'MMM d' }}</div>
     <div class="info-card__sub-header">Add and complete your expenses for auto-submission</div>

--- a/src/app/fyle/dashboard/tasks/auto-submission-info-card/auto-submission-info-card.component.ts
+++ b/src/app/fyle/dashboard/tasks/auto-submission-info-card/auto-submission-info-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-auto-submission-info-card',
@@ -8,7 +8,13 @@ import { Component, OnInit, Input } from '@angular/core';
 export class AutoSubmissionInfoCardComponent implements OnInit {
   @Input() autoSubmissionReportDate: Date;
 
+  @Output() cardClicked = new EventEmitter<void>();
+
   constructor() {}
 
   ngOnInit() {}
+
+  onCardClicked() {
+    this.cardClicked.emit();
+  }
 }

--- a/src/app/fyle/dashboard/tasks/tasks-card/tasks-card.component.html
+++ b/src/app/fyle/dashboard/tasks/tasks-card/tasks-card.component.html
@@ -45,7 +45,10 @@
       <ng-container *ngIf="showReportAutoSubmissionInfo">
         <ion-row>
           <ion-col class="ion-col-no-padding">
-            <app-auto-submission-info-card [autoSubmissionReportDate]="autoSubmissionReportDate">
+            <app-auto-submission-info-card
+              [autoSubmissionReportDate]="autoSubmissionReportDate"
+              (cardClicked)="onInfoCardClicked()"
+            >
             </app-auto-submission-info-card>
           </ion-col>
         </ion-row>

--- a/src/app/fyle/dashboard/tasks/tasks-card/tasks-card.component.ts
+++ b/src/app/fyle/dashboard/tasks/tasks-card/tasks-card.component.ts
@@ -18,6 +18,8 @@ export class TasksCardComponent implements OnInit {
 
   @Output() ctaClicked: EventEmitter<TaskCta> = new EventEmitter();
 
+  @Output() infoCardClicked = new EventEmitter();
+
   homeCurrency$: Observable<string>;
 
   currencySymbol$: Observable<string>;
@@ -37,5 +39,9 @@ export class TasksCardComponent implements OnInit {
 
   taskCtaClicked(event) {
     this.ctaClicked.emit(event);
+  }
+
+  onInfoCardClicked() {
+    this.infoCardClicked.emit();
   }
 }

--- a/src/app/fyle/dashboard/tasks/tasks.component.html
+++ b/src/app/fyle/dashboard/tasks/tasks.component.html
@@ -21,6 +21,7 @@
           <div class="task-card__container" [ngClass]="{ 'task-card__container--divider': tasks.length }">
             <app-auto-submission-info-card
               [autoSubmissionReportDate]="autoSubmissionReportDate$ | async"
+              (cardClicked)="autoSubmissionInfoCardClicked(true)"
             ></app-auto-submission-info-card>
           </div>
         </div>
@@ -31,6 +32,7 @@
             [task]="task"
             [autoSubmissionReportDate]="autoSubmissionReportDate$ | async"
             (ctaClicked)="onTaskClicked($event, task)"
+            (infoCardClicked)="autoSubmissionInfoCardClicked(false)"
           ></app-tasks-card>
         </ng-container>
       </ng-container>

--- a/src/app/fyle/dashboard/tasks/tasks.component.ts
+++ b/src/app/fyle/dashboard/tasks/tasks.component.ts
@@ -630,4 +630,10 @@ export class TasksComponent implements OnInit {
   onExpensesToReportTaskClick(taskCta: TaskCta, task: DashboardTask) {
     this.showOldReportsMatBottomSheet();
   }
+
+  autoSubmissionInfoCardClicked(isSeparateCard: boolean) {
+    this.trackingService.autoSubmissionInfoCardClicked({
+      isSeparateCard,
+    });
+  }
 }


### PR DESCRIPTION
We're tracking the click event to check if users are expecting this card to be clickable and if we need to show them the expenses that'll be submitted on the next schedule on clicking the card.