### PR TITLE
Fix: Add Mileage/Per-diem option is sometimes not visible on dashboard

### DIFF
--- a/src/app/fyle/dashboard/dashboard.page.ts
+++ b/src/app/fyle/dashboard/dashboard.page.ts
@@ -113,6 +113,10 @@ export class DashboardPage implements OnInit {
     this.orgSettings$ = this.orgSettingsService.get().pipe(shareReplay(1));
     this.homeCurrency$ = this.currencyService.getHomeCurrency().pipe(shareReplay(1));
 
+    this.orgSettings$.subscribe((orgSettings) => {
+      this.setupActionSheet(orgSettings);
+    });
+
     this.statsComponent.init();
     this.tasksComponent.init();
     /**
@@ -156,12 +160,7 @@ export class DashboardPage implements OnInit {
     });
   }
 
-  ngOnInit() {
-    const that = this;
-    that.orgSettingsService.get().subscribe((orgSettings) => {
-      this.setupActionSheet(orgSettings);
-    });
-  }
+  ngOnInit() {}
 
   onTaskClicked() {
     this.currentStateIndex = 1;


### PR DESCRIPTION
- Sometimes all the expense types available for the org users are not shown when clicking on the plus icon in the dashboard
- This probably happens because the orgsetting call is present in `ngOnInit()`
- So, if the user is on dashboard of some org where mileage/per-diem are not enabled, and then he switches to a different org where these settings are enabled, the `actionSheetOptions` array will not be updated as the dashboard page is already in stack.

Slack thread - https://fylein.slack.com/archives/CFGRGRY2X/p1670516936272879

![IMG_8301](https://user-images.githubusercontent.com/39493102/206516867-10e95b09-902b-49fb-823f-a0bf77639fa2.png)
