### PR TITLE
#mission_nps_mobile_40: Use app font size irrespective of device native font size

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -22,12 +22,15 @@ dependencies {
     implementation project(':capacitor-splash-screen')
     implementation project(':capacitor-status-bar')
     implementation project(':capacitor-storage')
+    implementation project(':capacitor-text-zoom')
+    implementation project(':capacitor-native-settings')
     implementation project(':capacitor-secure-storage-plugin')
     implementation "com.google.android.gms:play-services-auth:15.0.1"
     implementation "com.google.android.gms:play-services-identity:15.0.1"
     implementation "com.android.support:appcompat-v7:27.+"
 }
 apply from: "../../node_modules/cordova-plugin-ionic/src/android/cordovapluginionic.gradle"
+apply from: "../../node_modules/cordova-plugin-smartlook/src/android/plugin.gradle"
 apply from: "../../node_modules/cordova-plugin-telerik-imagepicker/src/android/ignorelinterrors.gradle"
 apply from: "../../node_modules/cordova-plugin-telerik-imagepicker/src/android/androidtarget.gradle"
 

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -52,6 +52,14 @@
 		"classpath": "com.capacitorjs.plugins.storage.StoragePlugin"
 	},
 	{
+		"pkg": "@capacitor/text-zoom",
+		"classpath": "com.capacitorjs.plugins.textzoom.TextZoomPlugin"
+	},
+	{
+		"pkg": "capacitor-native-settings",
+		"classpath": "nl.raphael.settings.NativeSettingsPlugin"
+	},
+	{
 		"pkg": "capacitor-secure-storage-plugin",
 		"classpath": "com.whitestein.securestorage.SecureStoragePlugin"
 	}

--- a/android/app/src/main/res/xml/config.xml
+++ b/android/app/src/main/res/xml/config.xml
@@ -20,6 +20,10 @@
     <param name="android-package" value="com.greybax.spinnerdialog.SpinnerDialog"/>
   </feature>
 
+  <feature name="SmartlookPlugin">
+    <param name="android-package" value="com.smartlook.cordovaplugin.SmartlookPlugin"/>
+  </feature>
+
   <feature name="ImagePicker">
     <param name="android-package" value="com.synconset.ImagePicker"/>
   </feature>

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -41,5 +41,11 @@ project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacit
 include ':capacitor-storage'
 project(':capacitor-storage').projectDir = new File('../node_modules/@capacitor/storage/android')
 
+include ':capacitor-text-zoom'
+project(':capacitor-text-zoom').projectDir = new File('../node_modules/@capacitor/text-zoom/android')
+
+include ':capacitor-native-settings'
+project(':capacitor-native-settings').projectDir = new File('../node_modules/capacitor-native-settings/android')
+
 include ':capacitor-secure-storage-plugin'
 project(':capacitor-secure-storage-plugin').projectDir = new File('../node_modules/capacitor-secure-storage-plugin/android')

--- a/ios/App/App/config.xml
+++ b/ios/App/App/config.xml
@@ -29,6 +29,10 @@
     <param name="ios-package" value="CDVSpinnerDialog"/>
   </feature>
 
+  <feature name="SmartlookPlugin">
+    <param name="ios-package" value="SmartlookPlugin"/>
+  </feature>
+
   <feature name="ImagePicker">
     <param name="ios-package" value="SOSPicker"/>
   </feature>

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -22,6 +22,8 @@ def capacitor_pods
   pod 'CapacitorSplashScreen', :path => '../../node_modules/@capacitor/splash-screen'
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
   pod 'CapacitorStorage', :path => '../../node_modules/@capacitor/storage'
+  pod 'CapacitorTextZoom', :path => '../../node_modules/@capacitor/text-zoom'
+  pod 'CapacitorNativeSettings', :path => '../../node_modules/capacitor-native-settings'
   pod 'CapacitorSecureStoragePlugin', :path => '../../node_modules/capacitor-secure-storage-plugin'
   pod 'CordovaPlugins', :path => '../capacitor-cordova-ios-plugins'
   pod 'CordovaPluginsStatic', :path => '../capacitor-cordova-ios-plugins'

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@capacitor/splash-screen": "^1.2.2",
         "@capacitor/status-bar": "^1.0.8",
         "@capacitor/storage": "^1.2.5",
+        "@capacitor/text-zoom": "^1.0.8",
         "@ionic/angular": "^6.1.5",
         "@ionic/core": "^6.1.5",
         "@ionic/pwa-elements": "^3.1.1",
@@ -71,7 +72,7 @@
         "ngx-pinch-zoom": "^2.6.2",
         "rxjs": "^7.5.5",
         "swiper": "^8.2.4",
-        "ts-cacheable": "^1.0.6",
+        "ts-cacheable": "^1.0.9",
         "tslib": "^2.4.0",
         "zone.js": "^0.11.6"
       },
@@ -2816,6 +2817,14 @@
       "resolved": "https://registry.npmjs.org/@capacitor/storage/-/storage-1.2.5.tgz",
       "integrity": "sha512-pWhnw4U7wN/zFV4lA4BLMypSufTktCbk548Yk4whSb0KAq3R0mLfSubRIHkGdcPqQWCsM6g/zUuszurhz6ncWQ==",
       "deprecated": "package has been renamed to @capacitor/preferences",
+      "peerDependencies": {
+        "@capacitor/core": "^3.0.0"
+      }
+    },
+    "node_modules/@capacitor/text-zoom": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@capacitor/text-zoom/-/text-zoom-1.0.8.tgz",
+      "integrity": "sha512-FkXZopm+4AdaqWRFiBujHX/MIhSpsvxZguGs4tWKKvMcoJYaNdNwt7LJudmu204nPw0GII0WfOFkexzmqz7ZCA==",
       "peerDependencies": {
         "@capacitor/core": "^3.0.0"
       }
@@ -16966,9 +16975,9 @@
       }
     },
     "node_modules/ts-cacheable": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/ts-cacheable/-/ts-cacheable-1.0.6.tgz",
-      "integrity": "sha512-Fqr0Xt3ra5ADqJytckD6P83vzVBM/t/z/Oa8nkPXjKAjJY5i/VsefbWXmNZAca0oLs+DxKErBkwfQFqLG8snqw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ts-cacheable/-/ts-cacheable-1.0.9.tgz",
+      "integrity": "sha512-Wqbuh086IO2268XGb+a2ZodBVkSQAdbo5UkJJ7/B1csiskMIpip5rC7jfEv3UGZ/ylgN1ij7El0rUcqikws3zg==",
       "peerDependencies": {
         "rxjs": "^6.6.0 || ^7.4.0"
       }
@@ -19999,6 +20008,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@capacitor/storage/-/storage-1.2.5.tgz",
       "integrity": "sha512-pWhnw4U7wN/zFV4lA4BLMypSufTktCbk548Yk4whSb0KAq3R0mLfSubRIHkGdcPqQWCsM6g/zUuszurhz6ncWQ==",
+      "requires": {}
+    },
+    "@capacitor/text-zoom": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@capacitor/text-zoom/-/text-zoom-1.0.8.tgz",
+      "integrity": "sha512-FkXZopm+4AdaqWRFiBujHX/MIhSpsvxZguGs4tWKKvMcoJYaNdNwt7LJudmu204nPw0GII0WfOFkexzmqz7ZCA==",
       "requires": {}
     },
     "@colors/colors": {
@@ -30540,9 +30555,9 @@
       "dev": true
     },
     "ts-cacheable": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/ts-cacheable/-/ts-cacheable-1.0.6.tgz",
-      "integrity": "sha512-Fqr0Xt3ra5ADqJytckD6P83vzVBM/t/z/Oa8nkPXjKAjJY5i/VsefbWXmNZAca0oLs+DxKErBkwfQFqLG8snqw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ts-cacheable/-/ts-cacheable-1.0.9.tgz",
+      "integrity": "sha512-Wqbuh086IO2268XGb+a2ZodBVkSQAdbo5UkJJ7/B1csiskMIpip5rC7jfEv3UGZ/ylgN1ij7El0rUcqikws3zg==",
       "requires": {}
     },
     "ts-node": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@capacitor/splash-screen": "^1.2.2",
     "@capacitor/status-bar": "^1.0.8",
     "@capacitor/storage": "^1.2.5",
+    "@capacitor/text-zoom": "^1.0.8",
     "@ionic/angular": "^6.1.5",
     "@ionic/core": "^6.1.5",
     "@ionic/pwa-elements": "^3.1.1",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,6 +25,7 @@ import { PerfTrackers } from './core/models/perf-trackers.enum';
 import { ExtendedDeviceInfo } from './core/models/extended-device-info.model';
 import { BackButtonActionPriority } from './core/models/back-button-action-priority.enum';
 import { BackButtonService } from './core/services/back-button.service';
+import { TextZoom } from '@capacitor/text-zoom';
 
 @Component({
   selector: 'app-root',
@@ -106,6 +107,8 @@ export class AppComponent implements OnInit {
         style: Style.Default,
       });
       setTimeout(async () => await SplashScreen.hide(), 1000);
+
+      await TextZoom.set({ value: 100 });
 
       from(this.routerAuthService.isLoggedIn())
         .pipe(

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -108,6 +108,11 @@ export class AppComponent implements OnInit {
       });
       setTimeout(async () => await SplashScreen.hide(), 1000);
 
+      /*
+       * Use the app's font size irrespective of the user's device font size.
+       * This is to ensure that the app's UI is consistent across devices.
+       * Ref: https://www.npmjs.com/package/@capacitor/text-zoom
+       */
       await TextZoom.set({ value: 1 });
 
       from(this.routerAuthService.isLoggedIn())

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -108,7 +108,7 @@ export class AppComponent implements OnInit {
       });
       setTimeout(async () => await SplashScreen.hide(), 1000);
 
-      await TextZoom.set({ value: 100 });
+      await TextZoom.set({ value: 1 });
 
       from(this.routerAuthService.isLoggedIn())
         .pipe(


### PR DESCRIPTION
- I'm using capacitor's official `text-zoom` plugin here - https://capacitorjs.com/docs/apis/text-zoom
- It has been around for a while and already has support for Capacitor 4
- Tested on both android and IOS 🟢 
- Will get a green from Sumanth and Bhavika before merging and we'll do a staged release as discussed