### PR TITLE
fix: Account Service Types

### DIFF
--- a/src/app/core/models/flattened-account.model.ts
+++ b/src/app/core/models/flattened-account.model.ts
@@ -1,0 +1,25 @@
+export interface FlattenedAccount {
+  acc_id: string;
+  acc_created_at: string;
+  acc_updated_at: string;
+  acc_name: string;
+  acc_type: string;
+  acc_currency: string;
+  acc_target_balance_amount: number;
+  acc_current_balance_amount: number;
+  acc_tentative_balance_amount: number;
+  acc_category: string;
+  ou_id: string;
+  ou_org_id: string;
+  us_email: string;
+  us_full_name: string;
+  org_id: string;
+  org_domain: string;
+  advance_purpose: string;
+  advance_number: number;
+  orig_currency: string;
+  currency: string;
+  orig_amount: number;
+  amount: number;
+  advance_id: string;
+}

--- a/src/app/core/services/accounts.service.ts
+++ b/src/app/core/services/accounts.service.ts
@@ -32,7 +32,7 @@ export class AccountsService {
         const accounts: ExtendedAccount[] = [];
 
         accountsRaw.forEach((accountRaw) => {
-          const account = this.dataTransformService.unflatten(accountRaw) as ExtendedAccount;
+          const account = this.dataTransformService.unflatten<ExtendedAccount, {}>(accountRaw);
           accounts.push(account);
         });
 
@@ -95,7 +95,7 @@ export class AccountsService {
     paymentMode: string,
     isMultipleAdvanceEnabled: boolean
   ): ExtendedAccount {
-    const accountDisplayNameMapping = {
+    const accountDisplayNameMapping: Record<string, string> = {
       PERSONAL_ACCOUNT: 'Personal Card/Cash',
       COMPANY_ACCOUNT: 'Paid by Company',
       PERSONAL_CORPORATE_CREDIT_CARD_ACCOUNT: 'Corporate Card',
@@ -106,7 +106,7 @@ export class AccountsService {
       accountCopy.acc.displayName =
         paymentMode === AccountType.ADVANCE
           ? this.getAdvanceAccountDisplayName(accountCopy, isMultipleAdvanceEnabled)
-          : (accountDisplayNameMapping[paymentMode] as string);
+          : accountDisplayNameMapping[paymentMode];
       accountCopy.acc.isReimbursable = paymentMode === AccountType.PERSONAL;
     }
 

--- a/src/app/core/services/accounts.service.ts
+++ b/src/app/core/services/accounts.service.ts
@@ -12,7 +12,7 @@ import { ExpenseType } from '../enums/expense-type.enum';
 import { Observable } from 'rxjs';
 import { UnflattenedTransaction } from '../models/unflattened-transaction.model';
 import { OrgSettings } from '../models/org-settings.model';
-import { DateService } from './date.service';
+import { FlattenedAccount } from '../models/flattened-account.model';
 
 @Injectable({
   providedIn: 'root',
@@ -21,18 +21,17 @@ export class AccountsService {
   constructor(
     private apiService: ApiService,
     private dataTransformService: DataTransformService,
-    private fyCurrencyPipe: FyCurrencyPipe,
-    private dateService: DateService
+    private fyCurrencyPipe: FyCurrencyPipe
   ) {}
 
   @Cacheable()
   getEMyAccounts(): Observable<ExtendedAccount[]> {
-    return this.apiService.get<ExtendedAccount[]>('/eaccounts/').pipe(
-      map((accountsRaw: ExtendedAccount[]) => {
+    return this.apiService.get<FlattenedAccount[]>('/eaccounts/').pipe(
+      map((accountsRaw: FlattenedAccount[]) => {
         const accounts: ExtendedAccount[] = [];
 
         accountsRaw.forEach((accountRaw) => {
-          const account = this.dataTransformService.unflatten<ExtendedAccount, {}>(accountRaw);
+          const account = this.dataTransformService.unflatten<ExtendedAccount, FlattenedAccount>(accountRaw);
           accounts.push(account);
         });
 

--- a/src/app/core/services/accounts.service.ts
+++ b/src/app/core/services/accounts.service.ts
@@ -27,12 +27,12 @@ export class AccountsService {
 
   @Cacheable()
   getEMyAccounts(): Observable<ExtendedAccount[]> {
-    return this.apiService.get('/eaccounts/').pipe(
+    return this.apiService.get<ExtendedAccount[]>('/eaccounts/').pipe(
       map((accountsRaw: ExtendedAccount[]) => {
         const accounts: ExtendedAccount[] = [];
 
         accountsRaw.forEach((accountRaw) => {
-          const account = this.dataTransformService.unflatten<ExtendedAccount, {}>(accountRaw);
+          const account = this.dataTransformService.unflatten(accountRaw) as ExtendedAccount;
           accounts.push(account);
         });
 
@@ -106,7 +106,7 @@ export class AccountsService {
       accountCopy.acc.displayName =
         paymentMode === AccountType.ADVANCE
           ? this.getAdvanceAccountDisplayName(accountCopy, isMultipleAdvanceEnabled)
-          : accountDisplayNameMapping[paymentMode];
+          : (accountDisplayNameMapping[paymentMode] as string);
       accountCopy.acc.isReimbursable = paymentMode === AccountType.PERSONAL;
     }
 


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64e872d</samp>

This file improves the type safety and readability of the accounts service code. It uses generic types for the `apiService` and `dataTransformService` methods, and a more specific type for the `accountDisplayNameMapping` object.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 64e872d</samp>

> _Sing, O Muse, of the skillful coder who enhanced_
> _The type safety and readability of the accounts service,_
> _Using generic types, like a cunning craftsman, to shape_
> _The `apiService` and `dataTransformService` methods._

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 64e872d</samp>

*  Update `apiService.get` and `dataTransformService.unflatten` to use generic types for better type safety and readability ([link](https://github.com/fylein/fyle-mobile-app/pull/2098/files?diff=unified&w=0#diff-acb4f2d0105052014c5b8746f35020b2ecf00198ec7b1d278c6f172704ac62e1L30-R35))
*  Add `as ExtendedAccount` assertion to `accountCopy.acc` to match the type of `accounts` array ([link](https://github.com/fylein/fyle-mobile-app/pull/2098/files?diff=unified&w=0#diff-acb4f2d0105052014c5b8746f35020b2ecf00198ec7b1d278c6f172704ac62e1L30-R35))
*  Refine the type of `accountDisplayNameMapping` object to use `AccountType` as the key instead of `string` ([link](https://github.com/fylein/fyle-mobile-app/pull/2098/files?diff=unified&w=0#diff-acb4f2d0105052014c5b8746f35020b2ecf00198ec7b1d278c6f172704ac62e1L109-R109))
*  Add `as string` assertion to `accountCopy.acc.displayName` to match the type of `accountDisplayNameMapping` values ([link](https://github.com/fylein/fyle-mobile-app/pull/2098/files?diff=unified&w=0#diff-acb4f2d0105052014c5b8746f35020b2ecf00198ec7b1d278c6f172704ac62e1L109-R109))

## Clickup
https://app.clickup.com/t/85zt699bh

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes