### PR TITLE
Fix project field not visible in mileage/per-diem forms

### DIFF
--- a/src/app/core/services/projects.service.ts
+++ b/src/app/core/services/projects.service.ts
@@ -70,11 +70,12 @@ export class ProjectsService {
 
   @Cacheable()
   getProjectCount(params: { categoryIds: string[] } = { categoryIds: [] }) {
+    const categoryIds = params.categoryIds.map((categoryId) => parseInt(categoryId, 10));
     return this.getAllActive().pipe(
       map((projects) => {
         const filterdProjects = projects.filter((project) => {
-          if (params.categoryIds.length) {
-            return intersection(params.categoryIds, project.org_category_ids).length > 0;
+          if (categoryIds.length) {
+            return intersection(categoryIds, project.org_category_ids).length > 0;
           } else {
             return true;
           }

--- a/src/app/core/services/projects.service.ts
+++ b/src/app/core/services/projects.service.ts
@@ -70,11 +70,11 @@ export class ProjectsService {
 
   @Cacheable()
   getProjectCount(params: { categoryIds: string[] } = { categoryIds: [] }) {
-    const categoryIds = params.categoryIds.map((categoryId) => parseInt(categoryId, 10));
+    const categoryIds = params.categoryIds?.map((categoryId) => parseInt(categoryId, 10));
     return this.getAllActive().pipe(
       map((projects) => {
         const filterdProjects = projects.filter((project) => {
-          if (categoryIds.length) {
+          if (categoryIds?.length) {
             return intersection(categoryIds, project.org_category_ids).length > 0;
           } else {
             return true;


### PR DESCRIPTION
Fixes https://app.clickup.com/t/2y8wx9x

Issue:
- In mileage and per-diem forms, we filter the projects to show only the projects that are allowed for `Mileage` or `Per Diem`
- When comparing the project ids, in the `getProjectCount()` method in projects service, we were passing category ids as an array of string
- But, the API returns allowed category ids as an array of numbers. And so, the intersection always returned an empty array because of which the project field was not shown for mileage/per-diem expenses

Solution:
- Converted `string[]` to `number[]` inside the `getProjectCount()` method before checking for intersection