### PR TITLE
#mission_nps_mobile_40: Use autofill if DE extracts invalid category

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1797,18 +1797,13 @@ export class AddEditExpensePage implements OnInit {
 
     let category = config.category;
 
-    const doRecentOrgCategoryIdsExist =
-      isAutofillsEnabled &&
-      recentValue &&
-      recentValue.recent_org_category_ids &&
-      recentValue.recent_org_category_ids.length > 0;
+    const doRecentOrgCategoryIdsExist = isAutofillsEnabled && recentValue?.recent_org_category_ids?.length;
 
-    if (recentCategories && recentCategories.length > 0) {
+    if (recentCategories?.length) {
       this.recentCategories = recentCategories;
     }
 
-    // Check if category is extracted from instaFyle/autoFyle
-    const isCategoryExtracted = etxn.tx && etxn.tx.extracted_data && etxn.tx.extracted_data.category;
+    const isCategoryEmpty = !etxn.tx.org_category_id || etxn.tx.fyle_category?.toLowerCase() === 'unspecified';
 
     /* Autofill category during these cases:
      * 1. vm.canAutofill - Autofills is allowed and enabled - mandatory
@@ -1817,16 +1812,8 @@ export class AddEditExpensePage implements OnInit {
      * 4. During edit expense - When the expense is in draft state and
      * there is no category extracted or no category already added - optional
      */
-    if (
-      doRecentOrgCategoryIdsExist &&
-      !isCategoryExtracted &&
-      (!etxn.tx.id ||
-        (etxn.tx.id &&
-          etxn.tx.state === 'DRAFT' &&
-          (!etxn.tx.org_category_id ||
-            (etxn.tx.fyle_category && etxn.tx.fyle_category.toLowerCase() === 'unspecified'))))
-    ) {
-      const autoFillCategory = recentCategories && recentCategories.length > 0 && recentCategories[0];
+    if (doRecentOrgCategoryIdsExist && isCategoryEmpty && (!etxn.tx.id || etxn.tx.state === 'DRAFT')) {
+      const autoFillCategory = recentCategories.length && recentCategories[0];
 
       if (autoFillCategory) {
         category = autoFillCategory.value;

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1307,6 +1307,7 @@ export class AddEditExpensePage implements OnInit {
             const categoryName = extractedData.category || 'unspecified';
             const category = categories.find((orgCategory) => orgCategory.name === categoryName);
             etxn.tx.org_category_id = category && category.id;
+            etxn.tx.fyle_category = category.fyle_category;
           }
         }
 

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1304,10 +1304,9 @@ export class AddEditExpensePage implements OnInit {
           }
 
           if (extractedData.category) {
-            const categoryName = extractedData.category || 'unspecified';
-            const category = categories.find((orgCategory) => orgCategory.name === categoryName);
-            etxn.tx.org_category_id = category && category.id;
-            etxn.tx.fyle_category = category.fyle_category;
+            const category = categories.find((orgCategory) => orgCategory.name === extractedData.category);
+            etxn.tx.org_category_id = category?.id;
+            etxn.tx.fyle_category = category?.fyle_category;
           }
         }
 

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1805,12 +1805,12 @@ export class AddEditExpensePage implements OnInit {
 
     const isCategoryEmpty = !etxn.tx.org_category_id || etxn.tx.fyle_category?.toLowerCase() === 'unspecified';
 
-    /* Autofill category during these cases:
-     * 1. vm.canAutofill - Autofills is allowed and enabled - mandatory
-     * 2. When there exists recently used category ids to auto-fill - mandatory
-     * 3. During add expense - When category field is empty - optional
-     * 4. During edit expense - When the expense is in draft state and
-     * there is no category extracted or no category already added - optional
+    /*
+     * Autofill should be applied iff:
+     * - Autofilled is allowed and enabled for the user
+     * - The user has some recently used categories present
+     * - The transaction category is empty or 'unspecified'
+     * - The user is on creating a new expense or editing a DRAFT expense
      */
     if (doRecentOrgCategoryIdsExist && isCategoryEmpty && (!etxn.tx.id || etxn.tx.state === 'DRAFT')) {
       const autoFillCategory = recentCategories.length && recentCategories[0];


### PR DESCRIPTION
Fixes two issues. We switch back to autofill iff:
- DE extracted category is not enabled for the org - https://app.clickup.com/t/2x6fx89
- DE extracts `unspecified` category