### PR TITLE
#mission_nps_mobile_40: Fix custom inputs not shown when using instafyle

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1713,6 +1713,13 @@ export class AddEditExpensePage implements OnInit {
               etxn,
               category,
             });
+
+            /*
+             * Patching the category value here to trigger 'customInputs$' to get the
+             * custom inputs for this category. The patchValue call below uses
+             * 'emitEvent: false' which does not trigger valueChanges.
+             */
+            this.fg.controls.category.patchValue(category);
           }
 
           // Check if recent cost centers exist


### PR DESCRIPTION
- In cases where DE extracts `unspecified` as the category, and we use autofill, custom inputs are not shown.
- `customInputs$` emits a value when the category field is changed i.e. `fg.controls.category.valueChanges` emits a new value.
- Here, when we'e patching values for the entire form, we're setting `emitEvent` to `false` which does not trigger valueChanges
- Removiong the property for the entire form may lead to some other issues. So, I'm patching the value of category separately which triggers valueChanges event, and the custom fields are shown.