### PR TITLE
Stop camera only if it is in RUNNING state

### DIFF
--- a/src/app/shared/components/capture-receipt/camera-preview/camera-preview.component.ts
+++ b/src/app/shared/components/capture-receipt/camera-preview/camera-preview.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, OnInit, Output, EventEmitter, OnChanges, SimpleChange
 import { CameraPreview, CameraPreviewOptions } from '@capacitor-community/camera-preview';
 import { Camera } from '@capacitor/camera';
 import { from } from 'rxjs';
-import { LoaderService } from 'src/app/core/services/loader.service';
 import { DEVICE_PLATFORM } from 'src/app/constants';
 
 enum CameraState {
@@ -82,7 +81,7 @@ export class CameraPreviewComponent implements OnInit, OnChanges {
   }
 
   startCameraPreview() {
-    if (this.cameraState !== CameraState.STARTING) {
+    if (![CameraState.STARTING, CameraState.RUNNING].includes(this.cameraState)) {
       this.cameraState = CameraState.STARTING;
       const cameraPreviewOptions: CameraPreviewOptions = {
         position: 'rear',
@@ -101,7 +100,8 @@ export class CameraPreviewComponent implements OnInit, OnChanges {
   }
 
   stopCamera() {
-    if ([CameraState.STARTING, CameraState.RUNNING].includes(this.cameraState)) {
+    //Stop camera only if it is in RUNNING state
+    if (this.cameraState === CameraState.RUNNING) {
       this.cameraState = CameraState.STOPPING;
       from(CameraPreview.stop()).subscribe((_) => (this.cameraState = CameraState.STOPPED));
     }
@@ -157,7 +157,10 @@ export class CameraPreviewComponent implements OnInit, OnChanges {
     }
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    //Component is initialized with camera in STOPPED state
+    this.cameraState = CameraState.STOPPED;
+  }
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.isBulkMode?.previousValue !== undefined) {


### PR DESCRIPTION
- When we click on gallery icon, we stop the camera before opening the imagepicker.
- So, when we click on gallery icon before the camera preview starts, we’re stopping the preview before it even started due to which the plugin throws some error and the app crashes
- Slack thread - https://fylein.slack.com/archives/CFGRGRY2X/p1676738064418799