### PR TITLE
Fix expense/mileage/per-diem redirections

### DIFF
--- a/src/app/core/services/transactions-outbox.service.ts
+++ b/src/app/core/services/transactions-outbox.service.ts
@@ -423,6 +423,7 @@ export class TransactionsOutboxService {
           that
             .matchIfRequired(resp.id, entry.transaction.matchCCCId)
             .then(() => {
+              that.removeEntry(entry);
               if (reportId) {
                 const txnIds = [resp.id];
                 that.reportService
@@ -430,7 +431,6 @@ export class TransactionsOutboxService {
                   .toPromise()
                   .then(() => {
                     this.trackingService.addToExistingReportAddEditExpense();
-                    that.removeEntry(entry);
                     resolve(entry);
                   })
                   .catch((err) => {
@@ -438,7 +438,6 @@ export class TransactionsOutboxService {
                     reject(err);
                   });
               } else {
-                that.removeEntry(entry);
                 resolve(entry);
               }
             })

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -3094,25 +3094,11 @@ export class AddEditExpensePage implements OnInit {
                     this.saveExpenseLoader = false;
                   })
                 )
-                .subscribe({
-                  next: () => this.goBack(),
-                  error: (err) => {
-                    if (err.url.includes('reports')) {
-                      this.router.navigate(['/', 'enterprise', 'my_expenses']);
-                    }
-                  },
-                });
+                .subscribe(() => this.goBack());
             }
           } else {
             // to do edit
-            that.editExpense('SAVE_EXPENSE').subscribe({
-              next: () => this.goBack(),
-              error: (err) => {
-                if (err.url.includes('reports')) {
-                  this.router.navigate(['/', 'enterprise', 'my_expenses']);
-                }
-              },
-            });
+            that.editExpense('SAVE_EXPENSE').subscribe(() => this.goBack());
           }
         } else {
           that.fg.markAllAsTouched();

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -417,13 +417,17 @@ export class AddEditExpensePage implements OnInit {
   goBack() {
     const bankTxn =
       this.activatedRoute.snapshot.params.bankTxn && JSON.parse(this.activatedRoute.snapshot.params.bankTxn);
-    if (this.activatedRoute.snapshot.params.persist_filters) {
+    if (this.activatedRoute.snapshot.params.persist_filters || this.isRedirectedFromReport) {
       this.navController.back();
     } else {
       if (bankTxn) {
         this.router.navigate(['/', 'enterprise', 'corporate_card_expenses']);
       } else {
         this.router.navigate(['/', 'enterprise', 'my_expenses']);
+        const reportId = this.fg.value.report?.rp?.id;
+        if (reportId) {
+          this.showAddToReportSuccessToast(reportId);
+        }
       }
     }
   }
@@ -3090,23 +3094,11 @@ export class AddEditExpensePage implements OnInit {
                     this.saveExpenseLoader = false;
                   })
                 )
-                .subscribe((res: any) => {
-                  if (that.fg.value.report?.rp?.id) {
-                    this.router.navigate(['/', 'enterprise', 'my_view_report', { id: that.fg.value.report.rp.id }]);
-                  } else {
-                    that.goBack();
-                  }
-                });
+                .subscribe(() => this.goBack());
             }
           } else {
             // to do edit
-            that.editExpense('SAVE_EXPENSE').subscribe((res) => {
-              if (that.fg.value.report?.rp?.id) {
-                this.router.navigate(['/', 'enterprise', 'my_view_report', { id: that.fg.value.report.rp.id }]);
-              } else {
-                that.goBack();
-              }
-            });
+            that.editExpense('SAVE_EXPENSE').subscribe(() => this.goBack());
           }
         } else {
           that.fg.markAllAsTouched();

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -3094,11 +3094,25 @@ export class AddEditExpensePage implements OnInit {
                     this.saveExpenseLoader = false;
                   })
                 )
-                .subscribe(() => this.goBack());
+                .subscribe({
+                  next: () => this.goBack(),
+                  error: (err) => {
+                    if (err.url.includes('reports')) {
+                      this.router.navigate(['/', 'enterprise', 'my_expenses']);
+                    }
+                  },
+                });
             }
           } else {
             // to do edit
-            that.editExpense('SAVE_EXPENSE').subscribe(() => this.goBack());
+            that.editExpense('SAVE_EXPENSE').subscribe({
+              next: () => this.goBack(),
+              error: (err) => {
+                if (err.url.includes('reports')) {
+                  this.router.navigate(['/', 'enterprise', 'my_expenses']);
+                }
+              },
+            });
           }
         } else {
           that.fg.markAllAsTouched();

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -1564,10 +1564,14 @@ export class AddEditMileagePage implements OnInit {
   }
 
   close() {
-    if (this.activatedRoute.snapshot.params.persist_filters) {
+    if (this.activatedRoute.snapshot.params.persist_filters || this.isRedirectedFromReport) {
       this.navController.back();
     } else {
       this.router.navigate(['/', 'enterprise', 'my_expenses']);
+      const reportId = this.fg.value.report?.rp?.id;
+      if (reportId) {
+        this.showAddToReportSuccessToast(reportId);
+      }
     }
   }
 
@@ -1620,22 +1624,10 @@ export class AddEditMileagePage implements OnInit {
       .subscribe((invalidPaymentMode) => {
         if (that.fg.valid && !invalidPaymentMode) {
           if (that.mode === 'add') {
-            that.addExpense('SAVE_MILEAGE').subscribe((etxn) => {
-              if (that.fg.value.report?.rp?.id) {
-                this.router.navigate(['/', 'enterprise', 'my_view_report', { id: that.fg.value.report.rp.id }]);
-              } else {
-                that.close();
-              }
-            });
+            that.addExpense('SAVE_MILEAGE').subscribe(() => this.close());
           } else {
             // to do edit
-            that.editExpense('SAVE_MILEAGE').subscribe((tx) => {
-              if (that.fg.value.report?.rp?.id) {
-                this.router.navigate(['/', 'enterprise', 'my_view_report', { id: that.fg.value.report.rp.id }]);
-              } else {
-                that.close();
-              }
-            });
+            that.editExpense('SAVE_MILEAGE').subscribe(() => this.close());
           }
         } else {
           that.fg.markAllAsTouched();

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -304,10 +304,14 @@ export class AddEditPerDiemPage implements OnInit {
   }
 
   goBack() {
-    if (this.activatedRoute.snapshot.params.persist_filters) {
+    if (this.activatedRoute.snapshot.params.persist_filters || this.isRedirectedFromReport) {
       this.navController.back();
     } else {
       this.router.navigate(['/', 'enterprise', 'my_expenses']);
+      const reportId = this.fg.value.report?.rp?.id;
+      if (reportId) {
+        this.showAddToReportSuccessToast(reportId);
+      }
     }
   }
 
@@ -1923,21 +1927,9 @@ export class AddEditPerDiemPage implements OnInit {
       .subscribe((invalidPaymentMode) => {
         if (that.fg.valid && !invalidPaymentMode) {
           if (that.mode === 'add') {
-            that.addExpense('SAVE_PER_DIEM').subscribe((res: any) => {
-              if (that.fg.value.report?.rp?.id) {
-                this.router.navigate(['/', 'enterprise', 'my_view_report', { id: that.fg.value.report.rp.id }]);
-              } else {
-                that.goBack();
-              }
-            });
+            that.addExpense('SAVE_PER_DIEM').subscribe(() => this.goBack());
           } else {
-            that.editExpense('SAVE_PER_DIEM').subscribe((res) => {
-              if (that.fg.value.report?.rp?.id) {
-                this.router.navigate(['/', 'enterprise', 'my_view_report', { id: that.fg.value.report.rp.id }]);
-              } else {
-                that.goBack();
-              }
-            });
+            that.editExpense('SAVE_PER_DIEM').subscribe(() => this.goBack());
           }
         } else {
           that.fg.markAllAsTouched();

--- a/src/app/fyle/my-view-report/add-expenses-to-report/add-expenses-to-report.component.ts
+++ b/src/app/fyle/my-view-report/add-expenses-to-report/add-expenses-to-report.component.ts
@@ -95,7 +95,12 @@ export class AddExpensesToReportComponent implements OnInit {
   }
 
   addNewExpense() {
-    this.router.navigate(['/', 'enterprise', 'add_edit_expense', { rp_id: this.reportId }]);
+    this.router.navigate([
+      '/',
+      'enterprise',
+      'add_edit_expense',
+      { rp_id: this.reportId, remove_from_report: false, navigate_back: true },
+    ]);
     this.modalController.dismiss();
   }
 


### PR DESCRIPTION
Fixes:
- If user opens add/edit expense from view report page, he'll be redirected to the same page after saving expense
- If add/edit expense is opened from dashboard or expenses page, he'll be redirected to expenses page irrespective if expense is added to a report or not.