### PR TITLE
Add Missing Filter : Payment Processing

### DIFF
--- a/src/app/fyle/my-reports/my-reports.page.ts
+++ b/src/app/fyle/my-reports/my-reports.page.ts
@@ -375,6 +375,10 @@ export class MyReportsPage implements OnInit {
         stateOrFilter.push('rp_state.in.(PAYMENT_PENDING)');
       }
 
+      if (this.filters.state.includes('PAYMENT_PROCESSING')) {
+        stateOrFilter.push('rp_state.in.(PAYMENT_PROCESSING)');
+      }
+
       if (this.filters.state.includes('PAID')) {
         stateOrFilter.push('rp_state.in.(PAID)');
       }
@@ -922,6 +926,10 @@ export class MyReportsPage implements OnInit {
               {
                 label: 'Payment Pending',
                 value: 'PAYMENT_PENDING',
+              },
+              {
+                label: 'Payment Processing',
+                value: 'PAYMENT_PROCESSING',
               },
               {
                 label: 'Paid',


### PR DESCRIPTION
## Addition of Payment Processing Filter

<img width="221" alt="image" src="https://user-images.githubusercontent.com/115472256/195346919-4443276f-0142-4793-aeb9-1391753f852d.png">

The filter on Reports page on the mobile app did not have Payment Processing Filter, which has now been added
