### PR TITLE
Dependent Fields: Fix bugs in implementation

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -4364,16 +4364,22 @@ export class AddEditExpensePage implements OnInit {
       const dependentFieldValue = txCustomProperties.find(
         (customProp) => customProp.name === dependentField.field_name
       );
-      //Add dependent field with selected value
-      this.addDependentField(dependentField, parentField.value, dependentFieldValue?.value);
 
-      //Add field which is dependent on the depenent field (if present)
       if (dependentFieldValue?.value) {
+        //Add dependent field with selected value
+        this.addDependentField(dependentField, parentField.value, dependentFieldValue?.value);
+
+        //Add field which is dependent on the depenent field (if present)
         const currentField = {
           id: dependentField.id,
           value: dependentFieldValue?.value,
         };
         this.addDependentFieldWithValue(txCustomProperties, dependentFields, currentField);
+      } else {
+        //If the dependent field does not have a value, trigger the onChange event for parent field
+        //This will add a new field(if it exists) for the selected value of parent field
+        const parentDependentFieldControl = this.dependentFieldControls.at(this.dependentFieldControls.length - 1);
+        this.onDependentFieldChanged(parentDependentFieldControl.value);
       }
     }
   }

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -2692,20 +2692,19 @@ export class AddEditExpensePage implements OnInit {
     this.fg.controls.project.valueChanges
       .pipe(
         takeUntil(this.onPageExit$),
-        filter((project) => !!project),
-        distinctUntilChanged(),
         tap(() => {
-          this.isDependentFieldLoading = true;
           this.dependentFieldControls.clear();
           this.dependentFields = [];
         }),
-        switchMap((project) =>
-          this.txnFields$.pipe(
+        filter((project) => !!project),
+        switchMap((project) => {
+          this.isDependentFieldLoading = true;
+          return this.txnFields$.pipe(
             take(1),
             switchMap((txnFields) => this.getDependentField(txnFields.project_id.id, project.project_name)),
             finalize(() => (this.isDependentFieldLoading = false))
-          )
-        )
+          );
+        })
       )
       .subscribe((res) => {
         if (res?.dependentField) {

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -1540,20 +1540,19 @@ export class AddEditMileagePage implements OnInit {
     this.fg.controls.project.valueChanges
       .pipe(
         takeUntil(this.onPageExit$),
-        filter((val) => !!val),
-        distinctUntilChanged(),
         tap(() => {
-          this.isDependentFieldLoading = true;
           this.dependentFieldControls.clear();
           this.dependentFields = [];
         }),
-        switchMap((val) =>
-          this.txnFields$.pipe(
+        filter((project) => !!project),
+        switchMap((project) => {
+          this.isDependentFieldLoading = true;
+          return this.txnFields$.pipe(
             take(1),
-            switchMap((txnFields) => this.getDependentField(txnFields.project_id.id, val.project_name)),
+            switchMap((txnFields) => this.getDependentField(txnFields.project_id.id, project.project_name)),
             finalize(() => (this.isDependentFieldLoading = false))
-          )
-        )
+          );
+        })
       )
       .subscribe((res) => {
         if (res?.dependentField) {

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -2580,16 +2580,22 @@ export class AddEditMileagePage implements OnInit {
       const dependentFieldValue = txCustomProperties.find(
         (customProp) => customProp.name === dependentField.field_name
       );
-      //Add dependent field with selected value
-      this.addDependentField(dependentField, parentField.value, dependentFieldValue?.value);
 
-      //Add field which is dependent on the depenent field (if present)
       if (dependentFieldValue?.value) {
+        //Add dependent field with selected value
+        this.addDependentField(dependentField, parentField.value, dependentFieldValue?.value);
+
+        //Add field which is dependent on the depenent field (if present
         const currentField = {
           id: dependentField.id,
           value: dependentFieldValue?.value,
         };
         this.addDependentFieldWithValue(txCustomProperties, dependentFields, currentField);
+      } else {
+        //If the dependent field does not have a value, trigger the onChange event for parent field
+        //This will add a new field(if it exists) for the selected value of parent field
+        const parentDependentFieldControl = this.dependentFieldControls.at(this.dependentFieldControls.length - 1);
+        this.onDependentFieldChanged(parentDependentFieldControl.value);
       }
     }
   }

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -1498,20 +1498,19 @@ export class AddEditPerDiemPage implements OnInit {
     this.fg.controls.project.valueChanges
       .pipe(
         takeUntil(this.onPageExit$),
-        filter((val) => !!val),
-        distinctUntilChanged(),
         tap(() => {
-          this.isDependentFieldLoading = true;
           this.dependentFieldControls.clear();
           this.dependentFields = [];
         }),
-        switchMap((val) =>
-          this.txnFields$.pipe(
+        filter((project) => !!project),
+        switchMap((project) => {
+          this.isDependentFieldLoading = true;
+          return this.txnFields$.pipe(
             take(1),
-            switchMap((txnFields) => this.getDependentField(txnFields.project_id.id, val.project_name)),
+            switchMap((txnFields) => this.getDependentField(txnFields.project_id.id, project.project_name)),
             finalize(() => (this.isDependentFieldLoading = false))
-          )
-        )
+          );
+        })
       )
       .subscribe((res) => {
         if (res?.dependentField) {

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -2345,16 +2345,22 @@ export class AddEditPerDiemPage implements OnInit {
       const dependentFieldValue = txCustomProperties.find(
         (customProp) => customProp.name === dependentField.field_name
       );
-      //Add dependent field with selected value
-      this.addDependentField(dependentField, parentField.value, dependentFieldValue?.value);
 
-      //Add field which is dependent on the depenent field (if present)
       if (dependentFieldValue?.value) {
+        //Add dependent field with selected value
+        this.addDependentField(dependentField, parentField.value, dependentFieldValue?.value);
+
+        //Add field which is dependent on the depenent field (if present)
         const currentField = {
           id: dependentField.id,
           value: dependentFieldValue?.value,
         };
         this.addDependentFieldWithValue(txCustomProperties, dependentFields, currentField);
+      } else {
+        //If the dependent field does not have a value, trigger the onChange event for parent field
+        //This will add a new field(if it exists) for the selected value of parent field
+        const parentDependentFieldControl = this.dependentFieldControls.at(this.dependentFieldControls.length - 1);
+        this.onDependentFieldChanged(parentDependentFieldControl.value);
       }
     }
   }


### PR DESCRIPTION
Fixes two bugs found during testing
- When changing the project to None, the dependent fields are still visible
- When loading form in edit expense, the if there is a child dependent field, but the value selected in parent field does not have any values for the child field, the child field is still shown. 