### PR TITLE
Infobox update

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -115,6 +115,17 @@
         </ng-container>
 
         <ng-container *ngIf="isUnifyCcceExpensesSettingsEnabled && isCccExpense">
+          <div class="add-edit-expense--split-info-container add-edit-expense--split-info-container__with-border">
+            <mat-icon class="add-edit-expense--split-info-icon" svgIcon="fy-info"></mat-icon>
+            <div class="add-edit-expense--split-info-message">
+              If the expense is linked with incorrect card details, click on Options (<span
+                ><ion-icon
+                  class="add-edit-expense--icon-dots"
+                  [src]="'../../../assets/svg/dot-menu.svg'"
+                ></ion-icon></span
+              >) to unlink the card details.
+            </div>
+          </div>
           <ion-grid class="add-edit-expense--card-container">
             <ion-row>
               <ion-col>
@@ -149,17 +160,6 @@
               </ion-col>
             </ion-row>
           </ion-grid>
-          <div class="add-edit-expense--split-info-container add-edit-expense--split-info-container__with-border">
-            <mat-icon class="add-edit-expense--split-info-icon" svgIcon="fy-info"></mat-icon>
-            <div class="add-edit-expense--split-info-message">
-              If the expense is linked with incorrect card details, click on Options (<span
-                ><ion-icon
-                  class="add-edit-expense--icon-dots"
-                  [src]="'../../../assets/svg/dot-menu.svg'"
-                ></ion-icon></span
-              >) to unlink the card details.
-            </div>
-          </div>
         </ng-container>
 
         <div class="add-edit-expense--receipt-currency-container">

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -117,7 +117,10 @@
         <ng-container *ngIf="isUnifyCcceExpensesSettingsEnabled && isCccExpense">
           <div class="add-edit-expense--split-info-container add-edit-expense--split-info-container__with-border">
             <mat-icon class="add-edit-expense--split-info-icon" svgIcon="fy-info"></mat-icon>
-            <div class="add-edit-expense--split-info-message">
+            <div
+              class="add-edit-expense--split-info-message"
+              *ngIf="((isUnifyCcceExpensesSettingsEnabled) && !(etxn?.tx?.report_id) && !(reviewList?.length > 1)) || (isCorporateCreditCardEnabled && canUnlinkCCCE)"
+            >
               If the expense is linked with incorrect card details, click on Options (<span
                 ><ion-icon
                   class="add-edit-expense--icon-dots"

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.scss
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.scss
@@ -322,8 +322,7 @@
     margin-left: 20px;
 
     &__with-border {
-      margin-top: 8px;
-      margin-bottom: 8px;
+      margin: 8px 0px;
       border: 1px solid $grey-lighter;
       margin-left: 0;
       border-radius: 4px;

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.scss
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.scss
@@ -322,6 +322,8 @@
     margin-left: 20px;
 
     &__with-border {
+      margin-top: 8px;
+      margin-bottom: 8px;
       border: 1px solid $grey-lighter;
       margin-left: 0;
       border-radius: 4px;


### PR DESCRIPTION
## Info box and menu bug fix in add edit expense page
## Clickup Task: https://app.clickup.com/t/2yemxkb


### Expense without Infobox
![expense-without-info](https://user-images.githubusercontent.com/115472256/204720430-aa57bd3e-4653-44ff-bcd5-55416067b8d3.png)

### Expense with Infobox
![expense-with-infobox](https://user-images.githubusercontent.com/115472256/204720590-a6af308d-6067-4a05-a0d2-96491865a413.png)


The info box position has been fixed, it now appears above the card information but the dot menu is not visible, hidden under spilt expense allowed condition