### PR TITLE
BR: Filter all accounts for a particular payment mode

### DIFF
--- a/src/app/core/services/accounts.service.ts
+++ b/src/app/core/services/accounts.service.ts
@@ -167,15 +167,22 @@ export class AccountsService {
       }
     }
 
-    return allowedPaymentModes.map((allowedPaymentMode) => {
-      const accountForPaymentMode = allAccounts.find((account) => {
-        if (allowedPaymentMode === AccountType.COMPANY) {
-          return account.acc.type === AccountType.PERSONAL;
-        }
-        return account.acc.type === allowedPaymentMode;
-      });
-      return this.setAccountProperties(accountForPaymentMode, allowedPaymentMode, isMultipleAdvanceEnabled);
-    });
+    return allowedPaymentModes
+      .map((allowedPaymentMode) => {
+        const accountsForPaymentMode = allAccounts.filter((account) => {
+          if (allowedPaymentMode === AccountType.COMPANY) {
+            return account.acc.type === AccountType.PERSONAL;
+          }
+          return account.acc.type === allowedPaymentMode;
+        });
+
+        //There can be multiple accounts of type PERSONAL_ADVANCE_ACCOUNT
+        const accountsWithRenamedProperties = accountsForPaymentMode.map((accountForPaymentMode) =>
+          this.setAccountProperties(accountForPaymentMode, allowedPaymentMode, isMultipleAdvanceEnabled)
+        );
+        return accountsWithRenamedProperties;
+      })
+      .reduce((allowedAccounts, accountsForPaymentMode) => [...allowedAccounts, ...accountsForPaymentMode]);
   }
 
   // `Paid by Company` and `Paid by Employee` have same account id so explicitly checking for them.


### PR DESCRIPTION
BR: https://app.clickup.com/t/85zrpeepz
- The issue here was that for every allowed payment mode, we were using `array.find()` which gave us the first account matching the payment mode. 
- This works for PERONAL/COMPANY/CCC accounts, but a user can have multiple ADVANCE accounts and in that case, only the first advance account will be shown.

This change does not affect the code coverage of the service, so no changes needed in unit tests.
Tested for a few settings of payment modes lgtm 👍 