### PR TITLE
fix: types added for setSnackbarProperties in model.ts

### DIFF
--- a/src/app/core/models/snackbar-properties.model.ts
+++ b/src/app/core/models/snackbar-properties.model.ts
@@ -1,0 +1,9 @@
+export interface SnackbarProperties {
+  data: {
+    icon: string;
+    showCloseButton: boolean;
+    message: string;
+    redirectiontext?: string;
+  };
+  duration: number;
+}

--- a/src/app/core/services/snackbar-properties.service.ts
+++ b/src/app/core/services/snackbar-properties.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { SnackbarProperties } from '../models/snackbar-properties.model';
 
 @Injectable({
   providedIn: 'root',
@@ -16,8 +17,8 @@ export class SnackbarPropertiesService {
   setSnackbarProperties(
     toastMessageType: 'success' | 'failure' | 'information',
     toastMessageData: { message: string; redirectiontext?: string }
-  ) {
-    let snackbarIcon;
+  ): SnackbarProperties {
+    let snackbarIcon: string;
     if (toastMessageType === 'success') {
       snackbarIcon = 'tick-square-filled';
     } else if (toastMessageType === 'failure') {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a4f2fa</samp>

Added `SnackbarProperties` interface to standardize snackbar data and duration. Refactored `snackbar-properties.service.ts` to use the interface and improve type safety.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1a4f2fa</samp>

> _We are the masters of the snackbar_
> _We shape the data and duration_
> _We use the `SnackbarProperties` interface_
> _We improve the type safety and readability_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a4f2fa</samp>

*  Add `SnackbarProperties` interface to define snackbar data and duration ([link](https://github.com/fylein/fyle-mobile-app/pull/2086/files?diff=unified&w=0#diff-ce01baace8b5d1a62eaeb0a09b28e8a3d8f3d6712c6274c63f53975880cd78cfR1-R9))
*  Import `SnackbarProperties` interface in `SnackbarPropertiesService` file ([link](https://github.com/fylein/fyle-mobile-app/pull/2086/files?diff=unified&w=0#diff-f3bf34609cf2ce4c07d2ac0b1033a624dc539238056bbdc4b7d92980929ab636R2))
*  Refactor `getSnackbarProperties` method to return `SnackbarProperties` object and declare `snackbarIcon` type as `string` ([link](https://github.com/fylein/fyle-mobile-app/pull/2086/files?diff=unified&w=0#diff-f3bf34609cf2ce4c07d2ac0b1033a624dc539238056bbdc4b7d92980929ab636L19-R21))

## Clickup
https://app.clickup.com/t/85zt699qh

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes