### PR TITLE
fix: Update info.plist to avoid encryption confirmation popover when deploying ios app

### DIFF
--- a/hooks/utils/ios-info.js
+++ b/hooks/utils/ios-info.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 
-module.exports.getIosInfo = () => 
-`<?xml version="1.0" encoding="UTF-8"?>
+module.exports.getIosInfo = () =>
+  `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
@@ -98,6 +98,8 @@ module.exports.getIosInfo = () =>
         <string>30</string>
       <key>IonApi</key>
         <string>https://api.ionicjs.com</string>
+      <key>ITSAppUsesNonExemptEncryption</key>
+        <string>NO</string>
   </dict>
 </plist>    
-`
+`;


### PR DESCRIPTION
Clickup - https://app.clickup.com/t/85zrrnnx9

- This bypasses the confirmation popover asking if our app uses encryption that we see everytime before releasing ios apps.
- With this, the app will be live on testflight once the appflow build process completes without the need to go to the store and add confirmation.

Apple developer ref doc - https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations
Documentation of the added key - https://developer.apple.com/documentation/bundleresources/information_property_list/itsappusesnonexemptencryption