### PR TITLE
Duplicate Expense On Smaller Screen

### DIFF
--- a/src/app/shared/components/fy-alert-info.component.html/fy-alert-info.component.html
+++ b/src/app/shared/components/fy-alert-info.component.html/fy-alert-info.component.html
@@ -6,7 +6,7 @@
     svgIcon="danger"
   ></mat-icon>
   <div class="alert-info-container--message">{{ message }}</div>
-  <div *ngIf="showActionButton">
+  <div *ngIf="showActionButton" class="alert-info-container--button-container">
     <ion-button
       class="text-capitalize alert-info-container--button"
       mode="md"

--- a/src/app/shared/components/fy-alert-info.component.html/fy-alert-info.component.scss
+++ b/src/app/shared/components/fy-alert-info.component.html/fy-alert-info.component.scss
@@ -30,4 +30,20 @@ $container-border: #dfdfe2;
     --padding-top: 0;
     height: 12px;
   }
+
+  @media (max-width: 360px) {
+    padding: 12px 4px;
+    &--message {
+      width: auto;
+    }
+    &--icon {
+      margin-right: 4px;
+    }
+
+    &--button-container {
+      width: 12%;
+      display: flex;
+      justify-content: center;
+    }
+  }
 }


### PR DESCRIPTION
# Duplicate Expense Warning Size Fix
## Clickup Link: https://app.clickup.com/t/2yemwu7

The warning message looked weird on smaller screen, the warning text sometimes stretching three lines

![duplicate_exp_Zoomed_in](https://user-images.githubusercontent.com/115472256/207037275-49c75a3b-8383-4c66-8045-9db2bddf63ce.png)
![duplicate_exp_Zoomed_out](https://user-images.githubusercontent.com/115472256/207037285-e55676ba-5607-4784-9645-1ca6dbd12e68.png)
