### PR TITLE
fix: Config Service

### DIFF
--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -14,7 +14,7 @@ export class ConfigService {
   ) {}
 
   async loadConfigurationData() {
-    const clusterDomain = await this.tokenService.getClusterDomain();
+    const clusterDomain: string = await this.tokenService.getClusterDomain();
 
     if (clusterDomain) {
       // if clusterdomain is present use that

--- a/src/app/core/services/token.service.ts
+++ b/src/app/core/services/token.service.ts
@@ -51,7 +51,7 @@ export class TokenService {
     return this.secureStorageService.delete('X-REFRESH-TOKEN');
   }
 
-  getClusterDomain() {
+  getClusterDomain(): Promise<string> {
     return this.secureStorageService.get('CLUSTER-DOMAIN');
   }
 


### PR DESCRIPTION
### Description
Fix the unsafe type warning in config service

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9f973cb</samp>

*  Declare the type of `clusterDomain` as `string` to improve type safety and readability ([link](https://github.com/fylein/fyle-mobile-app/pull/2071/files?diff=unified&w=0#diff-2b4f86131905d7974b79536dcfce427357a6f220cf56c56f074f6fde1bf1a5deL17-R17))
*  Declare the return type of `getClusterDomain` as `Promise<string>` to improve type safety and readability ([link](https://github.com/fylein/fyle-mobile-app/pull/2071/files?diff=unified&w=0#diff-fd12bbdf85049fd3f3640dbd992cd604c9d6d7fd9b2f42a2336464fb555b6203L54-R54))

## Clickup
https://app.clickup.com/t/85zt699cx

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes