### PR TITLE
Org And Name Area Clickable

### DIFF
--- a/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.html
+++ b/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-toolbar class="sidemenu-header__toolbar" translucent>
-    <ion-grid class="ion-grid-no-padding sidemenu-header__grid">
+    <ion-grid class="ion-grid-no-padding sidemenu-header__grid" (click)="onClickProfile()">
       <ion-row>
         <ion-col class="sidemenu-header__icon-container">
           <div class="sidemenu-header__icon-container__text">

--- a/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.html
+++ b/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.html
@@ -1,26 +1,28 @@
 <ion-header>
   <ion-toolbar class="sidemenu-header__toolbar" translucent>
-    <ion-grid class="ion-grid-no-padding sidemenu-header__grid" matRipple (click)="onClickProfile($event)">
-      <ion-row>
-        <ion-col class="sidemenu-header__icon-container">
-          <div class="sidemenu-header__icon-container__text">
-            {{ eou?.us?.full_name | initials | uppercase }}
-          </div>
-        </ion-col>
-        <ion-col class="sidemenu-header__content-container">
-          <div class="text-ellipsis sidemenu-header__content-container__title">
-            {{ eou?.us?.full_name | titlecase }}
-          </div>
-          <div class="d-flex">
-            <ion-icon
-              class="sidemenu-header__content-container__icon"
-              src="../../../../../assets/svg/organization.svg"
-              slot="icon-only"
-            ></ion-icon>
-            <div class="sidemenu-header__content-container__sub-title">{{ activeOrg?.name }}</div>
-          </div>
-        </ion-col>
-      </ion-row>
-    </ion-grid>
+    <div matRipple [matRippleColor]="'rgba(255, 255, 255, 0.3)'" (click)="onClickProfile($event)">
+      <ion-grid class="ion-grid-no-padding sidemenu-header__grid">
+        <ion-row>
+          <ion-col class="sidemenu-header__icon-container">
+            <div class="sidemenu-header__icon-container__text">
+              {{ eou?.us?.full_name | initials | uppercase }}
+            </div>
+          </ion-col>
+          <ion-col class="sidemenu-header__content-container">
+            <div class="text-ellipsis sidemenu-header__content-container__title">
+              {{ eou?.us?.full_name | titlecase }}
+            </div>
+            <div class="d-flex">
+              <ion-icon
+                class="sidemenu-header__content-container__icon"
+                src="../../../../../assets/svg/organization.svg"
+                slot="icon-only"
+              ></ion-icon>
+              <div class="sidemenu-header__content-container__sub-title">{{ activeOrg?.name }}</div>
+            </div>
+          </ion-col>
+        </ion-row>
+      </ion-grid>
+    </div>
   </ion-toolbar>
 </ion-header>

--- a/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.html
+++ b/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-toolbar class="sidemenu-header__toolbar" translucent>
-    <ion-grid class="ion-grid-no-padding sidemenu-header__grid" (click)="onClickProfile()">
+    <ion-grid class="ion-grid-no-padding sidemenu-header__grid" matRipple (click)="onClickProfile($event)">
       <ion-row>
         <ion-col class="sidemenu-header__icon-container">
           <div class="sidemenu-header__icon-container__text">

--- a/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.html
+++ b/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-toolbar class="sidemenu-header__toolbar" translucent>
-    <div matRipple [matRippleColor]="'rgba(255, 255, 255, 0.3)'" (click)="onClickProfile($event)">
+    <div matRipple [matRippleColor]="'rgba(255, 255, 255, 0.3)'" (click)="onProfileClicked($event)">
       <ion-grid class="ion-grid-no-padding sidemenu-header__grid">
         <ion-row>
           <ion-col class="sidemenu-header__icon-container">

--- a/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.ts
+++ b/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.ts
@@ -13,12 +13,12 @@ export class SidemenuHeaderComponent implements OnInit {
 
   @Input() activeOrg: Org;
 
-  @Output() profileClick = new EventEmitter();
+  @Output() profileClicked = new EventEmitter();
 
   constructor() {}
 
-  onClickProfile(event: Event) {
-    this.profileClick.emit(event);
+  onProfileClicked(event: Event) {
+    this.profileClicked.emit(event);
   }
 
   ngOnInit(): void {}

--- a/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.ts
+++ b/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
+import { Router } from '@angular/router';
+import { MenuController } from '@ionic/angular';
 import { ExtendedOrgUser } from 'src/app/core/models/extended-org-user.model';
 import { Org } from 'src/app/core/models/org.model';
 
@@ -12,7 +14,12 @@ export class SidemenuHeaderComponent implements OnInit {
 
   @Input() activeOrg: Org;
 
-  constructor() {}
+  constructor(private router: Router, private menuController: MenuController) {}
+
+  onClickProfile() {
+    this.router.navigate(['/', 'enterprise', 'my_profile']);
+    this.menuController.close();
+  }
 
   ngOnInit(): void {}
 }

--- a/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.ts
+++ b/src/app/shared/components/sidemenu/sidemenu-header/sidemenu-header.component.ts
@@ -1,8 +1,7 @@
-import { Component, OnInit, Input } from '@angular/core';
-import { Router } from '@angular/router';
-import { MenuController } from '@ionic/angular';
+import { Component, OnInit, Input, Output } from '@angular/core';
 import { ExtendedOrgUser } from 'src/app/core/models/extended-org-user.model';
 import { Org } from 'src/app/core/models/org.model';
+import { EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-sidemenu-header',
@@ -14,11 +13,12 @@ export class SidemenuHeaderComponent implements OnInit {
 
   @Input() activeOrg: Org;
 
-  constructor(private router: Router, private menuController: MenuController) {}
+  @Output() profileClick = new EventEmitter();
 
-  onClickProfile() {
-    this.router.navigate(['/', 'enterprise', 'my_profile']);
-    this.menuController.close();
+  constructor() {}
+
+  onClickProfile(event: Event) {
+    this.profileClick.emit(event);
   }
 
   ngOnInit(): void {}

--- a/src/app/shared/components/sidemenu/sidemenu.component.html
+++ b/src/app/shared/components/sidemenu/sidemenu.component.html
@@ -1,5 +1,5 @@
 <ion-menu side="start" class="sidemenu" content-id="main-content" [swipeGesture]="false">
-  <app-sidemenu-header [eou]="eou" [activeOrg]="activeOrg" (profileClick)="goToProfile($event)"></app-sidemenu-header>
+  <app-sidemenu-header [eou]="eou" [activeOrg]="activeOrg" (profileClicked)="goToProfile($event)"></app-sidemenu-header>
 
   <ion-content>
     <div class="sidemenu__content-container">

--- a/src/app/shared/components/sidemenu/sidemenu.component.html
+++ b/src/app/shared/components/sidemenu/sidemenu.component.html
@@ -1,5 +1,5 @@
 <ion-menu side="start" class="sidemenu" content-id="main-content" [swipeGesture]="false">
-  <app-sidemenu-header [eou]="eou" [activeOrg]="activeOrg"></app-sidemenu-header>
+  <app-sidemenu-header [eou]="eou" [activeOrg]="activeOrg" (profileClick)="goToProfile($event)"></app-sidemenu-header>
 
   <ion-content>
     <div class="sidemenu__content-container">

--- a/src/app/shared/components/sidemenu/sidemenu.component.ts
+++ b/src/app/shared/components/sidemenu/sidemenu.component.ts
@@ -18,6 +18,8 @@ import { OrgService } from 'src/app/core/services/org.service';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { ExtendedDeviceInfo } from 'src/app/core/models/extended-device-info.model';
 import { OrgUserSettingsService } from 'src/app/core/services/org-user-settings.service';
+import { Router } from '@angular/router';
+import { MenuController } from '@ionic/angular';
 
 @Component({
   selector: 'app-sidemenu',
@@ -52,6 +54,8 @@ export class SidemenuComponent implements OnInit {
   constructor(
     private deviceService: DeviceService,
     private routerAuthService: RouterAuthService,
+    private router: Router,
+    private menuController: MenuController,
     private orgUserService: OrgUserService,
     private orgSettingsService: OrgSettingsService,
     private networkService: NetworkService,
@@ -368,6 +372,13 @@ export class SidemenuComponent implements OnInit {
         disabled: !isConnected,
       },
     ].filter((sidemenuItem) => sidemenuItem.isVisible);
+  }
+
+  goToProfile(event) {
+    if (event.isTrusted) {
+      this.router.navigate(['/', 'enterprise', 'my_profile']);
+      this.menuController.close();
+    }
   }
 
   setupSideMenu(isConnected?: boolean, orgs?: Org[], isDelegatee?: boolean) {

--- a/src/app/shared/components/sidemenu/sidemenu.component.ts
+++ b/src/app/shared/components/sidemenu/sidemenu.component.ts
@@ -374,7 +374,7 @@ export class SidemenuComponent implements OnInit {
     ].filter((sidemenuItem) => sidemenuItem.isVisible);
   }
 
-  goToProfile(event) {
+  goToProfile(event: Event) {
     if (event.isTrusted) {
       this.router.navigate(['/', 'enterprise', 'my_profile']);
       this.menuController.close();


### PR DESCRIPTION
## Menu Click To Profile Fix
![App_menu](https://user-images.githubusercontent.com/115472256/202977896-714805c9-d03e-4ea4-a31a-abf802a1f2e4.png)

Now clicking on the name of the user on top of the menu will take the user to the profile page.

### Edit 1: 

https://user-images.githubusercontent.com/115472256/203004499-2bdb5cf1-eb2a-4d52-830d-992db2adb818.mov
Ripple effect added and click handler now relies on event emitter from sidemenu-header to parent component. 

### Edit 2: 

https://user-images.githubusercontent.com/115472256/203482899-c757ec2f-be32-41a2-8e30-c22ad1518fb4.mov

Ripple effect improved and refactor
