### PR TITLE
fix: File Size Limit BR

### DIFF
--- a/src/app/core/constants.ts
+++ b/src/app/core/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_FILE_SIZE = 5000000;

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -110,6 +110,7 @@ import { ExpenseField } from 'src/app/core/models/v1/expense-field.model';
 import { StorageService } from 'src/app/core/services/storage.service';
 import { DependentFieldsComponent } from 'src/app/shared/components/dependent-fields/dependent-fields.component';
 import { CCCExpUnflattened } from 'src/app/core/models/corporate-card-expense-unflattened.model';
+import { MAX_FILE_SIZE } from 'src/app/core/constants';
 
 @Component({
   selector: 'app-add-edit-expense',
@@ -3799,14 +3800,18 @@ export class AddEditExpensePage implements OnInit {
       nativeElement.onchange = async () => {
         const file = nativeElement.files[0];
         if (file) {
-          const dataUrl = await this.fileService.readFile(file);
-          this.trackingService.addAttachment({ type: file.type });
-          fileData = {
-            type: file.type,
-            dataUrl,
-            actionSource: 'gallery_upload',
-          };
-          this.attachReceipts(fileData);
+          if (file.size < MAX_FILE_SIZE) {
+            const dataUrl = await this.fileService.readFile(file);
+            this.trackingService.addAttachment({ type: file.type });
+            fileData = {
+              type: file.type,
+              dataUrl,
+              actionSource: 'gallery_upload',
+            };
+            this.attachReceipts(fileData);
+          } else {
+            this.showSizeLimitExceededPopover();
+          }
         }
       };
       nativeElement.click();
@@ -4276,5 +4281,21 @@ export class AddEditExpensePage implements OnInit {
     this.onPageExit$.next(null);
     this.onPageExit$.complete();
     this.selectedProject$.complete();
+  }
+
+  private async showSizeLimitExceededPopover() {
+    const sizeLimitExceededPopover = await this.popoverController.create({
+      component: PopupAlertComponent,
+      componentProps: {
+        title: 'Size limit exceeded',
+        message: 'The uploaded file is greater than 5MB in size. Please reduce the file size and try again.',
+        primaryCta: {
+          text: 'OK',
+        },
+      },
+      cssClass: 'pop-up-in-center',
+    });
+
+    await sizeLimitExceededPopover.present();
   }
 }

--- a/src/app/fyle/add-edit-expense/camera-options-popup/camera-options-popup.component.ts
+++ b/src/app/fyle/add-edit-expense/camera-options-popup/camera-options-popup.component.ts
@@ -3,9 +3,8 @@ import { PopoverController } from '@ionic/angular';
 import { FileService } from 'src/app/core/services/file.service';
 import { TrackingService } from '../../../core/services/tracking.service';
 import { PopupAlertComponent } from 'src/app/shared/components/popup-alert/popup-alert.component';
+import { MAX_FILE_SIZE } from 'src/app/core/constants';
 
-//Restrict file size to 5MB
-const MAX_FILE_SIZE = 5000000;
 @Component({
   selector: 'app-camera-options-popup',
   templateUrl: './camera-options-popup.component.html',


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at efb3769</samp>

Added a file size limit check for receipt uploads in the `add-edit-expense` component. Used a constant `MAX_FILE_SIZE` from `src/app/core/constants.ts` to store and reuse the limit value.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at efb3769</samp>

> _Upload receipts fast_
> _But check `MAX_FILE_SIZE`_
> _Popovers in spring_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at efb3769</samp>

*  Add a constant `MAX_FILE_SIZE` to store the maximum file size for uploading receipts ([link](https://github.com/fylein/fyle-mobile-app/pull/2128/files?diff=unified&w=0#diff-50ba5f281509111273c2a3aa7d96ca3fe720df01947d81e86361c9dceee103a7R1))
*  Import `MAX_FILE_SIZE` and use it to check the file size of the selected receipt in the `addEditExpense` component ([link](https://github.com/fylein/fyle-mobile-app/pull/2128/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bR113), [link](https://github.com/fylein/fyle-mobile-app/pull/2128/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL3802-R3814))
*  Show a popover with a message if the file size exceeds the limit using the `showSizeLimitExceededPopover` method and the `PopupAlertComponent` ([link](https://github.com/fylein/fyle-mobile-app/pull/2128/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bR4285-R4300))
*  Import `MAX_FILE_SIZE` and use it to check the file size of the photo or file from the gallery in the `cameraOptionsPopup` component ([link](https://github.com/fylein/fyle-mobile-app/pull/2128/files?diff=unified&w=0#diff-87d7fb258f45220697c3e663d654e6157f4d6ee062e7c4ed5234b259f7c23bc8L6-R7))

## Clickup
https://app.clickup.com/t/85zt20tgh

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes