### PR TITLE
Report Redirect Fix

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -352,6 +352,8 @@ export class AddEditExpensePage implements OnInit {
 
   breakfastSystemCategories: string[];
 
+  reportId: string;
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private accountsService: AccountsService,
@@ -969,6 +971,10 @@ export class AddEditExpensePage implements OnInit {
   }
 
   ngOnInit() {
+    if (this.activatedRoute.snapshot.params.rp_id) {
+      this.reportId = this.activatedRoute.snapshot.params.rp_id;
+    }
+
     this.isRedirectedFromReport = this.activatedRoute.snapshot.params.remove_from_report ? true : false;
     this.canRemoveFromReport = this.activatedRoute.snapshot.params.remove_from_report === 'true';
   }
@@ -3061,7 +3067,8 @@ export class AddEditExpensePage implements OnInit {
                 if (that.fg.controls.add_to_new_report.value && res && res.transaction) {
                   this.addToNewReport(res.transaction.id);
                 } else if (that.fg.value.report && that.fg.value.report.rp && that.fg.value.report.rp.id) {
-                  that.goBack();
+                  this.reportId = that.fg.value.report.rp.id;
+                  // that.goBack();
                   this.showAddToReportSuccessToast(that.fg.value.report.rp.id);
                 } else {
                   that.goBack();
@@ -3729,6 +3736,8 @@ export class AddEditExpensePage implements OnInit {
         this.saveAndNewExpenseLoader = false;
         this.saveAndNextExpenseLoader = false;
         this.saveAndPrevExpenseLoader = false;
+
+        this.router.navigate(['/', 'enterprise', 'my_view_report', { id: this.reportId }]);
       })
     );
   }

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -426,6 +426,16 @@ export class AddEditExpensePage implements OnInit {
     }
   }
 
+  getIdFromParam() {
+    if (this.activatedRoute.snapshot.params.rp_id) {
+      return this.activatedRoute.snapshot.params.rp_id;
+    }
+  }
+
+  redirectToReport(reportId: string) {
+    this.router.navigate(['/', 'enterprise', 'my_view_report', { id: this.reportId }]);
+  }
+
   async showClosePopup() {
     const isAutofilled =
       this.presetCategoryId || this.presetProjectId || this.presetCostCenterId || this.presetCurrency;
@@ -971,10 +981,7 @@ export class AddEditExpensePage implements OnInit {
   }
 
   ngOnInit() {
-    if (this.activatedRoute.snapshot.params.rp_id) {
-      this.reportId = this.activatedRoute.snapshot.params.rp_id;
-    }
-
+    this.reportId = this.getIdFromParam();
     this.isRedirectedFromReport = this.activatedRoute.snapshot.params.remove_from_report ? true : false;
     this.canRemoveFromReport = this.activatedRoute.snapshot.params.remove_from_report === 'true';
   }


### PR DESCRIPTION
## Redirection from Add Expense to Report

When creating an expense from the report, the app redirects to the expenses page instead of going to the report where the expense was created.

### Edit 1: The redirection works but happens before the expense has been added to the report