### PR TITLE
fix: Advance Request Policy Service

### DIFF
--- a/src/app/core/mock-data/advance-requests.data.ts
+++ b/src/app/core/mock-data/advance-requests.data.ts
@@ -1,6 +1,6 @@
 import { AdvanceRequests } from '../models/advance-requests.model';
 
-export const advancedRequests: AdvanceRequests = {
+export const advanceRequests: AdvanceRequests = {
   id: 'areqMP09oaYXBf',
   created_at: new Date('2023-02-23T16:24:01.335Z'),
   approved_at: null,
@@ -76,7 +76,7 @@ export const advancedRequests: AdvanceRequests = {
 };
 
 export const pullBackAdvancedRequests: AdvanceRequests = {
-  ...advancedRequests,
+  ...advanceRequests,
   is_pulled_back: true,
 };
 
@@ -105,7 +105,7 @@ export const expectedSingleErq = {
 };
 
 export const advancedRequests2: AdvanceRequests = {
-  ...advancedRequests,
+  ...advanceRequests,
   id: 'areq99bN9mZgu1',
 };
 

--- a/src/app/core/services/advance-request-policy.service.spec.ts
+++ b/src/app/core/services/advance-request-policy.service.spec.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { AdvanceRequestPolicyService } from './advance-request-policy.service';
 import { of } from 'rxjs';
 import { checkPolicyWithRulesData } from '../mock-data/policy-violation-check.data';
-import { advancedRequests } from '../mock-data/advance-requests.data';
+import { advanceRequests } from '../mock-data/advance-requests.data';
 
 describe('AdvanceRequestPolicyService', () => {
   const rootUrl = 'https://staging.fyle.tech';
@@ -48,11 +48,11 @@ describe('AdvanceRequestPolicyService', () => {
     };
     httpClient.post.and.returnValue(of(apiResponse));
 
-    advanceRequestPolicyService.servicePost('/policy_check', advancedRequests).subscribe((res) => {
+    advanceRequestPolicyService.servicePost('/policy_check', advanceRequests).subscribe((res) => {
       expect(res).toEqual(apiResponse);
       expect(httpClient.post).toHaveBeenCalledOnceWith(
         'https://staging.fyle.tech/policy/advance_requests/policy_check',
-        advancedRequests
+        advanceRequests
       );
       done();
     });

--- a/src/app/core/services/advance-request-policy.service.spec.ts
+++ b/src/app/core/services/advance-request-policy.service.spec.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { AdvanceRequestPolicyService } from './advance-request-policy.service';
 import { of } from 'rxjs';
 import { checkPolicyWithRulesData } from '../mock-data/policy-violation-check.data';
+import { advancedRequests } from '../mock-data/advance-requests.data';
 
 describe('AdvanceRequestPolicyService', () => {
   const rootUrl = 'https://staging.fyle.tech';
@@ -51,7 +52,7 @@ describe('AdvanceRequestPolicyService', () => {
     };
     httpClient.post.and.returnValue(of(apiResponse));
 
-    advanceRequestPolicyService.servicePost('/policy_check', requestObj, {}).subscribe((res) => {
+    advanceRequestPolicyService.servicePost('/policy_check', advancedRequests).subscribe((res) => {
       expect(res).toEqual(apiResponse);
       expect(httpClient.post).toHaveBeenCalledOnceWith(
         'https://staging.fyle.tech/policy/advance_requests/policy_check',

--- a/src/app/core/services/advance-request-policy.service.spec.ts
+++ b/src/app/core/services/advance-request-policy.service.spec.ts
@@ -43,10 +43,6 @@ describe('AdvanceRequestPolicyService', () => {
   });
 
   it('servicePost(): should make POST request', (done) => {
-    const requestObj = {
-      someKey: 'someValue',
-    };
-
     const apiResponse = {
       message: 'SUCCESS',
     };
@@ -56,7 +52,7 @@ describe('AdvanceRequestPolicyService', () => {
       expect(res).toEqual(apiResponse);
       expect(httpClient.post).toHaveBeenCalledOnceWith(
         'https://staging.fyle.tech/policy/advance_requests/policy_check',
-        requestObj
+        advancedRequests
       );
       done();
     });

--- a/src/app/core/services/advance-request-policy.service.ts
+++ b/src/app/core/services/advance-request-policy.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { PolicyViolationCheck } from '../models/policy-violation-check.model';
+import { AdvanceRequests } from '../models/advance-requests.model';
 
 @Injectable({
   providedIn: 'root',
@@ -23,7 +24,7 @@ export class AdvanceRequestPolicyService {
       .map((desiredState) => desiredState.description);
   }
 
-  servicePost(url, data, config) {
+  servicePost(url: string, data: AdvanceRequests) {
     return this.httpClient.post(this.ROOT_ENDPOINT + '/policy/advance_requests' + url, data);
   }
 }

--- a/src/app/core/services/advance-request-policy.service.ts
+++ b/src/app/core/services/advance-request-policy.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { PolicyViolationCheck } from '../models/policy-violation-check.model';
 import { AdvanceRequests } from '../models/advance-requests.model';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -18,7 +19,7 @@ export class AdvanceRequestPolicyService {
     this.ROOT_ENDPOINT = rootUrl;
   }
 
-  getPolicyRules(result: PolicyViolationCheck) {
+  getPolicyRules(result: PolicyViolationCheck): string[] {
     return result.advance_request_policy_rule_desired_states
       .filter((desiredState) => desiredState.popup === true)
       .map((desiredState) => desiredState.description);

--- a/src/app/core/services/advance-request.service.spec.ts
+++ b/src/app/core/services/advance-request.service.spec.ts
@@ -557,8 +557,7 @@ describe('AdvanceRequestService', () => {
       );
       expect(advanceRequestPolicyService.servicePost).toHaveBeenCalledOnceWith(
         '/policy_check/test',
-        checkPolicyAdvReqParam,
-        { timeout: 5000 }
+        checkPolicyAdvReqParam
       );
       done();
     });

--- a/src/app/core/services/advance-request.service.spec.ts
+++ b/src/app/core/services/advance-request.service.spec.ts
@@ -33,7 +33,7 @@ import { apiAdvanceRequestAction } from '../mock-data/advance-request-actions.da
 import { apiEouRes } from '../mock-data/extended-org-user.data';
 import { apiAdvanceReqRes } from '../mock-data/stats-dimension-response.data';
 import {
-  advancedRequests,
+  advanceRequests,
   advancedRequests2,
   checkPolicyAdvReqParam,
   draftAdvancedRequestParam,
@@ -289,11 +289,11 @@ describe('AdvanceRequestService', () => {
   });
 
   it('submit(): should submit an advance request', (done) => {
-    apiService.post.and.returnValue(of(advancedRequests));
+    apiService.post.and.returnValue(of(advanceRequests));
 
-    advanceRequestService.submit(advancedRequests).subscribe((res) => {
-      expect(res).toEqual(advancedRequests);
-      expect(apiService.post).toHaveBeenCalledOnceWith('/advance_requests/submit', advancedRequests);
+    advanceRequestService.submit(advanceRequests).subscribe((res) => {
+      expect(res).toEqual(advanceRequests);
+      expect(apiService.post).toHaveBeenCalledOnceWith('/advance_requests/submit', advanceRequests);
       done();
     });
   });
@@ -393,11 +393,11 @@ describe('AdvanceRequestService', () => {
   });
 
   it('delete(): should delete an advance request', (done) => {
-    apiService.delete.and.returnValue(of(advancedRequests));
+    apiService.delete.and.returnValue(of(advanceRequests));
 
-    advanceRequestService.delete(advancedRequests.id).subscribe((res) => {
-      expect(res).toEqual(advancedRequests);
-      expect(apiService.delete).toHaveBeenCalledOnceWith(`/advance_requests/${advancedRequests.id}`);
+    advanceRequestService.delete(advanceRequests.id).subscribe((res) => {
+      expect(res).toEqual(advanceRequests);
+      expect(apiService.delete).toHaveBeenCalledOnceWith(`/advance_requests/${advanceRequests.id}`);
       done();
     });
   });
@@ -437,22 +437,22 @@ describe('AdvanceRequestService', () => {
   describe('createAdvReqWithFilesAndSubmit():', () => {
     it('should create advanced request and submit it with the file', (done) => {
       fileService.post.and.returnValue(of(fileObjectData3));
-      spyOn(advanceRequestService, 'submit').and.returnValue(of(advancedRequests));
+      spyOn(advanceRequestService, 'submit').and.returnValue(of(advanceRequests));
 
-      advanceRequestService.createAdvReqWithFilesAndSubmit(advancedRequests, of(fileData1)).subscribe((res) => {
+      advanceRequestService.createAdvReqWithFilesAndSubmit(advanceRequests, of(fileData1)).subscribe((res) => {
         expect(res).toEqual(advRequestFile);
-        expect(advanceRequestService.submit).toHaveBeenCalledOnceWith(advancedRequests);
+        expect(advanceRequestService.submit).toHaveBeenCalledOnceWith(advanceRequests);
         expect(fileService.post).toHaveBeenCalledOnceWith(fileData1[0]);
         done();
       });
     });
 
     it('should create advanced request and submit it without the file', (done) => {
-      spyOn(advanceRequestService, 'submit').and.returnValue(of(advancedRequests));
+      spyOn(advanceRequestService, 'submit').and.returnValue(of(advanceRequests));
 
-      advanceRequestService.createAdvReqWithFilesAndSubmit(advancedRequests, of(null)).subscribe((res) => {
+      advanceRequestService.createAdvReqWithFilesAndSubmit(advanceRequests, of(null)).subscribe((res) => {
         expect(res).toEqual({ ...advRequestFile, files: null });
-        expect(advanceRequestService.submit).toHaveBeenCalledOnceWith(advancedRequests);
+        expect(advanceRequestService.submit).toHaveBeenCalledOnceWith(advanceRequests);
         done();
       });
     });

--- a/src/app/core/services/advance-request.service.ts
+++ b/src/app/core/services/advance-request.service.ts
@@ -245,7 +245,7 @@ export class AdvanceRequestService {
             orgUserSettings.locale.offset
           );
         }
-        return this.advanceRequestPolicyService.servicePost('/policy_check/test', advanceRequest, { timeout: 5000 });
+        return this.advanceRequestPolicyService.servicePost('/policy_check/test', advanceRequest);
       })
     );
   }

--- a/src/app/fyle/my-advances/my-advances-card/my-advances-card.component.spec.ts
+++ b/src/app/fyle/my-advances/my-advances-card/my-advances-card.component.spec.ts
@@ -9,7 +9,7 @@ import { HumanizeCurrencyPipe } from 'src/app/shared/pipes/humanize-currency.pip
 import { MyAdvancesCardComponent } from './my-advances-card.component';
 import * as dayjs from 'dayjs';
 import { click, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
-import { advancedRequests } from 'src/app/core/mock-data/advance-requests.data';
+import { advanceRequests } from 'src/app/core/mock-data/advance-requests.data';
 
 describe('MyAdvancesCardComponent', () => {
   let component: MyAdvancesCardComponent;
@@ -44,7 +44,7 @@ describe('MyAdvancesCardComponent', () => {
 
   it('change show date if previous date is provided', () => {
     component.prevDate = new Date('2023-01-16T06:22:47.058Z');
-    component.advanceRequest = advancedRequests;
+    component.advanceRequest = advanceRequests;
     fixture.detectChanges();
 
     component.ngOnInit();
@@ -53,7 +53,7 @@ describe('MyAdvancesCardComponent', () => {
   });
 
   it('should check if advance request information is displayed', () => {
-    component.advanceRequest = advancedRequests;
+    component.advanceRequest = advanceRequests;
     fixture.detectChanges();
     expect(getTextContent(getElementBySelector(fixture, '.advance-card--date'))).toEqual('Feb 23, 2023');
     expect(getTextContent(getElementBySelector(fixture, '.advance-card--purpose'))).toEqual('some');


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f47719f</samp>

This pull request refactors and updates the services and tests related to advance requests. It improves the code quality, readability, and type safety by using mock data, proper type annotations, and removing unnecessary arguments.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f47719f</samp>

> _Oh we're the coders of the sea, and we work with skill and glee_
> _We refactor and we type, to make our code more clean and tight_
> _We don't need `config` here, we've changed the `servicePost` signature_
> _So heave away, me hearties, heave away on the count of three_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f47719f</samp>

*  Import `AdvanceRequests` model and `Observable` type to use proper type annotations and observables in advance request policy service ([link](https://github.com/fylein/fyle-mobile-app/pull/2091/files?diff=unified&w=0#diff-3f02057f78b88003ed997044de7be911f805d3790305dd70f3df6c9fc0afd438R5-R6))
* Add return type of `string[]` to `getPolicyRules` method to make it more explicit and help type inference ([link](https://github.com/fylein/fyle-mobile-app/pull/2091/files?diff=unified&w=0#diff-3f02057f78b88003ed997044de7be911f805d3790305dd70f3df6c9fc0afd438L20-R22))
* Add parameter types of `string` and `AdvanceRequests` to `servicePost` method to make it more explicit and help type checking ([link](https://github.com/fylein/fyle-mobile-app/pull/2091/files?diff=unified&w=0#diff-3f02057f78b88003ed997044de7be911f805d3790305dd70f3df6c9fc0afd438L26-R28))
* Remove `config` parameter from `servicePost` method in advance request service and its tests to reflect the change in the method signature and avoid passing an unnecessary argument ([link](https://github.com/fylein/fyle-mobile-app/pull/2091/files?diff=unified&w=0#diff-8d6422f127ab8eee223ac016882b0f2f72be9abcb9c82f9df7a316c83ad8ba95L560-R560), [link](https://github.com/fylein/fyle-mobile-app/pull/2091/files?diff=unified&w=0#diff-cf10916e744e2583231b76613fcf05233b8c1268d7770d8b9160de84b17c02c6L248-R248))
* Import mock data for advance requests from another file to avoid repetition and improve readability and maintainability of tests in advance request policy service ([link](https://github.com/fylein/fyle-mobile-app/pull/2091/files?diff=unified&w=0#diff-1a25886f100a190d434deda7071625773278f58f688c7525ebf39fea50ad84abR6))
* Replace `requestObj` parameter with `advancedRequests` mock data in `servicePost` method call in advance request policy service test to make it more consistent with the actual data type and structure ([link](https://github.com/fylein/fyle-mobile-app/pull/2091/files?diff=unified&w=0#diff-1a25886f100a190d434deda7071625773278f58f688c7525ebf39fea50ad84abL54-R55))

## Clickup

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes