### PR TITLE
fix: Report Submission Date Mismatch

### DIFF
--- a/src/app/fyle/my-view-report/my-view-report.page.html
+++ b/src/app/fyle/my-view-report/my-view-report.page.html
@@ -74,7 +74,7 @@
                       >{{erpt.rp_state === "DRAFT" ? "Created on : " : "Submitted on : " }}
                     </span>
                     <span class="view-reports--submitted-date__date"
-                      >{{erpt.rp_created_at | date: 'MMM dd, YYYY'}}</span
+                      >{{erpt.rp_submitted_at | date: 'MMM dd, YYYY'}}</span
                     >
                   </div>
                 </div>

--- a/src/app/fyle/view-team-report/view-team-report.page.html
+++ b/src/app/fyle/view-team-report/view-team-report.page.html
@@ -70,7 +70,7 @@
                   <div>
                     <span class="view-reports--submitted-date__text">Submitted on: </span>
                     <span class="view-reports--submitted-date__date"
-                      >{{erpt.rp_created_at | date: 'MMM dd, YYYY'}}</span
+                      >{{erpt.rp_submitted_at | date: 'MMM dd, YYYY'}}</span
                     >
                   </div>
                 </div>


### PR DESCRIPTION
### ClickUp: https://app.clickup.com/t/85zrzcjmc

# Fix:
1. We want to show the date on which the report was submitted, but we actually display the date the report was created on
2. I have swapped `rp_created_at` to `rp_submitted_at`, hence it should now show the correct submission date.
<img width="331" alt="report_info_header_fix_BR" src="https://github.com/fylein/fyle-mobile-app/assets/115472256/5a29f92e-364e-4d53-90e8-21257bbeb89b">
