### PR TITLE
Add Expense Button Bug

### DIFF
--- a/src/app/fyle/my-view-report/my-view-report.page.html
+++ b/src/app/fyle/my-view-report/my-view-report.page.html
@@ -330,7 +330,7 @@
 
 <ion-footer
   class="view-reports--add-expense-footer"
-  *ngIf="!isCommentsView && ((erpt$|async)?.rp_state === 'APPROVER_PENDING') && unReportedEtxns && unReportedEtxns.length > 0"
+  *ngIf="!isCommentsView && !isHistoryView && ((erpt$|async)?.rp_state === 'APPROVER_PENDING') && unReportedEtxns"
 >
   <div class="view-reports--add-expense-footer__block">
     <div class="view-reports--add-expense-footer__cta" (click)="showAddExpensesToReportModal()">


### PR DESCRIPTION
## View Report Add Expense Button Fix

<img width="218" alt="image" src="https://user-images.githubusercontent.com/115472256/195833557-5e9fefca-520d-4327-ac29-bb67607cbfe2.png">

The Add Expense Button was not visible on the expense tab on opening a report on Reports Page