### PR TITLE
fix: Split Expense Service

### DIFF
--- a/src/app/core/models/expense.model.ts
+++ b/src/app/core/models/expense.model.ts
@@ -52,7 +52,7 @@ export interface Expense {
   tx_cost_center_name?: any;
   tx_created_at: Date;
   tx_creator_id: string;
-  tx_currency?: any;
+  tx_currency?: string;
   tx_custom_attributes?: any;
   tx_custom_properties?: any;
   tx_decimal_column1?: any;
@@ -104,8 +104,8 @@ export interface Expense {
   tx_org_category_code?: any;
   tx_org_category_id: number;
   tx_org_user_id: string;
-  tx_orig_amount?: any;
-  tx_orig_currency?: any;
+  tx_orig_amount?: number;
+  tx_orig_currency?: string;
   tx_payment_id?: any;
   tx_per_diem_rate_id?: any;
   tx_physical_bill: boolean;

--- a/src/app/core/models/file-obj.model.ts
+++ b/src/app/core/models/file-obj.model.ts
@@ -7,7 +7,8 @@ export interface FileObject {
   transaction_id?: string;
   invoice_id?: any;
   advance_request_id?: any;
-  purpose: string;
+  purpose?: string;
+  content?: string;
   password?: any;
   receipt_coordinates?: any;
   email_meta_data?: any;

--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -56,8 +56,8 @@ export class SplitExpenseService {
     return forkJoin(observables);
   }
 
-  getBase64Content(fileObjs: FileObject[]) {
-    const fileObservables = [];
+  getBase64Content(fileObjs: FileObject[]): Observable<FileObject[]> {
+    const fileObservables: Observable<{ content: string }>[] = [];
     const newFileObjs: FileObject[] = fileObjs.map((fileObj) => ({
       id: fileObj.id,
       name: fileObj.name,
@@ -69,7 +69,7 @@ export class SplitExpenseService {
     });
 
     return forkJoin(fileObservables).pipe(
-      map((data: FileObject[]) => {
+      map((data) => {
         newFileObjs.forEach((fileObj: FileObject, index) => {
           fileObj.content = data[index].content;
         });
@@ -228,7 +228,11 @@ export class SplitExpenseService {
     }
   }
 
-  createSplitTxns(sourceTxn: Transaction, totalSplitAmount: number, splitExpenses: Transaction[]) {
+  createSplitTxns(
+    sourceTxn: Transaction,
+    totalSplitAmount: number,
+    splitExpenses: Transaction[]
+  ): Observable<Transaction[]> {
     let splitGroupAmount = sourceTxn.split_group_user_amount || sourceTxn.amount;
     let splitGroupId = sourceTxn.split_group_id || sourceTxn.id;
 
@@ -295,7 +299,7 @@ export class SplitExpenseService {
     splitGroupId: string,
     index: number,
     totalSplitExpensesCount: number
-  ) {
+  ): void {
     if (transaction.purpose) {
       let splitIndex = 1;
 
@@ -308,11 +312,11 @@ export class SplitExpenseService {
     }
   }
 
-  private setUpSplitExpenseBillable(sourceTxn: Transaction, splitExpense: Transaction) {
+  private setUpSplitExpenseBillable(sourceTxn: Transaction, splitExpense: Transaction): boolean {
     return splitExpense.project_id ? splitExpense.billable : sourceTxn.billable;
   }
 
-  private setUpSplitExpenseTax(sourceTxn: Transaction, splitExpense: Transaction) {
+  private setUpSplitExpenseTax(sourceTxn: Transaction, splitExpense: Transaction): number {
     return splitExpense.tax_amount ? splitExpense.tax_amount : sourceTxn.tax_amount;
   }
 }

--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -58,7 +58,7 @@ export class SplitExpenseService {
 
   getBase64Content(fileObjs: FileObject[]) {
     const fileObservables = [];
-    const newFileObjs: any[] = fileObjs.map((fileObj) => ({
+    const newFileObjs: FileObject[] = fileObjs.map((fileObj) => ({
       id: fileObj.id,
       name: fileObj.name,
       content: '',
@@ -69,8 +69,8 @@ export class SplitExpenseService {
     });
 
     return forkJoin(fileObservables).pipe(
-      map((data: any[]) => {
-        newFileObjs.forEach((fileObj, index) => {
+      map((data: FileObject[]) => {
+        newFileObjs.forEach((fileObj: FileObject, index) => {
           fileObj.content = data[index].content;
         });
 
@@ -121,7 +121,7 @@ export class SplitExpenseService {
     });
 
     return from(payloadData).pipe(
-      concatMap((payload) => this.postComment(payload)),
+      concatMap((payload: PolicyViolationComment) => this.postComment(payload)),
       toArray()
     );
   }
@@ -211,7 +211,7 @@ export class SplitExpenseService {
 
   runPolicyCheck(etxns: Expense[], fileObjs: FileObject[]): Observable<PolicyViolationTxn> {
     if (etxns?.length > 0) {
-      const platformExpensesList = [];
+      const platformExpensesList: PublicPolicyExpense[] = [];
       etxns.forEach((etxn) => {
         // transformTo method requires unflattend transaction object
         const platformExpense = this.dataTransformService.unflatten<{ tx: PublicPolicyExpense }, Expense>(etxn).tx;
@@ -228,7 +228,7 @@ export class SplitExpenseService {
     }
   }
 
-  createSplitTxns(sourceTxn, totalSplitAmount, splitExpenses) {
+  createSplitTxns(sourceTxn: Transaction, totalSplitAmount: number, splitExpenses: Transaction[]) {
     let splitGroupAmount = sourceTxn.split_group_user_amount || sourceTxn.amount;
     let splitGroupId = sourceTxn.split_group_id || sourceTxn.id;
 
@@ -255,8 +255,8 @@ export class SplitExpenseService {
   ): Observable<Transaction[]> {
     const txnsObservables = [];
 
-    splitExpenses.forEach((splitExpense, index) => {
-      const transaction = { ...sourceTxn };
+    splitExpenses.forEach((splitExpense: Transaction, index) => {
+      const transaction: Transaction = { ...sourceTxn };
 
       if (sourceTxn.orig_currency) {
         const exchangeRate = sourceTxn.amount / sourceTxn.orig_amount;
@@ -308,11 +308,11 @@ export class SplitExpenseService {
     }
   }
 
-  private setUpSplitExpenseBillable(sourceTxn, splitExpense) {
+  private setUpSplitExpenseBillable(sourceTxn: Transaction, splitExpense: Transaction) {
     return splitExpense.project_id ? splitExpense.billable : sourceTxn.billable;
   }
 
-  private setUpSplitExpenseTax(sourceTxn, splitExpense) {
+  private setUpSplitExpenseTax(sourceTxn: Transaction, splitExpense: Transaction) {
     return splitExpense.tax_amount ? splitExpense.tax_amount : sourceTxn.tax_amount;
   }
 }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 739411c</samp>

The pull request enhances the type safety and consistency of the expense model and the split expense service by using more specific interface types instead of `any`. It also adds two new properties to the `FileObject` interface to store the file purpose and content.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 739411c</samp>

> _We are the masters of the code, we shape it as we please_
> _We use specific types to crush the bugs and errors_
> _We move and change the interfaces, we add new properties_
> _We are the SplitExpenseService, we split the bills of terrors_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 739411c</samp>

*  Enforce consistent types for transaction currency, amount, and original currency and amount in `Expense` interface ([link](https://github.com/fylein/fyle-mobile-app/pull/2105/files?diff=unified&w=0#diff-5d1df581fe858623a0a33d1c6f571e5561d7fbf25dbfdabe13f94fedc0964845L55-R55), [link](https://github.com/fylein/fyle-mobile-app/pull/2105/files?diff=unified&w=0#diff-5d1df581fe858623a0a33d1c6f571e5561d7fbf25dbfdabe13f94fedc0964845L107-R108))
* Move `FileObject` interface from `file-obj.model.ts` to `expense.model.ts` and add `purpose` and `content` properties ([link](https://github.com/fylein/fyle-mobile-app/pull/2105/files?diff=unified&w=0#diff-02c1b013a9189a6b73a85a5032757470ccf95b950701490c6618a45af21b63f5L10-R11))
* Use `FileObject` interface type for file objects in `SplitExpenseService` class ([link](https://github.com/fylein/fyle-mobile-app/pull/2105/files?diff=unified&w=0#diff-bab29bd73c5e5f43534ff8d9b9bc4a680f26d582c82c182ec8cc0b0586aacfd4L61-R61), [link](https://github.com/fylein/fyle-mobile-app/pull/2105/files?diff=unified&w=0#diff-bab29bd73c5e5f43534ff8d9b9bc4a680f26d582c82c182ec8cc0b0586aacfd4L72-R73))
* Use `PolicyViolationComment` interface type for policy violation comments in `SplitExpenseService` class ([link](https://github.com/fylein/fyle-mobile-app/pull/2105/files?diff=unified&w=0#diff-bab29bd73c5e5f43534ff8d9b9bc4a680f26d582c82c182ec8cc0b0586aacfd4L124-R124))
* Use `PublicPolicyExpense` interface type for policy expenses in `SplitExpenseService` class ([link](https://github.com/fylein/fyle-mobile-app/pull/2105/files?diff=unified&w=0#diff-bab29bd73c5e5f43534ff8d9b9bc4a680f26d582c82c182ec8cc0b0586aacfd4L214-R214))
* Use `Transaction` interface type for transactions and split expenses in `SplitExpenseService` class ([link](https://github.com/fylein/fyle-mobile-app/pull/2105/files?diff=unified&w=0#diff-bab29bd73c5e5f43534ff8d9b9bc4a680f26d582c82c182ec8cc0b0586aacfd4L231-R231), [link](https://github.com/fylein/fyle-mobile-app/pull/2105/files?diff=unified&w=0#diff-bab29bd73c5e5f43534ff8d9b9bc4a680f26d582c82c182ec8cc0b0586aacfd4L258-R259), [link](https://github.com/fylein/fyle-mobile-app/pull/2105/files?diff=unified&w=0#diff-bab29bd73c5e5f43534ff8d9b9bc4a680f26d582c82c182ec8cc0b0586aacfd4L311-R315))

## Clickup
https://app.clickup.com/t/85zt699qx

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes