### PR TITLE
#mission_nps_mobile_40:  Dont overwrite user-entered category with DE extracted category

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -3858,7 +3858,11 @@ export class AddEditExpensePage implements OnInit {
 
         // If category is auto-filled and there exists extracted category, priority is given to extracted category
         const isExtractedCategoryValid = extractedData.category && extractedData.category !== 'Unspecified';
-        if ((!this.fg.controls.category.value || this.presetCategoryId) && isExtractedCategoryValid) {
+        if (
+          (!this.fg.controls.category.value || this.presetCategoryId) &&
+          !this.fg.controls.category.dirty &&
+          isExtractedCategoryValid
+        ) {
           const categoryName = extractedData.category || 'Unspecified';
           const category = filteredCategories.find((orgCategory) => orgCategory.value.fyle_category === categoryName);
           this.fg.patchValue({


### PR DESCRIPTION
If the category field is dirty, dont change the category with user entered category