### PR TITLE
Fix for project<>category mapping issues

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -349,8 +349,6 @@ export class AddEditExpensePage implements OnInit {
 
   breakfastSystemCategories: string[];
 
-  canAutofillCategory: boolean;
-
   constructor(
     private activatedRoute: ActivatedRoute,
     private accountsService: AccountsService,
@@ -1643,6 +1641,7 @@ export class AddEditExpensePage implements OnInit {
 
           this.recentCurrencies = recentCurrencies;
 
+          let canAutofillCategory: boolean;
           /* Autofill project during these cases:
            * 1. Autofills is allowed and enabled
            * 2. During add expense - When project field is empty
@@ -1661,23 +1660,23 @@ export class AddEditExpensePage implements OnInit {
 
               // Check if the recent categories are allowed for the project auto-filled
               const isAllowedRecentCategories = recentCategories.map((category) =>
-                project.project_org_category_ids.indexOf(category.value.id) > -1 ? true : false
+                project.project_org_category_ids.includes(category.value.id)
               );
 
               // Set the updated allowed recent categories
-              this.recentCategories = recentCategories.filter(
-                (category) => project.project_org_category_ids.indexOf(category.value.id) > -1
+              this.recentCategories = recentCategories.filter((category) =>
+                project.project_org_category_ids.includes(category.value.id)
               );
 
               // Only if the most recent category is allowed for the auto-filled project, category field can be auto-filled
-              this.canAutofillCategory = isAllowedRecentCategories[0];
+              canAutofillCategory = isAllowedRecentCategories[0];
 
               // Set the project preset value to the formGroup to trigger filtering of all allowed categories
               this.fg.patchValue({ project });
             }
           }
 
-          if (this.canAutofillCategory) {
+          if (canAutofillCategory) {
             // Check if recent categories exist
             category = this.getAutofillCategory({
               isAutofillsEnabled,

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -349,6 +349,8 @@ export class AddEditExpensePage implements OnInit {
 
   breakfastSystemCategories: string[];
 
+  canAutofillCategory: boolean;
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private accountsService: AccountsService,
@@ -1628,15 +1630,6 @@ export class AddEditExpensePage implements OnInit {
             orgUserSettings.expense_form_autofills.allowed &&
             orgUserSettings.expense_form_autofills.enabled;
 
-          // Check if recent categories exist
-          category = this.getAutofillCategory({
-            isAutofillsEnabled,
-            recentValue,
-            recentCategories,
-            etxn,
-            category,
-          });
-
           // Check if recent projects exist
           const doRecentProjectIdsExist =
             isAutofillsEnabled &&
@@ -1665,7 +1658,34 @@ export class AddEditExpensePage implements OnInit {
             if (autoFillProject) {
               project = autoFillProject;
               this.presetProjectId = project.project_id;
+
+              // Check if the recent categories are allowed for the project auto-filled
+              const isAllowedRecentCategories = recentCategories.map((category) =>
+                project.project_org_category_ids.indexOf(category.value.id) > -1 ? true : false
+              );
+
+              // Set the updated allowed recent categories
+              this.recentCategories = recentCategories.filter(
+                (category) => project.project_org_category_ids.indexOf(category.value.id) > -1
+              );
+
+              // Only if the most recent category is allowed for the auto-filled project, category field can be auto-filled
+              this.canAutofillCategory = isAllowedRecentCategories[0];
+
+              // Set the project preset value to the formGroup to trigger filtering of all allowed categories
+              this.fg.patchValue({ project });
             }
+          }
+
+          if (this.canAutofillCategory) {
+            // Check if recent categories exist
+            category = this.getAutofillCategory({
+              isAutofillsEnabled,
+              recentValue,
+              recentCategories,
+              etxn,
+              category,
+            });
           }
 
           // Check if recent cost centers exist
@@ -2247,6 +2267,8 @@ export class AddEditExpensePage implements OnInit {
       switchMap((etxn) => {
         if (etxn.tx.project_id) {
           return this.projectsService.getbyId(etxn.tx.project_id);
+        } else if (this.fg.controls.project?.value?.project_id) {
+          return this.projectsService.getbyId(this.fg.controls.project.value.project_id);
         } else {
           return of(null);
         }
@@ -2766,9 +2788,9 @@ export class AddEditExpensePage implements OnInit {
       )
     );
 
-    this.setupCustomFields();
-
     this.setupFormInit(allCategories$);
+
+    this.setupCustomFields();
 
     this.transactionInReport$ = this.etxn$.pipe(
       map((etxn) => ['APPROVER_PENDING', 'APPROVER_INQUIRY'].indexOf(etxn.tx.state) > -1)


### PR DESCRIPTION
### What was the issue?
- When the project got preset, the project watcher did not trigger, due to which the allowed categories filter method did not get called

### What is the fix?
- I have explicitly added checks to filter the allowed categories for recent categories as well as the all-category list
- As soon as the project is preset, we filter out the allowed categories
- We will autofill category only if it is allowed for that particular project
- Setting the form group project value explicitly before the patch which triggers the project watcher and filters out the allowed categories