### PR TITLE
fix: Data Transform Service

### DIFF
--- a/src/app/core/mock-data/extended-advance-request.data.ts
+++ b/src/app/core/mock-data/extended-advance-request.data.ts
@@ -297,7 +297,7 @@ export const singleErqRes: ExtendedAdvanceRequest = {
 export const singleErqUnflattened = {
   areq: {
     id: 'areqGzKF1Tne23',
-    created_at: '2023-02-23T13:16:15.260Z',
+    created_at: new Date('2023-02-23T13:16:15.260Z'),
     approved_at: null,
     purpose: 'some',
     notes: null,
@@ -311,7 +311,7 @@ export const singleErqUnflattened = {
     policy_state: 'SUCCESS',
     project_id: null,
     custom_field_values: null,
-    updated_at: '2023-02-23T14:16:52.396Z',
+    updated_at: new Date('2023-02-23T14:16:52.396Z'),
     source: 'MOBILE',
     advance_request_number: 'AR/2023/02/R/4',
     updated_by: null,

--- a/src/app/core/models/advance-requests.model.ts
+++ b/src/app/core/models/advance-requests.model.ts
@@ -14,7 +14,7 @@ export interface AdvanceRequests {
   policy_amount: number;
   policy_flag: boolean;
   policy_state: string;
-  project_id: string;
+  project_id: string | number;
   custom_field_values: CustomField[];
   updated_at: Date;
   source: string;

--- a/src/app/core/models/unflattened-advance-request.model.ts
+++ b/src/app/core/models/unflattened-advance-request.model.ts
@@ -1,0 +1,63 @@
+export interface UnflattenedAdvanceRequest {
+  areq: {
+    advance_id: string;
+    advance_request_number: string;
+    amount: number;
+    approval_state?: string[];
+    approved_at: Date;
+    approvers_ids?: string[];
+    created_at: Date;
+    currency: string;
+    custom_field_values: string;
+    id: string;
+    is_pulled_back: boolean;
+    is_sent_back: boolean;
+    last_updated_by?: string;
+    updated_by?: string;
+    notes: string;
+    org_user_id: string;
+    policy_amount: number;
+    policy_flag: boolean;
+    policy_state: string;
+    project_id: string;
+    purpose: string;
+    source: string;
+    state: string;
+    updated_at: Date;
+  };
+  ou: {
+    business_unit: string;
+    department: string;
+    department_id: string;
+    employee_id: string;
+    id: string;
+    level: string;
+    level_id?: string;
+    location: string;
+    mobile: string;
+    org_id: string;
+    org_name: string;
+    sub_department: string;
+    title: string;
+  };
+  us: {
+    full_name: string;
+    email: string;
+    name: string;
+  };
+  project: {
+    code: string;
+    name: string;
+  };
+  advance?: {
+    id: string;
+  };
+  policy: {
+    amount?: number;
+    flag: boolean;
+    state: string;
+  };
+  new?: {
+    state: string;
+  };
+}

--- a/src/app/core/services/accounts.service.ts
+++ b/src/app/core/services/accounts.service.ts
@@ -32,7 +32,7 @@ export class AccountsService {
         const accounts: ExtendedAccount[] = [];
 
         accountsRaw.forEach((accountRaw) => {
-          const account = this.dataTransformService.unflatten(accountRaw);
+          const account = this.dataTransformService.unflatten<ExtendedAccount, {}>(accountRaw);
           accounts.push(account);
         });
 

--- a/src/app/core/services/advance-request.service.ts
+++ b/src/app/core/services/advance-request.service.ts
@@ -27,6 +27,7 @@ import { ApiV2Response } from '../models/api-v2.model';
 import { StatsDimensionResponse } from '../models/stats-dimension-response.model';
 import { AdvanceRequestActions } from '../models/advance-request-actions.model';
 import { AdvanceRequestFile } from '../models/advance-request-file.model';
+import { UnflattenedAdvanceRequest } from '../models/unflattened-advance-request.model';
 
 const advanceRequestsCacheBuster$ = new Subject<void>();
 
@@ -229,7 +230,9 @@ export class AdvanceRequestService {
   getEReq(advanceRequestId: string) {
     return this.apiService.get('/eadvance_requests/' + advanceRequestId).pipe(
       map((res) => {
-        const eAdvanceRequest = this.dataTransformService.unflatten(res);
+        const eAdvanceRequest = this.dataTransformService.unflatten<UnflattenedAdvanceRequest, ExtendedAdvanceRequest>(
+          res
+        );
         this.dateService.fixDates(eAdvanceRequest.areq);
         return eAdvanceRequest;
       })

--- a/src/app/core/services/data-transform.service.ts
+++ b/src/app/core/services/data-transform.service.ts
@@ -6,7 +6,7 @@ import { Injectable } from '@angular/core';
 export class DataTransformService {
   constructor() {}
 
-  unflatten(data): any {
+  unflatten<T, K>(data: K): T {
     const res = {};
     Object.keys(data).forEach((key) => {
       const idx = key.indexOf('_');
@@ -16,11 +16,13 @@ export class DataTransformService {
         if (!res[member]) {
           res[member] = {};
         }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         res[member][strippedKey] = data[key];
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         res[key] = data[key];
       }
     });
-    return res;
+    return res as T;
   }
 }

--- a/src/app/core/services/projects.service.ts
+++ b/src/app/core/services/projects.service.ts
@@ -142,7 +142,7 @@ export class ProjectsService {
     );
   }
 
-  getbyId(projectId: number): Observable<ExtendedProject> {
+  getbyId(projectId: number | string): Observable<ExtendedProject> {
     return this.apiV2Service
       .get('/projects', {
         params: {

--- a/src/app/core/services/report.service.ts
+++ b/src/app/core/services/report.service.ts
@@ -114,7 +114,7 @@ export class ReportService {
   getERpt(rptId: string) {
     return this.apiService.get('/erpts/' + rptId).pipe(
       map((data) => {
-        const erpt = this.dataTransformService.unflatten(data);
+        const erpt = this.dataTransformService.unflatten<UnflattenedReport, ReportV1>(data);
         this.dateService.fixDates(erpt.rp);
         if (erpt && erpt.rp && erpt.rp.created_at) {
           erpt.rp.created_at = this.dateService.getLocalDate(erpt.rp.created_at);
@@ -228,7 +228,7 @@ export class ReportService {
     cacheBusterNotifier: reportsCacheBuster$,
   })
   updateReportDetails(erpt: ExtendedReport): Observable<ReportV1> {
-    const reportData = this.dataTransformService.unflatten(erpt);
+    const reportData = this.dataTransformService.unflatten<UnflattenedReport, ExtendedReport>(erpt);
     return this.apiService
       .post('/reports', reportData.rp)
       .pipe(switchMap((res) => this.clearTransactionCache().pipe(map(() => res))));

--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -214,7 +214,7 @@ export class SplitExpenseService {
       const platformExpensesList = [];
       etxns.forEach((etxn) => {
         // transformTo method requires unflattend transaction object
-        const platformExpense = this.dataTransformService.unflatten(etxn).tx;
+        const platformExpense = this.dataTransformService.unflatten<{ tx: PublicPolicyExpense }, Expense>(etxn).tx;
         platformExpense.num_files = fileObjs ? fileObjs.length : 0;
 
         // Since expense has already been created in split expense flow, taking user_amount here.

--- a/src/app/core/services/transaction.service.ts
+++ b/src/app/core/services/transaction.service.ts
@@ -425,7 +425,7 @@ export class TransactionService {
   getETxnUnflattened(txnId: string): Observable<UnflattenedTransaction> {
     return this.apiService.get('/etxns/' + txnId).pipe(
       map((data) => {
-        const etxn = this.dataTransformService.unflatten(data);
+        const etxn = this.dataTransformService.unflatten<UnflattenedTransaction, Transaction>(data);
         this.dateService.fixDates(etxn.tx);
 
         // Adding a field categoryDisplayName in transaction object to save funciton calls


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4622218</samp>

This pull request improves the type safety and consistency of the code that handles advance requests, reports, accounts, projects, expenses, and transactions. It does this by using generic types and interfaces with the `unflatten` method of the `data-transform.service.ts` file, and by aligning the types of the mock data, models, and service methods.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4622218</samp>

> _To handle different data shapes_
> _The `unflatten` method escapes_
> _The implicit any_
> _With generics so handy_
> _And returns the right types without scrapes_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4622218</samp>

*  Added `UnflattenedAdvanceRequest` interface to define the shape of advance request objects after unflattening ([link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-16ec086965a67a56eb551e02f11f8ca0eeea781849a9dc05f48d4c9c6e9eb00aR1-R63))
*  Changed `project_id` property of `AdvanceRequests` interface to accept string or number ([link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-c726e7886d9052b1d5bb06ed9e3630a67ae071609079137e3f998cf8f1066118L17-R17))
*  Changed `created_at` and `updated_at` properties of `areq` object in mock data to Date objects ([link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-5523a698b796df7860831812b5e4121666f847e9e39be66fa11c5d5dbfe1e577L300-R300), [link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-5523a698b796df7860831812b5e4121666f847e9e39be66fa11c5d5dbfe1e577L314-R314))
  - account objects in `AccountsService` ([link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-acb4f2d0105052014c5b8746f35020b2ecf00198ec7b1d278c6f172704ac62e1L35-R35))
  - advance request objects in `AdvanceRequestService` ([link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-cf10916e744e2583231b76613fcf05233b8c1268d7770d8b9160de84b17c02c6R30), [link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-cf10916e744e2583231b76613fcf05233b8c1268d7770d8b9160de84b17c02c6L232-R235))
  - report objects in `ReportService` ([link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-12dc98777c493c39a3e7aec29b439cc7863ddfb002bf1e52052c8aee485c63c9L117-R117), [link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-12dc98777c493c39a3e7aec29b439cc7863ddfb002bf1e52052c8aee485c63c9L231-R231))
  - expense objects in `SplitExpenseService` ([link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-bab29bd73c5e5f43534ff8d9b9bc4a680f26d582c82c182ec8cc0b0586aacfd4L217-R217))
  - transaction objects in `TransactionService` ([link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-712edde8a2bf233766bbc21a32a8166358eca7a00851e1a25af976cff8b780b5L428-R428))
*  Modified `unflatten` method of data transform service to accept generic type parameters and return result as expected output type ([link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-dbe187a936044625ae3d4524e95c6e902af2697f34b0d9e4e14c833362a6a220L9-R9), [link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-dbe187a936044625ae3d4524e95c6e902af2697f34b0d9e4e14c833362a6a220L19-R26))
*  Modified `getbyId` method of `ProjectsService` to accept `projectId` parameter of type string or number ([link](https://github.com/fylein/fyle-mobile-app/pull/2088/files?diff=unified&w=0#diff-e792da4f87c1f0363cc743e99c96daed35d1480c037f0f893f9529090a40a5ddL145-R145))

## Clickup
(https://app.clickup.com/t/85zt699e5)

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes