### PR TITLE
Add new var for tracking if camera preview has been initiated

### DIFF
--- a/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.html
+++ b/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.html
@@ -1,4 +1,4 @@
-<ion-header mode="md" [ngClass]="{'d-none': isCameraShown}">
+<ion-header mode="md" [ngClass]="{'d-none': isCameraPreviewStarted}">
   <ion-toolbar mode="md" class="add-edit-advance-request--toolbar">
     <ion-buttons
       mode="md"
@@ -42,7 +42,7 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content [ngClass]="{'d-none': isCameraShown}">
+<ion-content [ngClass]="{'d-none': isCameraPreviewStarted}">
   <form [formGroup]="fg" class="add-edit-advance-request--form" #formContainer>
     <div class="add-edit-advance-request--receipt-currency-container">
       <div *ngIf="dataUrls && dataUrls.length === 0" class="add-edit-advance-request--receipt text-center">
@@ -226,7 +226,7 @@
   </form>
 </ion-content>
 
-<ion-footer class="cta-footer" [ngClass]="{'d-none': isCameraShown}">
+<ion-footer class="cta-footer" [ngClass]="{'d-none': isCameraPreviewStarted}">
   <ion-toolbar mode="md">
     <div class="add-edit-advance-request--cta-container">
       <ion-buttons>

--- a/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.ts
+++ b/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.ts
@@ -76,7 +76,7 @@ export class AddEditAdvanceRequestPage implements OnInit {
 
   expenseFields$: Observable<Partial<ExpenseFieldsMap>>;
 
-  isCameraShown = false;
+  isCameraPreviewStarted = false;
 
   constructor(
     private offlineService: OfflineService,
@@ -397,10 +397,10 @@ export class AddEditAdvanceRequestPage implements OnInit {
         cssClass: 'hide-modal',
       });
       await captureReceiptModal.present();
-      this.isCameraShown = true;
+      this.isCameraPreviewStarted = true;
 
       const { data } = await captureReceiptModal.onWillDismiss();
-      this.isCameraShown = false;
+      this.isCameraPreviewStarted = false;
 
       if (data && data.dataUrl) {
         receiptDetails = { ...data, type: this.fileService.getImageTypeFromDataUrl(data.dataUrl) };

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -1,4 +1,4 @@
-<ion-header [ngClass]="{'d-none': isCameraShown}" mode="md">
+<ion-header [ngClass]="{'d-none': isCameraPreviewStarted}" mode="md">
   <ion-toolbar class="add-edit-expense--toolbar" [ngClass]="{'add-edit-expense--toolbar__review': reviewList?.length}">
     <ion-buttons *ngIf="navigateBack" mode="md" slot="start">
       <ion-button (click)="showClosePopup()">
@@ -66,7 +66,7 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content [ngClass]="{'d-none': isCameraShown}">
+<ion-content [ngClass]="{'d-none': isCameraPreviewStarted}">
   <ng-container *ngIf="fg">
     <form #formContainer [formGroup]="fg" class="add-edit-expense--form">
       <div>
@@ -1155,7 +1155,7 @@
     (saveAndGoToNext)="saveExpenseAndGotoNext()"
   ></app-review-footer>
   <ion-footer
-    [ngClass]="{'d-none': isCameraShown}"
+    [ngClass]="{'d-none': isCameraPreviewStarted}"
     class="add-edit-expense--footer-container"
     *ngIf="!reviewList?.length"
   >

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -324,7 +324,7 @@ export class AddEditExpensePage implements OnInit {
 
   source = 'MOBILE';
 
-  isCameraShown = false;
+  isCameraPreviewStarted = false;
 
   isIos = false;
 
@@ -3978,10 +3978,10 @@ export class AddEditExpensePage implements OnInit {
         });
 
         await captureReceiptModal.present();
-        this.isCameraShown = true;
+        this.isCameraPreviewStarted = true;
 
         const { data } = await captureReceiptModal.onWillDismiss();
-        this.isCameraShown = false;
+        this.isCameraPreviewStarted = false;
 
         if (data && data.dataUrl) {
           receiptDetails = {

--- a/src/app/fyle/my-expenses/my-expenses.page.html
+++ b/src/app/fyle/my-expenses/my-expenses.page.html
@@ -1,5 +1,5 @@
 <app-fy-header
-  [ngClass]="{'d-none': isCameraShown}"
+  [ngClass]="{'d-none': isCameraPreviewStarted}"
   [currentState]="headerState"
   [navigateBack]="navigateBack"
   [title]="'Expenses'"
@@ -83,7 +83,7 @@
   </ng-container>
 </app-fy-header>
 
-<ion-content [ngClass]="{'d-none': isCameraShown}" class="my-expenses--content">
+<ion-content [ngClass]="{'d-none': isCameraPreviewStarted}" class="my-expenses--content">
   <div
     class="my-expenses--body"
     [ngClass]="{'my-expenses--zero-states-body': (((count$ | async) === 0) && isConnected$|async) || (pendingTransactions.length === 0 && !(isConnected$|async))}"
@@ -213,7 +213,7 @@
   </ng-container>
 </ion-content>
 
-<ion-footer [ngClass]="{'d-none': isCameraShown}" *ngIf="!isSearchBarFocused">
+<ion-footer [ngClass]="{'d-none': isCameraPreviewStarted}" *ngIf="!isSearchBarFocused">
   <app-fy-footer
     *ngIf="!selectionMode"
     (homeClicked)="onHomeClicked()"

--- a/src/app/fyle/my-expenses/my-expenses.page.ts
+++ b/src/app/fyle/my-expenses/my-expenses.page.ts
@@ -149,7 +149,7 @@ export class MyExpensesPage implements OnInit {
 
   expensesTaskCount = 0;
 
-  isCameraShown = false;
+  isCameraPreviewStarted = false;
 
   isUnifyCCCEnabled$: Observable<boolean>;
 
@@ -1514,7 +1514,7 @@ export class MyExpensesPage implements OnInit {
     ]);
   }
 
-  showCamera(isCameraShown: boolean) {
-    this.isCameraShown = isCameraShown;
+  showCamera(isCameraPreviewStarted: boolean) {
+    this.isCameraPreviewStarted = isCameraPreviewStarted;
   }
 }

--- a/src/app/shared/components/capture-receipt/capture-receipt.component.html
+++ b/src/app/shared/components/capture-receipt/capture-receipt.component.html
@@ -1,6 +1,6 @@
 <ion-content
   class="capture-receipt--camera-preview"
-  [ngClass]="{ 'capture-receipt--camera-preview__is-active': isCameraShown }"
+  [ngClass]="{ 'capture-receipt--camera-preview__is-active': isCameraPreviewStarted }"
 >
   <div id="cameraPreview"></div>
   <div *ngIf="hasModeChanged" class="capture-receipt--switch-mode-info text-center">

--- a/src/app/shared/components/capture-receipt/capture-receipt.component.ts
+++ b/src/app/shared/components/capture-receipt/capture-receipt.component.ts
@@ -34,7 +34,11 @@ export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit
 
   @Input() allowBulkFyle = true;
 
-  isCameraShown: boolean;
+  //isCameraPreviewInitiated denotes that a camera preview has been initiated, but may or may not have started yet.
+  isCameraPreviewInitiated = false;
+
+  //isCameraPreviewStarted tracks if the camera preview has started.
+  isCameraPreviewStarted = false;
 
   isBulkMode: boolean;
 
@@ -80,7 +84,8 @@ export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit
 
   ngOnInit() {
     this.setupNetworkWatcher();
-    this.isCameraShown = false;
+    this.isCameraPreviewStarted = false;
+    this.isCameraPreviewInitiated = false;
     this.isBulkMode = false;
     this.base64ImagesWithSource = [];
     this.flashMode = null;
@@ -139,9 +144,10 @@ export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit
   }
 
   async stopCamera() {
-    if (this.isCameraShown === true) {
+    if (this.isCameraPreviewInitiated) {
+      this.isCameraPreviewInitiated = false;
       await CameraPreview.stop();
-      this.isCameraShown = false;
+      this.isCameraPreviewStarted = false;
     }
   }
 
@@ -182,7 +188,8 @@ export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit
   }
 
   setUpAndStartCamera() {
-    if (!this.isCameraShown) {
+    if (!this.isCameraPreviewInitiated) {
+      this.isCameraPreviewInitiated = true;
       const cameraPreviewOptions: CameraPreviewOptions = {
         position: 'rear',
         toBack: true,
@@ -194,7 +201,7 @@ export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit
 
       this.loaderService.showLoader();
       CameraPreview.start(cameraPreviewOptions).then((res) => {
-        this.isCameraShown = true;
+        this.isCameraPreviewStarted = true;
         this.getFlashModes();
         this.loaderService.hideLoader();
       });


### PR DESCRIPTION
Issue:
- We're getting errors like `camera already started` and `camera already stopped` very frequently
- Previously, we used to track camera preview using a flag called `isCameraShown`, but the problem here is that we used to set this flag only when the camera started or stopped, and not when we initiated the request to start/stop the camera
- The camera plugin takes some time to start/stop the camera preview, and hence we may get the above errors if the user tries to open the camera in between
- Also, we cannot change `isCameraShown` to track when the camera start/stop request was initiated, as we use it hide the parent components, and if we do so, the the user would see a weird UI till the camera preview actually starts

Solution
- Created a new flag `isCameraPreviewInitiated` to track whether the user has intitiated a camera preview - if yes, we wont intitiated it again. Same goes for stopping the preview
- The existing flag `isCameraShown` is renamed to `isCameraPreviewStarted` which aptly signifies the purpose of this flag.

Sentry bugs:
- [Uncaught (in promise): Error: camera already started](https://sentry.io/organizations/fyle-technologies-private-limi/issues/3356869620/events/d6172a8d118b43859bc8769450c5e938/?project=5622998&statsPeriod=14d)
- [Uncaught (in promise): Error: camera already stopped](https://sentry.io/organizations/fyle-technologies-private-limi/issues/3552152935/events/dc3d88e2a9f240ed802d68771dc88089/?project=5622998&statsPeriod=14d)