### PR TITLE
feat: Show project mapped categories in split expense page using LD flag

### DIFF
--- a/src/app/core/test-data/projects.spec.data.ts
+++ b/src/app/core/test-data/projects.spec.data.ts
@@ -1,11 +1,12 @@
 import { ProjectV1 } from '../models/v1/extended-project.model';
+import { OrgCategory } from '../models/v1/org-category.model';
 import { ExtendedProject } from '../models/v2/extended-project.model';
 
 export const apiResponseActiveOnly = [
   {
     id: 257528,
-    created_at: '2021-05-12T10:28:40.834Z',
-    updated_at: '2021-07-08T10:28:27.686Z',
+    created_at: new Date('2021-05-12T10:28:40.834Z'),
+    updated_at: new Date('2021-07-08T10:28:27.686Z'),
     name: 'Customer Mapped Project',
     sub_project: null,
     code: '1184',
@@ -18,8 +19,8 @@ export const apiResponseActiveOnly = [
   },
   {
     id: 257541,
-    created_at: '2021-05-12T10:28:40.834Z',
-    updated_at: '2021-07-08T10:28:27.686Z',
+    created_at: new Date('2021-05-12T10:28:40.834Z'),
+    updated_at: new Date('2021-07-08T10:28:27.686Z'),
     name: 'Sage Project 8',
     sub_project: null,
     code: '1178',
@@ -32,8 +33,8 @@ export const apiResponseActiveOnly = [
   },
   {
     id: 257531,
-    created_at: '2021-05-12T10:28:40.834Z',
-    updated_at: '2021-07-08T10:28:27.686Z',
+    created_at: new Date('2021-05-12T10:28:40.834Z'),
+    updated_at: new Date('2021-07-08T10:28:27.686Z'),
     name: 'Fyle Team Integrations',
     sub_project: null,
     code: '1183',
@@ -150,13 +151,13 @@ export const apiV2ResponseSingle = {
       project_approver1_id: null,
       project_approver2_id: null,
       project_code: '1184',
-      project_created_at: '2021-05-12T10:28:40.834844',
+      project_created_at: new Date('2021-05-12T10:28:40.834844'),
       project_description: 'Sage Intacct Project - Customer Mapped Project, Id - 1184',
       project_id: 257528,
       project_name: 'Customer Mapped Project',
       project_org_category_ids: [122269, 122270, 122271, null],
       project_org_id: 'orFdTTTNcyye',
-      project_updated_at: '2021-07-08T10:28:27.686886',
+      project_updated_at: new Date('2021-07-08T10:28:27.686886'),
       projectv2_name: 'Customer Mapped Project',
       sub_project_name: null,
     },
@@ -166,10 +167,10 @@ export const apiV2ResponseSingle = {
   url: '/v2/projects',
 };
 
-export const testActiveCategoryList = [
+export const testActiveCategoryList: OrgCategory[] = [
   {
     code: '4060340',
-    created_at: '2018-01-31T23:50:27.215171+00:00',
+    created_at: new Date('2018-01-31T23:50:27.215171+00:00'),
     displayName: 'Snacks',
     enabled: true,
     fyle_category: 'Food',
@@ -177,11 +178,11 @@ export const testActiveCategoryList = [
     name: 'Snacks',
     org_id: 'orNVthTo2Zyo',
     sub_category: 'Snacks',
-    updated_at: '2022-11-23T14:25:26.485891+00:00',
+    updated_at: new Date('2022-11-23T14:25:26.485891+00:00'),
   },
   {
     code: '4060337',
-    created_at: '2022-07-05T07:52:00.417939+00:00',
+    created_at: new Date('2022-07-05T07:52:00.417939+00:00'),
     displayName: 'Train / Induction',
     enabled: true,
     fyle_category: 'Train',
@@ -189,11 +190,11 @@ export const testActiveCategoryList = [
     name: 'Train',
     org_id: 'orNVthTo2Zyo',
     sub_category: 'Induction',
-    updated_at: '2022-07-05T07:52:00.417939+00:00',
+    updated_at: new Date('2022-07-05T07:52:00.417939+00:00'),
   },
   {
     code: 'Cell phone',
-    created_at: '2021-03-19T04:44:55.627307+00:00',
+    created_at: new Date('2021-03-19T04:44:55.627307+00:00'),
     displayName: 'Cell phone',
     enabled: true,
     fyle_category: null,
@@ -201,14 +202,14 @@ export const testActiveCategoryList = [
     name: 'Cell phone',
     org_id: 'orNVthTo2Zyo',
     sub_category: 'Cell phone',
-    updated_at: '2022-05-05T17:46:15.434494+00:00',
+    updated_at: new Date('2022-05-05T17:46:15.434494+00:00'),
   },
 ];
 
-export const allowedActiveCategories = [
+export const allowedActiveCategories: OrgCategory[] = [
   {
     code: '4060340',
-    created_at: '2018-01-31T23:50:27.215171+00:00',
+    created_at: new Date('2018-01-31T23:50:27.215171+00:00'),
     displayName: 'Snacks',
     enabled: true,
     fyle_category: 'Food',
@@ -216,11 +217,11 @@ export const allowedActiveCategories = [
     name: 'Snacks',
     org_id: 'orNVthTo2Zyo',
     sub_category: 'Snacks',
-    updated_at: '2022-11-23T14:25:26.485891+00:00',
+    updated_at: new Date('2022-11-23T14:25:26.485891+00:00'),
   },
   {
     code: '4060337',
-    created_at: '2022-07-05T07:52:00.417939+00:00',
+    created_at: new Date('2022-07-05T07:52:00.417939+00:00'),
     displayName: 'Train / Induction',
     enabled: true,
     fyle_category: 'Train',
@@ -228,7 +229,7 @@ export const allowedActiveCategories = [
     name: 'Train',
     org_id: 'orNVthTo2Zyo',
     sub_category: 'Induction',
-    updated_at: '2022-07-05T07:52:00.417939+00:00',
+    updated_at: new Date('2022-07-05T07:52:00.417939+00:00'),
   },
 ];
 

--- a/src/app/core/test-data/projects.spec.data.ts
+++ b/src/app/core/test-data/projects.spec.data.ts
@@ -1,5 +1,5 @@
 import { ProjectV1 } from '../models/v1/extended-project.model';
-import { OrgCategory } from '../models/v1/org-category.model';
+import { OrgCategory, OrgCategoryListItem } from '../models/v1/org-category.model';
 import { ExtendedProject } from '../models/v2/extended-project.model';
 
 export const apiResponseActiveOnly = [
@@ -206,6 +206,54 @@ export const testActiveCategoryList: OrgCategory[] = [
   },
 ];
 
+export const testActiveCategoryListOptions: OrgCategoryListItem[] = [
+  {
+    label: 'Snacks',
+    value: {
+      code: '4060340',
+      created_at: new Date('2018-01-31T23:50:27.215171+00:00'),
+      displayName: 'Snacks',
+      enabled: true,
+      fyle_category: 'Food',
+      id: 16560,
+      name: 'Snacks',
+      org_id: 'orNVthTo2Zyo',
+      sub_category: 'Snacks',
+      updated_at: new Date('2022-11-23T14:25:26.485891+00:00'),
+    },
+  },
+  {
+    label: 'Train / Induction',
+    value: {
+      code: '4060337',
+      created_at: new Date('2022-07-05T07:52:00.417939+00:00'),
+      displayName: 'Train / Induction',
+      enabled: true,
+      fyle_category: 'Train',
+      id: 201949,
+      name: 'Train',
+      org_id: 'orNVthTo2Zyo',
+      sub_category: 'Induction',
+      updated_at: new Date('2022-07-05T07:52:00.417939+00:00'),
+    },
+  },
+  {
+    label: 'Cell phone',
+    value: {
+      code: 'Cell phone',
+      created_at: new Date('2021-03-19T04:44:55.627307+00:00'),
+      displayName: 'Cell phone',
+      enabled: true,
+      fyle_category: null,
+      id: 130361,
+      name: 'Cell phone',
+      org_id: 'orNVthTo2Zyo',
+      sub_category: 'Cell phone',
+      updated_at: new Date('2022-05-05T17:46:15.434494+00:00'),
+    },
+  },
+];
+
 export const allowedActiveCategories: OrgCategory[] = [
   {
     code: '4060340',
@@ -230,6 +278,39 @@ export const allowedActiveCategories: OrgCategory[] = [
     org_id: 'orNVthTo2Zyo',
     sub_category: 'Induction',
     updated_at: new Date('2022-07-05T07:52:00.417939+00:00'),
+  },
+];
+
+export const allowedActiveCategoriesListOptions: OrgCategoryListItem[] = [
+  {
+    label: 'Snacks',
+    value: {
+      code: '4060340',
+      created_at: new Date('2018-01-31T23:50:27.215171+00:00'),
+      displayName: 'Snacks',
+      enabled: true,
+      fyle_category: 'Food',
+      id: 16560,
+      name: 'Snacks',
+      org_id: 'orNVthTo2Zyo',
+      sub_category: 'Snacks',
+      updated_at: new Date('2022-11-23T14:25:26.485891+00:00'),
+    },
+  },
+  {
+    label: 'Train / Induction',
+    value: {
+      code: '4060337',
+      created_at: new Date('2022-07-05T07:52:00.417939+00:00'),
+      displayName: 'Train / Induction',
+      enabled: true,
+      fyle_category: 'Train',
+      id: 201949,
+      name: 'Train',
+      org_id: 'orNVthTo2Zyo',
+      sub_category: 'Induction',
+      updated_at: new Date('2022-07-05T07:52:00.417939+00:00'),
+    },
   },
 ];
 

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -765,8 +765,9 @@ export class AddEditExpensePage implements OnInit {
       costCenters: this.costCenters$,
       projects: this.projectsService.getAllActive(),
       txnFields: this.txnFields$.pipe(take(1)),
+      filteredCategories: this.filteredCategories$.pipe(take(1)),
     }).pipe(
-      map(({ orgSettings, costCenters, projects, txnFields }) => {
+      map(({ orgSettings, costCenters, projects, txnFields, filteredCategories }) => {
         const isSplitExpenseAllowed = orgSettings.expense_settings.split_expense_settings.enabled;
 
         const actionSheetOptions = [];
@@ -774,18 +775,21 @@ export class AddEditExpensePage implements OnInit {
         if (isSplitExpenseAllowed) {
           const areCostCentersAvailable = costCenters.length > 0;
           const areProjectsAvailable = orgSettings.projects.enabled && projects.length > 0;
+          const areCategoriesAvailable = filteredCategories.length > 1;
           const projectField = txnFields.project_id;
 
-          actionSheetOptions.push({
-            text: 'Split Expense By Category',
-            handler: () => {
-              if (this.fg.valid) {
-                this.openSplitExpenseModal('categories');
-              } else {
-                this.showFormValidationErrors();
-              }
-            },
-          });
+          if (areCategoriesAvailable) {
+            actionSheetOptions.push({
+              text: 'Split Expense By Category',
+              handler: () => {
+                if (this.fg.valid) {
+                  this.openSplitExpenseModal('categories');
+                } else {
+                  this.showFormValidationErrors();
+                }
+              },
+            });
+          }
 
           if (areProjectsAvailable) {
             actionSheetOptions.push({

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -790,10 +790,10 @@ export class AddEditExpensePage implements OnInit {
           if (isSplitExpenseAllowed) {
             const areCostCentersAvailable = costCenters.length > 0;
             const areProjectsAvailable = orgSettings.projects.enabled && projects.length > 0;
-            const areCategoriesAvailable = filteredCategories.length > 1;
+            const areProjectDependentCategoriesAvailable = filteredCategories.length > 1;
             const projectField = txnFields.project_id;
 
-            if (areCategoriesAvailable || !showProjectMappedCategoriesInSplitExpense) {
+            if (!showProjectMappedCategoriesInSplitExpense || areProjectDependentCategoriesAvailable) {
               actionSheetOptions.push({
                 text: 'Split Expense By Category',
                 handler: () => {

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -45,7 +45,9 @@ import { orgUserSettingsData } from 'src/app/core/mock-data/org-user-settings.da
 import { dependentFieldValues } from 'src/app/core/test-data/dependent-fields.service.spec.data';
 import {
   allowedActiveCategories,
+  allowedActiveCategoriesListOptions,
   testActiveCategoryList,
+  testActiveCategoryListOptions,
   testProjectV2,
 } from 'src/app/core/test-data/projects.spec.data';
 
@@ -342,11 +344,7 @@ describe('SplitExpensePage', () => {
       expect(projectsService.getAllowedOrgCategoryIds).not.toHaveBeenCalled();
 
       component.categories$.subscribe((categories) => {
-        const expectedData = testActiveCategoryList.map((category) => ({
-          label: category.displayName,
-          value: category,
-        }));
-        expect(categories).toEqual(expectedData);
+        expect(categories).toEqual(testActiveCategoryListOptions);
       });
     });
 
@@ -365,11 +363,7 @@ describe('SplitExpensePage', () => {
       expect(projectsService.getAllowedOrgCategoryIds).toHaveBeenCalledOnceWith(testProjectV2, testActiveCategoryList);
 
       component.categories$.subscribe((categories) => {
-        const expectedData = allowedActiveCategories.map((category) => ({
-          label: category.displayName,
-          value: category,
-        }));
-        expect(categories).toEqual(expectedData);
+        expect(categories).toEqual(allowedActiveCategoriesListOptions);
       });
     });
 
@@ -389,12 +383,7 @@ describe('SplitExpensePage', () => {
       expect(projectsService.getAllowedOrgCategoryIds).not.toHaveBeenCalled();
 
       component.categories$.subscribe((categories) => {
-        const expectedData = testActiveCategoryList.map((category) => ({
-          label: category.displayName,
-          value: category,
-        }));
-
-        expect(categories).toEqual(expectedData);
+        expect(categories).toEqual(testActiveCategoryListOptions);
       });
     });
   });

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -342,9 +342,11 @@ describe('SplitExpensePage', () => {
       expect(projectsService.getAllowedOrgCategoryIds).not.toHaveBeenCalled();
 
       component.categories$.subscribe((categories) => {
-        expect(categories).toEqual(
-          testActiveCategoryList.map((category) => ({ label: category.displayName, value: category }))
-        );
+        const expectedData = testActiveCategoryList.map((category) => ({
+          label: category.displayName,
+          value: category,
+        }));
+        expect(categories).toEqual(expectedData);
       });
     });
 
@@ -363,9 +365,11 @@ describe('SplitExpensePage', () => {
       expect(projectsService.getAllowedOrgCategoryIds).toHaveBeenCalledOnceWith(testProjectV2, testActiveCategoryList);
 
       component.categories$.subscribe((categories) => {
-        expect(categories).toEqual(
-          allowedActiveCategories.map((category) => ({ label: category.displayName, value: category }))
-        );
+        const expectedData = allowedActiveCategories.map((category) => ({
+          label: category.displayName,
+          value: category,
+        }));
+        expect(categories).toEqual(expectedData);
       });
     });
 
@@ -385,9 +389,12 @@ describe('SplitExpensePage', () => {
       expect(projectsService.getAllowedOrgCategoryIds).not.toHaveBeenCalled();
 
       component.categories$.subscribe((categories) => {
-        expect(categories).toEqual(
-          testActiveCategoryList.map((category) => ({ label: category.displayName, value: category }))
-        );
+        const expectedData = testActiveCategoryList.map((category) => ({
+          label: category.displayName,
+          value: category,
+        }));
+
+        expect(categories).toEqual(expectedData);
       });
     });
   });

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -506,10 +506,10 @@ export class SplitExpensePage implements OnInit {
 
     this.launchDarklyService
       .getVariation('show_project_mapped_categories_in_split_expense', false)
-      .subscribe((variation) => {
+      .subscribe((showProjectMappedCategories) => {
         this.categories$ = this.getActiveCategories().pipe(
           switchMap((activeCategories) => {
-            if (variation) {
+            if (showProjectMappedCategories && this.transaction.project_id) {
               return this.projectsService
                 .getbyId(this.transaction.project_id)
                 .pipe(map((project) => this.projectsService.getAllowedOrgCategoryIds(project, activeCategories)));

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -507,15 +507,15 @@ export class SplitExpensePage implements OnInit {
     this.categories$ = this.getActiveCategories().pipe(
       switchMap((activeCategories) =>
         this.launchDarklyService.getVariation('show_project_mapped_categories_in_split_expense', false).pipe(
-          switchMap((showProjectMappedCategories) =>
-            iif(
-              () => showProjectMappedCategories && this.transaction.project_id,
-              this.projectsService
+          switchMap((showProjectMappedCategories) => {
+            if (showProjectMappedCategories && this.transaction.project_id) {
+              return this.projectsService
                 .getbyId(this.transaction.project_id)
-                .pipe(map((project) => this.projectsService.getAllowedOrgCategoryIds(project, activeCategories))),
-              of(activeCategories)
-            )
-          ),
+                .pipe(map((project) => this.projectsService.getAllowedOrgCategoryIds(project, activeCategories)));
+            }
+
+            return of(activeCategories);
+          }),
           map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
         )
       )

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -504,11 +504,10 @@ export class SplitExpensePage implements OnInit {
     this.reportId = JSON.parse(this.activatedRoute.snapshot.params.selectedReportId);
     this.transaction = JSON.parse(this.activatedRoute.snapshot.params.txn);
 
-    this.launchDarklyService
-      .getVariation('show_project_mapped_categories_in_split_expense', false)
-      .subscribe((showProjectMappedCategories) => {
-        this.categories$ = this.getActiveCategories().pipe(
-          switchMap((activeCategories) => {
+    this.categories$ = this.getActiveCategories().pipe(
+      switchMap((activeCategories) =>
+        this.launchDarklyService.getVariation('show_project_mapped_categories_in_split_expense', false).pipe(
+          switchMap((showProjectMappedCategories) => {
             if (showProjectMappedCategories && this.transaction.project_id) {
               return this.projectsService
                 .getbyId(this.transaction.project_id)
@@ -518,10 +517,11 @@ export class SplitExpensePage implements OnInit {
             return of(activeCategories);
           }),
           map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
-        );
+        )
+      )
+    );
 
-        this.getCategoryList();
-      });
+    this.getCategoryList();
 
     let parentFieldId: number;
     if (this.splitType === 'projects') {

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -507,15 +507,15 @@ export class SplitExpensePage implements OnInit {
     this.categories$ = this.getActiveCategories().pipe(
       switchMap((activeCategories) =>
         this.launchDarklyService.getVariation('show_project_mapped_categories_in_split_expense', false).pipe(
-          switchMap((showProjectMappedCategories) => {
-            if (showProjectMappedCategories && this.transaction.project_id) {
-              return this.projectsService
+          switchMap((showProjectMappedCategories) =>
+            iif(
+              () => showProjectMappedCategories && this.transaction.project_id,
+              this.projectsService
                 .getbyId(this.transaction.project_id)
-                .pipe(map((project) => this.projectsService.getAllowedOrgCategoryIds(project, activeCategories)));
-            }
-
-            return of(activeCategories);
-          }),
+                .pipe(map((project) => this.projectsService.getAllowedOrgCategoryIds(project, activeCategories))),
+              of(activeCategories)
+            )
+          ),
           map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
         )
       )

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { AbstractControl, FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ModalController, NavController, PopoverController } from '@ionic/angular';
-import { isNumber } from 'lodash';
+import { isNumber, take } from 'lodash';
 import * as dayjs from 'dayjs';
 import { forkJoin, from, iif, noop, Observable, of, throwError } from 'rxjs';
 import { catchError, concatMap, finalize, map, mergeMap, switchMap, tap, toArray } from 'rxjs/operators';
@@ -28,6 +28,8 @@ import { CurrencyService } from 'src/app/core/services/currency.service';
 import { OrgUserSettingsService } from 'src/app/core/services/org-user-settings.service';
 import { DependentFieldsService } from 'src/app/core/services/dependent-fields.service';
 import { CustomInput } from 'src/app/core/models/custom-input.model';
+import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
+import { ProjectsService } from 'src/app/core/services/projects.service';
 
 @Component({
   selector: 'app-split-expense',
@@ -106,7 +108,9 @@ export class SplitExpensePage implements OnInit {
     private modalProperties: ModalPropertiesService,
     private orgUserSettingsService: OrgUserSettingsService,
     private orgSettingsService: OrgSettingsService,
-    private dependentFieldsService: DependentFieldsService
+    private dependentFieldsService: DependentFieldsService,
+    private launchDarklyService: LaunchDarklyService,
+    private projectsService: ProjectsService
   ) {}
 
   ngOnInit() {}
@@ -498,13 +502,26 @@ export class SplitExpensePage implements OnInit {
     this.fileUrls = JSON.parse(this.activatedRoute.snapshot.params.fileObjs);
     this.selectedCCCTransaction = JSON.parse(this.activatedRoute.snapshot.params.selectedCCCTransaction);
     this.reportId = JSON.parse(this.activatedRoute.snapshot.params.selectedReportId);
-
-    this.categories$ = this.getActiveCategories().pipe(
-      map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
-    );
-    this.getCategoryList();
-
     this.transaction = JSON.parse(this.activatedRoute.snapshot.params.txn);
+
+    this.launchDarklyService
+      .getVariation('show_project_mapped_categories_in_split_expense', false)
+      .subscribe((variation) => {
+        this.categories$ = this.getActiveCategories().pipe(
+          switchMap((activeCategories) => {
+            if (variation) {
+              return this.projectsService
+                .getbyId(this.transaction.project_id)
+                .pipe(map((project) => this.projectsService.getAllowedOrgCategoryIds(project, activeCategories)));
+            }
+
+            return of(activeCategories);
+          }),
+          map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
+        );
+
+        this.getCategoryList();
+      });
 
     let parentFieldId: number;
     if (this.splitType === 'projects') {


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18priUEgGJrULHE8LRk5zQlDEVjXEvuPo%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=hgF9DJ9)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d8af8b</samp>

This pull request improves the user experience of splitting expenses by category and project. It adds a validation check for the split by category option and hides it when not applicable. It also enables the split by project option based on a feature flag and shows the relevant categories for each project.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1d8af8b</samp>

> _Split expense by cat_
> _`filteredCategories` check_
> _Autumn leaves project_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d8af8b</samp>

*  Add `filteredCategories` observable to forkJoin operator and use it to conditionally show split expense by category option ([link](https://github.com/fylein/fyle-mobile-app/pull/2131/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL768-R770), [link](https://github.com/fylein/fyle-mobile-app/pull/2131/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL777-R792)) in `add-edit-expense.page.ts`

## Clickup
https://app.clickup.com/null

## UI Preview
When LD flag is enabled
https://www.loom.com/share/43a059b8fa994ed98f612fed9fbae423

When LD flag is disabled (By default)
https://www.loom.com/share/c9a2e933978344e498f1df13f1f1f410