### PR TITLE
Code coverage: Expense fields service - Subtasks 1&2

### DIFF
--- a/src/app/core/models/v1/expense-field.model.ts
+++ b/src/app/core/models/v1/expense-field.model.ts
@@ -15,7 +15,7 @@ export interface ExpenseField {
   org_category_ids: number[];
   org_id: string;
   placeholder: string;
-  roles_editable: string[];
+  roles_editable?: string[];
   seq: number;
   type: string;
   updated_at: Date;

--- a/src/app/core/services/expense-fields.service.spec.ts
+++ b/src/app/core/services/expense-fields.service.spec.ts
@@ -1,16 +1,38 @@
 import { TestBed } from '@angular/core/testing';
+import { ApiService } from './api.service';
+import { AuthService } from './auth.service';
 
 import { ExpenseFieldsService } from './expense-fields.service';
 
-xdescribe('ExpenseFieldsService', () => {
-  let service: ExpenseFieldsService;
+describe('ExpenseFieldsService', () => {
+  let expenseFieldsService: ExpenseFieldsService;
+  let apiService: jasmine.SpyObj<ApiService>;
+  let authService: jasmine.SpyObj<AuthService>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(ExpenseFieldsService);
+    const apiServiceSpy = jasmine.createSpyObj('ApiService', ['get']);
+    const authServiceSpy = jasmine.createSpyObj('AuthService', ['getEou']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ExpenseFieldsService,
+        {
+          provide: ApiService,
+          useValue: apiServiceSpy,
+        },
+        {
+          provide: AuthService,
+          useValue: authServiceSpy,
+        },
+      ],
+    });
+
+    expenseFieldsService = TestBed.inject(ExpenseFieldsService);
+    apiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
+    authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
   });
 
   it('should be created', () => {
-    expect(service).toBeTruthy();
+    expect(expenseFieldsService).toBeTruthy();
   });
 });

--- a/src/app/core/services/expense-fields.service.ts
+++ b/src/app/core/services/expense-fields.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
-import { forkJoin, from, Observable, of } from 'rxjs';
-import { concatMap, map, reduce, switchMap } from 'rxjs/operators';
+import { from, Observable, of } from 'rxjs';
+import { map, reduce, switchMap } from 'rxjs/operators';
 import { Cacheable } from 'ts-cacheable';
 import { DefaultTxnFieldValues } from '../models/v1/default-txn-field-values.model';
 import { ExpenseField } from '../models/v1/expense-field.model';
 import { ExpenseFieldsMap } from '../models/v1/expense-fields-map.model';
+import { OrgCategory } from '../models/v1/org-category.model';
 import { ApiService } from './api.service';
 import { AuthService } from './auth.service';
 
@@ -27,15 +28,6 @@ export class ExpenseFieldsService {
         })
       )
     );
-  }
-
-  formatBillableFields(expenseFields: ExpenseField[]) {
-    return expenseFields.map((field) => {
-      if (!field.is_custom && field.field_name.toLowerCase() === 'billable') {
-        field.default_value = field.default_value === 'true';
-      }
-      return field;
-    });
   }
 
   /* getAllMap() method returns a mapping of column_names and their respective mapped fields
@@ -72,19 +64,11 @@ export class ExpenseFieldsService {
     );
   }
 
-  getUserRoles(): Observable<string[]> {
-    return from(this.authService.getRoles());
-  }
-
-  findCommonRoles(roles): Observable<string[]> {
-    return this.getUserRoles().pipe(map((userRoles) => roles.filter((role) => userRoles.indexOf(role) > -1)));
-  }
-
-  canEdit(roles): Observable<boolean> {
-    return this.findCommonRoles(roles).pipe(map((commonRoles) => commonRoles.length > 0));
-  }
-
-  filterByOrgCategoryId(tfcMap: any, fields: string[], orgCategory: any): Observable<Partial<ExpenseFieldsMap>> {
+  filterByOrgCategoryId(
+    tfcMap: Partial<ExpenseFieldsMap>,
+    fields: string[],
+    orgCategory: OrgCategory
+  ): Observable<Partial<ExpenseFieldsMap>> {
     const orgCategoryId = orgCategory && orgCategory.id;
     return of(fields).pipe(
       map((fields) =>
@@ -119,16 +103,9 @@ export class ExpenseFieldsService {
           .filter((filteredField) => !!filteredField)
       ),
       switchMap((fields) => from(fields)),
-      concatMap((field) =>
-        forkJoin({
-          canEdit: this.canEdit(field.roles_editable),
-        }).pipe(
-          map((res) => ({
-            ...field,
-            ...res,
-          }))
-        )
-      ),
+      map((field) => ({
+        ...field,
+      })),
       reduce((acc, curr) => {
         acc[curr.field] = curr;
         return acc;
@@ -136,7 +113,7 @@ export class ExpenseFieldsService {
     );
   }
 
-  getDefaultTxnFieldValues(txnFields): DefaultTxnFieldValues {
+  getDefaultTxnFieldValues(txnFields: Partial<ExpenseFieldsMap>): DefaultTxnFieldValues {
     const defaultValues = {};
     for (const configurationColumn in txnFields) {
       if (txnFields.hasOwnProperty(configurationColumn)) {
@@ -147,5 +124,14 @@ export class ExpenseFieldsService {
     }
 
     return defaultValues;
+  }
+
+  private formatBillableFields(expenseFields: ExpenseField[]): ExpenseField[] {
+    return expenseFields.map((field) => {
+      if (!field.is_custom && field.field_name.toLowerCase() === 'billable') {
+        field.default_value = field.default_value === 'true';
+      }
+      return field;
+    });
   }
 }

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -593,7 +593,6 @@
                         </div>
                         <input
                           appFormatDate
-                          [disabled]="!txnFields.from_dt?.canEdit"
                           class="add-edit-expense--date-input date-input__format smartlook-show"
                           formControlName="from_dt"
                           [name]="txnFields.from_dt?.field_name"
@@ -618,7 +617,6 @@
                         </div>
                         <input
                           appFormatDate
-                          [disabled]="!txnFields.to_dt?.canEdit"
                           class="add-edit-expense--date-input date-input__format smartlook-show"
                           formControlName="to_dt"
                           [name]="txnFields.to_dt?.field_name"
@@ -641,7 +639,6 @@
                       >
                         <app-fy-select
                           *ngIf="flightJourneyTravelClassOptions$|async as flightJourneyTravelClassOptions"
-                          [disabled]="!txnFields.flight_journey_travel_class?.canEdit"
                           [label]="txnFields.flight_journey_travel_class?.field_name"
                           [mandatory]="txnFields.flight_journey_travel_class?.is_mandatory"
                           [options]="txnFields.flight_journey_travel_class?.options"
@@ -661,7 +658,6 @@
                       >
                         <app-fy-select
                           *ngIf="flightJourneyTravelClassOptions$|async as flightJourneyTravelClassOptions"
-                          [disabled]="!txnFields.flight_return_travel_class?.canEdit"
                           [label]="txnFields.flight_return_travel_class?.field_name"
                           [mandatory]="txnFields.flight_return_travel_class?.is_mandatory"
                           [options]="txnFields.flight_journey_travel_class?.options"
@@ -692,7 +688,6 @@
                     <input
                       (blur)="focusState = false"
                       (focus)="focusState = true"
-                      [disabled]="!txnFields.train_travel_class?.canEdit"
                       [placeholder]="txnFields.train_travel_class.placeholder || 'Enter ' + txnFields.train_travel_class.field_name"
                       class="add-edit-expense--text-input add-edit-expense--text-input__large smartlook-show"
                       formControlName="train_travel_class"
@@ -702,7 +697,6 @@
 
                   <app-fy-select
                     *ngIf="txnFields.train_travel_class?.type === 'SELECT'"
-                    [disabled]="!txnFields.train_travel_class?.canEdit"
                     [label]="txnFields.train_travel_class?.field_name"
                     [mandatory]="txnFields.train_travel_class?.is_mandatory"
                     [options]="txnFields.train_travel_class?.options"
@@ -730,14 +724,12 @@
                     (focus)="focusState = true"
                     [placeholder]="txnFields.bus_travel_class?.placeholder || 'Enter ' + txnFields.bus_travel_class?.field_name"
                     *ngIf="txnFields.bus_travel_class?.type === 'TEXT'"
-                    [disabled]="!txnFields.bus_travel_class?.canEdit"
                     class="add-edit-expense--text-input add-edit-expense--text-input__large smartlook-show"
                     formControlName="bus_travel_class"
                     type="text"
                   />
                   <app-fy-select
                     *ngIf="txnFields.bus_travel_class?.type === 'SELECT'"
-                    [disabled]="!txnFields.bus_travel_class?.canEdit"
                     [label]="txnFields.bus_travel_class?.field_name"
                     [mandatory]="txnFields.bus_travel_class?.is_mandatory"
                     [options]="txnFields.bus_travel_class?.options"
@@ -802,7 +794,6 @@
             >
               <app-fy-select-vendor
                 *ngIf="!txnFields.vendor_id?.options?.length"
-                [disabled]="!txnFields?.vendor_id?.canEdit"
                 [label]="txnFields.vendor_id?.field_name"
                 [mandatory]="txnFields?.vendor_id?.is_mandatory"
                 formControlName="vendor_id"
@@ -811,7 +802,6 @@
               </app-fy-select-vendor>
               <app-virtual-select
                 *ngIf="txnFields.vendor_id?.options?.length"
-                [disabled]="!txnFields.vendor_id?.canEdit"
                 [label]="txnFields.vendor_id?.field_name"
                 [mandatory]="txnFields.vendor_id?.is_mandatory"
                 [options]="txnFields.vendor_id?.options"
@@ -869,7 +859,6 @@
                     <span class="add-edit-expense--mandatory" *ngIf="txnFields.purpose?.is_mandatory"> * </span>
                   </div>
                   <input
-                    [disabled]="!txnFields.purpose?.canEdit"
                     [placeholder]="txnFields.purpose?.placeholder || 'Enter '+txnFields.purpose?.field_name | slice: 0:30"
                     [required]="txnFields.purpose?.is_mandatory"
                     [title]="'Enter'+txnFields.purpose?.field_name"
@@ -884,7 +873,6 @@
                 >
                   <app-fy-select
                     [cacheName]="'recentPurposeList'"
-                    [disabled]="!txnFields.purpose?.canEdit"
                     [label]="txnFields.purpose?.field_name"
                     [mandatory]="txnFields.purpose?.is_mandatory"
                     [nullOption]="txnFields.purpose?.is_mandatory ? false : true"

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
@@ -137,7 +137,7 @@
                           [recentlyUsedMileageLocations]="recentlyUsedMileageLocations"
                           [formInitialized]="formInitializedFlag"
                           [txnFields]="txnFields"
-                          [isAmountDisabled]="(isAmountDisabled$|async) || (txnFields?.distance?(!txnFields?.distance?.canEdit):false)"
+                          [isAmountDisabled]="(isAmountDisabled$|async)"
                           [isDistanceMandatory]="txnFields?.distance?.is_mandatory"
                           [mileageConfig]="mileageConfig"
                           [unit]="etxn.tx.distance_unit || mileageConfig.unit"
@@ -399,7 +399,6 @@
                         <span class="add-edit-mileage--mandatory" *ngIf="txnFields.purpose?.is_mandatory"> * </span>
                       </div>
                       <input
-                        [disabled]="!txnFields.purpose?.canEdit"
                         [placeholder]="txnFields.purpose?.placeholder || 'Enter '+ txnFields.purpose?.field_name | slice: 0:30"
                         [required]="txnFields.purpose?.is_mandatory"
                         [title]="'Enter'+txnFields.purpose?.field_name"
@@ -409,7 +408,6 @@
                     </div>
                     <div *ngIf="txnFields.purpose?.type === 'SELECT'" class="add-edit-mileage--internal-block">
                       <app-fy-select
-                        [disabled]="!txnFields.purpose?.canEdit"
                         [label]="txnFields.purpose?.field_name"
                         [mandatory]="txnFields.purpose?.is_mandatory"
                         [options]="txnFields.purpose?.options"

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
@@ -162,7 +162,7 @@
                             </div>
                             <input
                               appFormatDate
-                              [disabled]="isAmountDisabled || !txnFields?.from_dt.canEdit"
+                              [disabled]="isAmountDisabled"
                               [min]="minDate"
                               class="add-edit-per-diem--date-input date-input__format smartlook-show"
                               [placeholder]="'Select ' + txnFields?.from_dt"
@@ -197,7 +197,7 @@
                             </div>
                             <input
                               appFormatDate
-                              [disabled]="isAmountDisabled || !txnFields?.to_dt.canEdit"
+                              [disabled]="isAmountDisabled"
                               [min]="minPerDiemDate"
                               class="add-edit-per-diem--date-input date-input__format smartlook-show"
                               formControlName="to_dt"
@@ -233,7 +233,7 @@
                         <app-fy-number
                           formControlName="num_days"
                           [min]="0"
-                          [disabled]="isAmountDisabled || !txnFields?.num_days.canEdit"
+                          [disabled]="isAmountDisabled"
                           [placeholder]="txnFields.num_days.placeholder || 'Enter ' + txnFields.num_days.field_name | ellipsis: 30"
                         ></app-fy-number>
                       </div>
@@ -428,7 +428,6 @@
                               >
                             </div>
                             <input
-                              [disabled]="!txnFields.purpose?.canEdit"
                               [placeholder]="txnFields.purpose.placeholder || 'Enter ' + txnFields.purpose.field_name | ellipsis: 30"
                               [required]="txnFields.purpose?.is_mandatory"
                               [title]="'Enter'+txnFields.purpose?.field_name"
@@ -439,7 +438,7 @@
                         </div>
                         <div *ngIf="txnFields?.purpose.type === 'SELECT'" class="add-edit-per-diem--internal-block">
                           <app-fy-select
-                            [disabled]="mode === 'edit' && !txnFields?.purpose.canEdit"
+                            [disabled]="mode === 'edit'"
                             [label]="txnFields?.purpose.field_name"
                             [options]="txnFields?.purpose?.options"
                             [mandatory]="txnFields?.purpose?.is_mandatory"

--- a/src/app/shared/components/route-selector/route-selector.component.html
+++ b/src/app/shared/components/route-selector/route-selector.component.html
@@ -145,12 +145,7 @@
         </ng-template>
         <div class="route-selector--mandatory" *ngIf="isDistanceMandatory">*</div>
       </div>
-      <app-fy-number
-        [disabled]="isAmountDisabled || !txnFields?.distance.canEdit"
-        [min]="0"
-        formControlName="distance"
-        placeholder="Enter Distance"
-      >
+      <app-fy-number [disabled]="isAmountDisabled" [min]="0" formControlName="distance" placeholder="Enter Distance">
       </app-fy-number>
     </div>
     <div


### PR DESCRIPTION
### Changes made
- Removed unused methods
- Added return and param types 
- Removed `roles_editable` references in expense fields service
- Cleaned up `canEdit` references across all expense forms 
- Added initial setup for unit tests of expense fields service

### Expense fields code coverage as of now
<img width="653" alt="Screenshot 2023-01-11 at 10 04 11 PM" src="https://user-images.githubusercontent.com/31147415/211874971-a500b267-f65a-4df9-af81-def94e552c64.png">
