### PR TITLE
Stop camera only if it is in starting or running state

### DIFF
--- a/src/app/shared/components/capture-receipt/camera-preview/camera-preview.component.ts
+++ b/src/app/shared/components/capture-receipt/camera-preview/camera-preview.component.ts
@@ -103,7 +103,7 @@ export class CameraPreviewComponent implements OnInit, OnChanges {
   }
 
   stopCamera() {
-    if (this.cameraState !== CameraState.STOPPING) {
+    if ([CameraState.STARTING, CameraState.RUNNING].includes(this.cameraState)) {
       this.cameraState = CameraState.STOPPING;
       from(CameraPreview.stop()).subscribe((_) => (this.cameraState = CameraState.STOPPED));
     }


### PR DESCRIPTION
Fixes: https://sentry.io/organizations/fyle-technologies-private-limi/issues/3283451811/?cursor=0%3A50%3A0&project=5622998&referrer=issue-stream

Call `CameraPreview.stop()` only if camera is in STARTING or RUNNING state