### PR TITLE
FYLE-2uw0r29: Fix for cards of different org showing up on dashboard and clean up

### DIFF
--- a/src/app/fyle/dashboard/stats/stats.component.html
+++ b/src/app/fyle/dashboard/stats/stats.component.html
@@ -95,72 +95,50 @@
     </ion-grid>
   </div>
 
-  <ng-container *ngIf="isConnected$ | async; else offlineMessage"></ng-container>
-
-  <div *ngIf="(isConnected$ | async) && cardTransactionsAndDetails?.length > 0" class="stats--ccc-cards-section">
-    <div>
-      <ion-grid
-        [ngClass]="{
-          'stats--ccc-cards-grid': !isUnifyCCCExpensesSettings,
-          'stats--ccc-cards-grid-multiple': isUnifyCCCExpensesSettings
-        }"
-        class=""
-      >
-        <ion-row>
-          <ion-col>
-            <div class="stats--header stats--ccc-cards-header">CARD SPEND</div>
-          </ion-col>
-        </ion-row>
-      </ion-grid>
-      <ng-container *ngIf="isUnifyCCCExpensesSettings">
-        <app-spent-cards
-          *ngIf="cardTransactionsAndDetails?.length > 1"
-          [spentCards]="cardTransactionsAndDetails"
-          [homeCurrency]="homeCurrency$"
-          [currencySymbol]="currencySymbol$"
-        ></app-spent-cards>
-        <div *ngIf="cardTransactionsAndDetails?.length === 1" class="stats--single-ccc">
-          <app-card-detail
-            [cardDetail]="cardTransactionsAndDetails[0]"
+  <ng-container *ngIf="isConnected$ | async; else offlineMessage">
+    <div *ngIf="cardTransactionsAndDetails?.length > 0" class="stats--ccc-cards-section">
+      <div>
+        <ion-grid
+          [ngClass]="{
+            'stats--ccc-cards-grid': !isUnifyCCCExpensesSettings,
+            'stats--ccc-cards-grid-multiple': isUnifyCCCExpensesSettings
+          }"
+          class=""
+        >
+          <ion-row>
+            <ion-col>
+              <div class="stats--header stats--ccc-cards-header">CARD SPEND</div>
+            </ion-col>
+          </ion-row>
+        </ion-grid>
+        <ng-container *ngIf="isUnifyCCCExpensesSettings">
+          <app-spent-cards
+            *ngIf="cardTransactionsAndDetails?.length > 1"
+            [spentCards]="cardTransactionsAndDetails"
             [homeCurrency]="homeCurrency$"
             [currencySymbol]="currencySymbol$"
-          >
-          </app-card-detail>
-        </div>
-      </ng-container>
+          ></app-spent-cards>
+          <div *ngIf="cardTransactionsAndDetails?.length === 1" class="stats--single-ccc">
+            <app-card-detail
+              [cardDetail]="cardTransactionsAndDetails[0]"
+              [homeCurrency]="homeCurrency$"
+              [currencySymbol]="currencySymbol$"
+            >
+            </app-card-detail>
+          </div>
+        </ng-container>
 
-      <ng-template #cccStatsLoading>
-        <div class="stats--ccc-card-details">
-          <ion-grid>
-            <ion-row>
-              <ion-col>
-                <ion-skeleton-text
-                  class="stats--ccc-skeleton-text stats--ccc-skeleton-text__height-small stats--ccc-skeleton-text__width-small"
-                  animated
-                ></ion-skeleton-text>
-                <ion-skeleton-text
-                  class="stats--ccc-skeleton-text stats--ccc-skeleton-text__height-small stats--ccc-skeleton-text__width-small"
-                  animated
-                ></ion-skeleton-text>
-              </ion-col>
-            </ion-row>
-            <ion-row>
-              <ion-col>
-                <ion-skeleton-text
-                  class="stats--ccc-skeleton-text stats--ccc-skeleton-text__width-large"
-                  animated
-                ></ion-skeleton-text>
-              </ion-col>
-            </ion-row>
-          </ion-grid>
-        </div>
-        <div class="stats--ccc-stats">
-          <div>
+        <ng-template #cccStatsLoading>
+          <div class="stats--ccc-card-details">
             <ion-grid>
               <ion-row>
                 <ion-col>
                   <ion-skeleton-text
-                    class="stats--expenses-skeleton-text stats--ccc-skeleton-text__width-large"
+                    class="stats--ccc-skeleton-text stats--ccc-skeleton-text__height-small stats--ccc-skeleton-text__width-small"
+                    animated
+                  ></ion-skeleton-text>
+                  <ion-skeleton-text
+                    class="stats--ccc-skeleton-text stats--ccc-skeleton-text__height-small stats--ccc-skeleton-text__width-small"
                     animated
                   ></ion-skeleton-text>
                 </ion-col>
@@ -168,50 +146,72 @@
               <ion-row>
                 <ion-col>
                   <ion-skeleton-text
-                    class="stats--expenses-skeleton-text stats--expenses-skeleton-text__width-small"
-                    animated
-                  ></ion-skeleton-text>
-                  <ion-skeleton-text
-                    class="stats--expenses-skeleton-text stats--expenses-skeleton-text__width-medium"
-                    animated
-                  ></ion-skeleton-text>
-                </ion-col>
-                <ion-col>
-                  <ion-skeleton-text
-                    class="stats--expenses-skeleton-text stats--expenses-skeleton-text__align-right stats--ccc-skeleton-text__width-medium"
+                    class="stats--ccc-skeleton-text stats--ccc-skeleton-text__width-large"
                     animated
                   ></ion-skeleton-text>
                 </ion-col>
               </ion-row>
             </ion-grid>
           </div>
-          <hr class="stats--ccc-stats-divider" />
-          <div>
-            <ion-grid>
-              <ion-row>
-                <ion-col>
-                  <ion-skeleton-text
-                    class="stats--expenses-skeleton-text stats--expenses-skeleton-text__width-small"
-                    animated
-                  ></ion-skeleton-text>
-                  <ion-skeleton-text
-                    class="stats--expenses-skeleton-text stats--expenses-skeleton-text__width-medium"
-                    animated
-                  ></ion-skeleton-text>
-                </ion-col>
-                <ion-col>
-                  <ion-skeleton-text
-                    class="stats--expenses-skeleton-text stats--expenses-skeleton-text__align-right stats--ccc-skeleton-text__width-medium"
-                    animated
-                  ></ion-skeleton-text>
-                </ion-col>
-              </ion-row>
-            </ion-grid>
+          <div class="stats--ccc-stats">
+            <div>
+              <ion-grid>
+                <ion-row>
+                  <ion-col>
+                    <ion-skeleton-text
+                      class="stats--expenses-skeleton-text stats--ccc-skeleton-text__width-large"
+                      animated
+                    ></ion-skeleton-text>
+                  </ion-col>
+                </ion-row>
+                <ion-row>
+                  <ion-col>
+                    <ion-skeleton-text
+                      class="stats--expenses-skeleton-text stats--expenses-skeleton-text__width-small"
+                      animated
+                    ></ion-skeleton-text>
+                    <ion-skeleton-text
+                      class="stats--expenses-skeleton-text stats--expenses-skeleton-text__width-medium"
+                      animated
+                    ></ion-skeleton-text>
+                  </ion-col>
+                  <ion-col>
+                    <ion-skeleton-text
+                      class="stats--expenses-skeleton-text stats--expenses-skeleton-text__align-right stats--ccc-skeleton-text__width-medium"
+                      animated
+                    ></ion-skeleton-text>
+                  </ion-col>
+                </ion-row>
+              </ion-grid>
+            </div>
+            <hr class="stats--ccc-stats-divider" />
+            <div>
+              <ion-grid>
+                <ion-row>
+                  <ion-col>
+                    <ion-skeleton-text
+                      class="stats--expenses-skeleton-text stats--expenses-skeleton-text__width-small"
+                      animated
+                    ></ion-skeleton-text>
+                    <ion-skeleton-text
+                      class="stats--expenses-skeleton-text stats--expenses-skeleton-text__width-medium"
+                      animated
+                    ></ion-skeleton-text>
+                  </ion-col>
+                  <ion-col>
+                    <ion-skeleton-text
+                      class="stats--expenses-skeleton-text stats--expenses-skeleton-text__align-right stats--ccc-skeleton-text__width-medium"
+                      animated
+                    ></ion-skeleton-text>
+                  </ion-col>
+                </ion-row>
+              </ion-grid>
+            </div>
           </div>
-        </div>
-      </ng-template>
+        </ng-template>
+      </div>
     </div>
-  </div>
+  </ng-container>
 
   <ng-template #offlineMessage>
     <div>

--- a/src/app/fyle/dashboard/stats/stats.component.html
+++ b/src/app/fyle/dashboard/stats/stats.component.html
@@ -97,10 +97,7 @@
 
   <ng-container *ngIf="isConnected$ | async; else offlineMessage"></ng-container>
 
-  <div
-    *ngIf="(isConnected$ | async) && (cardTransactionsAndDetails?.length > 0 || cardTransactionsAndDetailsNonUnifyCCC)"
-    class="stats--ccc-cards-section"
-  >
+  <div *ngIf="(isConnected$ | async) && cardTransactionsAndDetails?.length > 0" class="stats--ccc-cards-section">
     <div>
       <ion-grid
         [ngClass]="{
@@ -132,77 +129,6 @@
         </div>
       </ng-container>
 
-      <ng-container *ngIf="!isUnifyCCCExpensesSettings">
-        <div class="stats--ccc-card-details">
-          <div class="stats--ccc-bank-name1">
-            <ion-grid class="stats--ccc-container">
-              <ion-row class="stats--ccc-block">
-                <ion-col class="stats--ccc-bank-name" size="8">
-                  <div>
-                    {{ cardTransactionsAndDetailsNonUnifyCCC?.ba_bank_name }}
-                  </div>
-                </ion-col>
-                <ion-col size="4">
-                  <div class="stats--ccc-card-info">Corporate Card</div>
-                </ion-col>
-              </ion-row>
-              <ion-row>
-                <ion-col class="stats--ccc-account-info">
-                  <span class="stats--ccc-account-info__type"> CREDIT </span>
-                  <span class="stats--ccc-account-info__mask">{{
-                    ' xxxx ' + cardTransactionsAndDetailsNonUnifyCCC?.ba_mask
-                  }}</span>
-                </ion-col>
-              </ion-row>
-            </ion-grid>
-          </div>
-          <div class="stats--ccc-sync-detail" *ngIf="cardTransactionsAndDetailsNonUnifyCCC?.ba_last_synced_at">
-            Last synced: {{ cardTransactionsAndDetailsNonUnifyCCC?.ba_last_synced_at | date: 'MMM d, y | h:mm a' }}
-          </div>
-        </div>
-        <div class="stats--ccc-stats">
-          <div class="stats--ccc-created_dt">
-            Showing all transactions from {{ cardTransactionsAndDetailsNonUnifyCCC?.ba_created_at | date: 'MMM d, y' }}
-          </div>
-          <div>
-            <div (click)="goToCCCPage('classified')">
-              <div class="stats--ccc-classified-stats">
-                <div class="stats--ccc-classified-count">
-                  {{ cardTransactionsAndDetailsNonUnifyCCC?.total_classified_count }}
-                </div>
-                <div class="stats--ccc-classified-amount">
-                  <span class="stats--expenses-amount-currency">
-                    {{ currencySymbol$ | async }}
-                  </span>
-                  {{
-                    cardTransactionsAndDetailsNonUnifyCCC?.total_classified_amount
-                      | humanizeCurrency: (homeCurrency$ | async):true
-                  }}
-                </div>
-              </div>
-              <div class="stats--ccc-stats-title">Classified Transactions</div>
-            </div>
-            <hr class="stats--ccc-stats-divider" />
-            <div (click)="goToCCCPage('unclassified')">
-              <div class="stats--ccc-classified-stats stats--ccc-classified-stats__margin-top">
-                <div class="stats--ccc-classified-count">
-                  {{ cardTransactionsAndDetailsNonUnifyCCC?.total_unclassified_count }}
-                </div>
-                <div class="stats--ccc-classified-amount">
-                  <span class="stats--expenses-amount-currency">
-                    {{ currencySymbol$ | async }}
-                  </span>
-                  {{
-                    cardTransactionsAndDetailsNonUnifyCCC?.total_unclassified_amount
-                      | humanizeCurrency: (homeCurrency$ | async):true
-                  }}
-                </div>
-              </div>
-              <div class="stats--ccc-stats-title">Unclassified Transactions</div>
-            </div>
-          </div>
-        </div>
-      </ng-container>
       <ng-template #cccStatsLoading>
         <div class="stats--ccc-card-details">
           <ion-grid>

--- a/src/app/fyle/dashboard/stats/stats.component.ts
+++ b/src/app/fyle/dashboard/stats/stats.component.ts
@@ -52,12 +52,6 @@ export class StatsComponent implements OnInit {
 
   isCCCStatsLoading: boolean;
 
-  allCardTransactionsAndDetailsNonUnifyCCC$: Observable<BankAccountsAssigned[]>;
-
-  cardTransactionsAndDetailsNonUnifyCCC$: Observable<BankAccountsAssigned>;
-
-  cardTransactionsAndDetailsNonUnifyCCC: BankAccountsAssigned;
-
   cardTransactionsAndDetails$: Observable<{ totalTxns: number; totalAmount: number; cardDetails: CardAggregateStat[] }>;
 
   cardTransactionsAndDetails: CardDetail[];
@@ -136,45 +130,13 @@ export class StatsComponent implements OnInit {
   }
 
   initializeCCCStats() {
-    if (this.isUnifyCCCExpensesSettings) {
-      this.dashboardService
-        .getCCCDetails()
-        .pipe(
-          switchMap((details) =>
-            this.dashboardService.getNonUnifyCCCDetails().pipe(map((cards) => ({ details, cards })))
-          )
-        )
-        .subscribe(({ details, cards }) => {
-          this.cardTransactionsAndDetails = this.getCardDetail(details.cardDetails);
-          cards.forEach((card) => {
-            if (
-              this.cardTransactionsAndDetails.filter((cardDetail) => cardDetail.cardNumber === card.ba_account_number)
-                ?.length === 0
-            ) {
-              this.cardTransactionsAndDetails.push({
-                cardNumber: card.ba_account_number,
-                cardName: card.ba_bank_name,
-                totalAmountValue: 0,
-                totalCompleteExpensesValue: 0,
-                totalCompleteTxns: 0,
-                totalDraftTxns: 0,
-                totalDraftValue: 0,
-                totalTxnsCount: 0,
-              });
-            }
-          });
-          this.isCCCStatsLoading = false;
-        });
-    } else {
-      this.cardTransactionsAndDetailsNonUnifyCCC$ = this.dashboardService.getNonUnifyCCCDetails().pipe(
-        map((res) => res[0]),
-        shareReplay(1)
-      );
-      this.cardTransactionsAndDetailsNonUnifyCCC$.subscribe((details) => {
-        this.cardTransactionsAndDetailsNonUnifyCCC = details;
+    this.dashboardService
+      .getCCCDetails()
+      .pipe()
+      .subscribe((details) => {
+        this.cardTransactionsAndDetails = this.getCardDetail(details.cardDetails);
         this.isCCCStatsLoading = false;
       });
-    }
   }
 
   /*
@@ -184,6 +146,7 @@ export class StatsComponent implements OnInit {
    * **/
   init() {
     const that = this;
+    that.cardTransactionsAndDetails = [];
     that.homeCurrency$ = that.currencyService.getHomeCurrency().pipe(shareReplay(1));
     that.currencySymbol$ = that.homeCurrency$.pipe(
       map((homeCurrency: string) => getCurrencySymbol(homeCurrency, 'wide'))
@@ -201,7 +164,6 @@ export class StatsComponent implements OnInit {
         that.initializeCCCStats();
       } else {
         this.cardTransactionsAndDetails$ = of(null);
-        this.cardTransactionsAndDetailsNonUnifyCCC$ = of(null);
       }
     });
 

--- a/src/app/fyle/dashboard/stats/stats.component.ts
+++ b/src/app/fyle/dashboard/stats/stats.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { DashboardService } from '../dashboard.service';
 import { Observable } from 'rxjs/internal/Observable';
 import { shareReplay } from 'rxjs/internal/operators/shareReplay';
-import { delay, map, switchMap, tap } from 'rxjs/operators';
+import { delay, finalize, map, switchMap, tap } from 'rxjs/operators';
 import { CurrencyService } from '../../../core/services/currency.service';
 import { Params, Router } from '@angular/router';
 import { NetworkService } from '../../../core/services/network.service';
@@ -130,13 +130,10 @@ export class StatsComponent implements OnInit {
   }
 
   initializeCCCStats() {
-    this.dashboardService
-      .getCCCDetails()
-      .pipe()
-      .subscribe((details) => {
-        this.cardTransactionsAndDetails = this.getCardDetail(details.cardDetails);
-        this.isCCCStatsLoading = false;
-      });
+    this.dashboardService.getCCCDetails().subscribe((details) => {
+      this.cardTransactionsAndDetails = this.getCardDetail(details.cardDetails);
+    }),
+      finalize(() => (this.isCCCStatsLoading = false));
   }
 
   /*

--- a/src/app/fyle/dashboard/stats/stats.component.ts
+++ b/src/app/fyle/dashboard/stats/stats.component.ts
@@ -130,10 +130,10 @@ export class StatsComponent implements OnInit {
   }
 
   initializeCCCStats() {
-    this.dashboardService
-      .getCCCDetails()
-      .subscribe((details) => (this.cardTransactionsAndDetails = this.getCardDetail(details.cardDetails))),
-      finalize(() => (this.isCCCStatsLoading = false));
+    this.dashboardService.getCCCDetails().subscribe((details) => {
+      this.cardTransactionsAndDetails = this.getCardDetail(details.cardDetails);
+    });
+    finalize(() => (this.isCCCStatsLoading = false));
   }
 
   /*

--- a/src/app/fyle/dashboard/stats/stats.component.ts
+++ b/src/app/fyle/dashboard/stats/stats.component.ts
@@ -130,9 +130,9 @@ export class StatsComponent implements OnInit {
   }
 
   initializeCCCStats() {
-    this.dashboardService.getCCCDetails().subscribe((details) => {
-      this.cardTransactionsAndDetails = this.getCardDetail(details.cardDetails);
-    }),
+    this.dashboardService
+      .getCCCDetails()
+      .subscribe((details) => (this.cardTransactionsAndDetails = this.getCardDetail(details.cardDetails))),
       finalize(() => (this.isCCCStatsLoading = false));
   }
 


### PR DESCRIPTION
### What was the issue?
- There were 2 variables used to get the cardTransactionsAndDetails
- One was the observable `cardTransactionsAndDetails$` and the other was the subscribed list value `cardTransactionsAndDetails`
- When the corporate card settings were enabled, cardTransactionsAndDetails$ and cardTransactionsAndDetails both got set
- In the else block, only the observable was set to null, the `cardTransactionsAndDetails` list was not set to an empty list
- Due to this, when we switched to an org with the settings disabled from an org that had card details, it showed up the previous data, basically, the list didn't get reset at all
- This also happened because we didn't call the initialize method if the settings were disabled, that's why the value never got reset

### What is the fix?
- I have added the change to reset the `cardTransactionsAndDetails` list to an empty list

### Refactoring and cleaning up
- There were a few pieces of code that were lying around even though it didn't matter now related to the `#unify_ccc_expenses_flow` initiative, these were supposed to be removed during `#fix_implicit_merge changes`
- I have removed a bunch of code and cleaned up a few unnecessary conditions