### PR TITLE
Fix personal cards bug

### DIFF
--- a/src/app/shared/components/bank-account-cards/bank-account-cards.component.ts
+++ b/src/app/shared/components/bank-account-cards/bank-account-cards.component.ts
@@ -36,8 +36,8 @@ export class BankAccountCardsComponent implements OnInit {
   }
 
   onCardChange(event) {
-    if (!this.minimal) {
-      this.changed.emit(this.linkedAccounts[event.realIndex]?.id);
+    if (!this.minimal && event.length) {
+      this.changed.emit(this.linkedAccounts[event[0].realIndex]?.id);
     }
   }
 }


### PR DESCRIPTION
Issue: In the url for fetching transactions, the card id is undefined. So the API throws 400. The event object that we’re listening to is an array while we’re expecting an object.