### PR TITLE
fix: Advance Request Service

### DIFF
--- a/src/app/core/services/advance-request.service.ts
+++ b/src/app/core/services/advance-request.service.ts
@@ -40,7 +40,8 @@ type Filters = Partial<{
 type Config = Partial<{
   offset: number;
   limit: number;
-  queryParams: any;
+  queryParams: Record<string, string | string[]>;
+  areq_org_user_id?: string;
   filter: Filters;
 }>;
 
@@ -79,7 +80,7 @@ export class AdvanceRequestService {
   ): Observable<ApiV2Response<ExtendedAdvanceRequest>> {
     return from(this.authService.getEou()).pipe(
       switchMap((eou) =>
-        this.apiv2Service.get('/advance_requests', {
+        this.apiv2Service.get<ExtendedAdvanceRequest, { params: Config }>('/advance_requests', {
           params: {
             offset: config.offset,
             limit: config.limit,
@@ -289,7 +290,7 @@ export class AdvanceRequestService {
   modifyAdvanceRequestCustomFields(customFields: CustomField[]): CustomField[] {
     customFields = customFields.map((customField) => {
       if (customField.type === 'DATE' && customField.value) {
-        customField.value = new Date(customField.value);
+        customField.value = new Date(customField.value as string);
       }
       return customField;
     });


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4adc98d</samp>

Improved type safety and filtering for advance request service. The file `src/app/core/services/advance-request.service.ts` now uses more precise and generic types for the query, response, and custom fields, and allows filtering by org id.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4adc98d</samp>

> _`advance request` service_
> _more types, more clarity_
> _autumn of refactor_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4adc98d</samp>

*  Refine the type of `queryParams` and add `areq_org_user_id` as an optional parameter to filter advance requests by user's org id ([link](https://github.com/fylein/fyle-mobile-app/pull/2095/files?diff=unified&w=0#diff-cf10916e744e2583231b76613fcf05233b8c1268d7770d8b9160de84b17c02c6L43-R44))
*  Use generic types for the response data and the request options of the `apiv2Service.get` method, and set them to `ExtendedAdvanceRequest` and `{ params: Config }` respectively ([link](https://github.com/fylein/fyle-mobile-app/pull/2095/files?diff=unified&w=0#diff-cf10916e744e2583231b76613fcf05233b8c1268d7770d8b9160de84b17c02c6L82-R83))
*  Cast `customField.value` to `string` before passing it to the `Date` constructor, to avoid a type error when the value is a number ([link](https://github.com/fylein/fyle-mobile-app/pull/2095/files?diff=unified&w=0#diff-cf10916e744e2583231b76613fcf05233b8c1268d7770d8b9160de84b17c02c6L292-R293))

## Clickup
https://app.clickup.com/t/85zt699bv

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes