### PR TITLE
fix: Dependent Fields: Remove project dep fields when splitting expense by project

### DIFF
--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -292,6 +292,7 @@ export class SplitExpenseService {
       transaction.org_category_id = splitExpense.org_category_id || sourceTxn.org_category_id;
       transaction.billable = this.setUpSplitExpenseBillable(sourceTxn, splitExpense);
       transaction.tax_amount = this.setUpSplitExpenseTax(sourceTxn, splitExpense);
+      transaction.custom_properties = splitExpense.custom_properties || sourceTxn.custom_properties;
 
       this.setupSplitExpensePurpose(transaction, splitGroupId, index, totalSplitExpensesCount);
 

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -215,6 +215,7 @@ export class SplitExpensePage implements OnInit {
       this.transaction?.from_dt && this.dateService.getUTCDate(new Date(this.transaction.from_dt));
     this.transaction.to_dt = this.transaction?.to_dt && this.dateService.getUTCDate(new Date(this.transaction.to_dt));
 
+    //If expense is split by projects and the selected project is same as the original expense, then add dependent fields from source expense.
     let txnCustomProperties = this.transaction.custom_properties;
     if (this.splitType === 'projects' && splitExpenseValue.project?.project_id === this.transaction.project_id) {
       txnCustomProperties = this.transaction.custom_properties.concat(this.projectDependentFields);

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -215,7 +215,6 @@ export class SplitExpensePage implements OnInit {
       this.transaction?.from_dt && this.dateService.getUTCDate(new Date(this.transaction.from_dt));
     this.transaction.to_dt = this.transaction?.to_dt && this.dateService.getUTCDate(new Date(this.transaction.to_dt));
 
-    //TODO: Check why dependent fields are not getting set for split expenses
     let txnCustomProperties = this.transaction.custom_properties;
     if (this.splitType === 'projects' && splitExpenseValue.project?.project_id === this.transaction.project_id) {
       txnCustomProperties = this.transaction.custom_properties.concat(this.projectDependentFields);

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -530,12 +530,12 @@ export class SplitExpensePage implements OnInit {
       )
     );
 
-    //TODO: Remove this nested subscribe
-    this.currencyService.getHomeCurrency().subscribe((homeCurrency) => {
-      this.isCorporateCardsEnabled$.subscribe((isCorporateCardsEnabled) => {
-        this.setValuesForCCC(currencyObj, homeCurrency, isCorporateCardsEnabled);
-      });
-    });
+    forkJoin({
+      homeCurrency: this.currencyService.getHomeCurrency(),
+      isCorporateCardsEnabled: this.isCorporateCardsEnabled$,
+    }).subscribe(({ homeCurrency, isCorporateCardsEnabled }) =>
+      this.setValuesForCCC(currencyObj, homeCurrency, isCorporateCardsEnabled)
+    );
   }
 
   setValuesForCCC(currencyObj: any, homeCurrency: any, isCorporateCardsEnabled: boolean) {


### PR DESCRIPTION
Clickup Link - https://app.clickup.com/t/85zrtbkgq

Changes:
- When expense is split by project, remove all dependent fields from custom properties
- If any of the selected project is same as the original expense project, then use the same dependent field values