### PR TITLE
fix: Check if projects is enabled before auto filling

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1513,6 +1513,7 @@ export class AddEditExpensePage implements OnInit {
            * 4. When there exists recently used project ids to auto-fill
            */
           if (
+            orgSettings.projects.enabled &&
             doRecentProjectIdsExist &&
             (!etxn.tx.id || (etxn.tx.id && etxn.tx.state === 'DRAFT' && !etxn.tx.project_id))
           ) {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf398a1</samp>

Enable project field in expense form based on organization settings. Modify `add-edit-expense.page.ts` to check the settings before displaying the field.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cf398a1</samp>

> _`projects` enabled?_
> _show field in expense form_
> _a winter feature_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cf398a1</samp>

*  Add a condition to show project field only if projects are enabled in organization settings ([link](https://github.com/fylein/fyle-mobile-app/pull/2132/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bR1516))

## Clickup
https://app.clickup.com/t/85zt9x4fd

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes