### PR TITLE
Create Report Title Bug

### DIFF
--- a/src/app/fyle/my-create-report/my-create-report.page.ts
+++ b/src/app/fyle/my-create-report/my-create-report.page.ts
@@ -277,7 +277,7 @@ export class MyCreateReportPage implements OnInit {
       0
     );
 
-    if (this.reportTitleInput && !this.reportTitleInput.dirty && txnIds.length > 0) {
+    if (this.reportTitleInput && !this.reportTitleInput.dirty) {
       return this.reportService.getReportPurpose({ ids: txnIds }).subscribe((res) => {
         this.reportTitle = res;
       });


### PR DESCRIPTION
## Fixing Autocomplete for Create Report Title Field

<img width="217" alt="image" src="https://user-images.githubusercontent.com/115472256/195798061-1b2f42b8-5f7d-45e4-b9d7-296ff71e1cf3.png">

When creating a new report the title of the report was not autopopulating