### PR TITLE
fix: Added types LaunchDarkly Service

### DIFF
--- a/src/app/core/services/launch-darkly.service.ts
+++ b/src/app/core/services/launch-darkly.service.ts
@@ -19,13 +19,13 @@ export class LaunchDarklyService {
 
   getVariation(key: string, defaultValue: boolean): Observable<boolean> {
     if (this.ldClient) {
-      return of(this.ldClient.variation(key, defaultValue));
+      return of(this.ldClient.variation(key, defaultValue) as boolean);
     }
 
     return from(this.storageService.get('cachedLDFlags')).pipe(
       map((cachedFlags) => {
         if (cachedFlags) {
-          return cachedFlags[key] === undefined ? defaultValue : cachedFlags[key];
+          return cachedFlags[key] === undefined ? defaultValue : (cachedFlags[key] as boolean);
         } else {
           return defaultValue;
         }
@@ -37,7 +37,7 @@ export class LaunchDarklyService {
    * https://launchdarkly.github.io/js-client-sdk/interfaces/_launchdarkly_js_client_sdk_.ldclient.html#off
    * https://launchdarkly.github.io/js-client-sdk/interfaces/_launchdarkly_js_client_sdk_.ldclient.html#close
    */
-  shutDownClient() {
+  shutDownClient(): void {
     if (this.ldClient) {
       this.ldClient.off('initialized', this.updateCache, this);
       this.ldClient.off('change', this.updateCache, this);
@@ -47,7 +47,7 @@ export class LaunchDarklyService {
     }
   }
 
-  initializeUser(user: LDClient.LDUser) {
+  initializeUser(user: LDClient.LDUser): void {
     /**
      * Only makes LaunchDarkly call if the user has changed since the last initalization
      * This is done to avoid redundant calls
@@ -60,7 +60,7 @@ export class LaunchDarklyService {
     }
   }
 
-  checkIfKeyboardPluginIsEnabled() {
+  checkIfKeyboardPluginIsEnabled(): Observable<boolean> {
     return this.getVariation('keyboard_plugin_enabled', true);
   }
 
@@ -72,7 +72,7 @@ export class LaunchDarklyService {
     return isUserEqual;
   }
 
-  private updateCache() {
+  private updateCache(): void {
     if (this.ldClient) {
       const latestFlags = this.ldClient.allFlags();
       this.storageService.set('cachedLDFlags', latestFlags);


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 852209b</samp>

Improved type safety and clarity in `launch-darkly.service.ts`. Fixed a type error in flag variation logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 852209b</samp>

> _Type annotations_
> _`launch-darkly` service shines_
> _Booleans in fall_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 852209b</samp>

*  Cast flag values to boolean type in `getVariation` method to avoid type errors ([link](https://github.com/fylein/fyle-mobile-app/pull/2115/files?diff=unified&w=0#diff-71f4466157f0e92a07972c3b8cfbff4769368e0453456a7b64efd5819e0d71bbL22-R22), [link](https://github.com/fylein/fyle-mobile-app/pull/2115/files?diff=unified&w=0#diff-71f4466157f0e92a07972c3b8cfbff4769368e0453456a7b64efd5819e0d71bbL28-R28))
*  Annotate methods with `void` return type to improve readability and consistency ([link](https://github.com/fylein/fyle-mobile-app/pull/2115/files?diff=unified&w=0#diff-71f4466157f0e92a07972c3b8cfbff4769368e0453456a7b64efd5819e0d71bbL40-R40), [link](https://github.com/fylein/fyle-mobile-app/pull/2115/files?diff=unified&w=0#diff-71f4466157f0e92a07972c3b8cfbff4769368e0453456a7b64efd5819e0d71bbL50-R50), [link](https://github.com/fylein/fyle-mobile-app/pull/2115/files?diff=unified&w=0#diff-71f4466157f0e92a07972c3b8cfbff4769368e0453456a7b64efd5819e0d71bbL75-R75))
*  Annotate `checkIfKeyboardPluginIsEnabled` method with `Observable<boolean>` return type to indicate observable output ([link](https://github.com/fylein/fyle-mobile-app/pull/2115/files?diff=unified&w=0#diff-71f4466157f0e92a07972c3b8cfbff4769368e0453456a7b64efd5819e0d71bbL63-R63))

## Clickup
https://app.clickup.com/t/85zt699gy

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes