### PR TITLE
#mission_nps_mobile_40: Fix camera not working in browser

### DIFF
--- a/src/app/shared/components/capture-receipt/capture-receipt.component.ts
+++ b/src/app/shared/components/capture-receipt/capture-receipt.component.ts
@@ -239,6 +239,11 @@ export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit
   }
 
   setUpAndStartCamera() {
+    if (Capacitor.getPlatform() === 'web') {
+      this.startCameraPreview();
+      return;
+    }
+
     from(Camera.requestPermissions()).subscribe((permissions) => {
       if (permissions?.camera === 'denied') {
         return this.showPermissionDeniedPopover('CAMERA');
@@ -252,25 +257,29 @@ export class CaptureReceiptComponent implements OnInit, OnDestroy, AfterViewInit
         return this.setUpAndStartCamera();
       }
 
-      if (!this.isCameraPreviewInitiated) {
-        this.isCameraPreviewInitiated = true;
-        const cameraPreviewOptions: CameraPreviewOptions = {
-          position: 'rear',
-          toBack: true,
-          width: window.innerWidth,
-          height: window.innerHeight,
-          parent: 'cameraPreview',
-          disableAudio: true,
-        };
-
-        this.loaderService.showLoader();
-        CameraPreview.start(cameraPreviewOptions).then((res) => {
-          this.isCameraPreviewStarted = true;
-          this.getFlashModes();
-          this.loaderService.hideLoader();
-        });
-      }
+      this.startCameraPreview();
     });
+  }
+
+  startCameraPreview() {
+    if (!this.isCameraPreviewInitiated) {
+      this.isCameraPreviewInitiated = true;
+      const cameraPreviewOptions: CameraPreviewOptions = {
+        position: 'rear',
+        toBack: true,
+        width: window.innerWidth,
+        height: window.innerHeight,
+        parent: 'cameraPreview',
+        disableAudio: true,
+      };
+
+      this.loaderService.showLoader();
+      CameraPreview.start(cameraPreviewOptions).then((res) => {
+        this.isCameraPreviewStarted = true;
+        this.getFlashModes();
+        this.loaderService.hideLoader();
+      });
+    }
   }
 
   switchMode() {


### PR DESCRIPTION
`Camera.requestPermissions()` is not implemented for web, so directly use `startCamera()` for web