### PR TITLE
Set tax_amount to 0 if not specified

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -2806,7 +2806,7 @@ export class AddEditExpensePage implements OnInit {
             orig_currency: this.fg.value?.currencyObj?.orig_currency,
             orig_amount: this.fg.value?.currencyObj?.orig_amount,
             project_id: this.fg.value?.project?.project_id,
-            tax_amount: this.fg.value?.tax_amount,
+            tax_amount: this.fg.value?.tax_amount || 0,
             tax_group_id: this.fg.value?.tax_group?.id,
             org_category_id: this.fg.value?.category?.id,
             fyle_category: this.fg.value?.category?.fyle_category,


### PR DESCRIPTION
### Description
copilot:summary

copilot:poem

### Walkthrough
copilot:walkthrough

## Changes
- The org complaned that exports were failing. On debuggin the FB team found that this is because the tax amount field is se to null in mobile app.
- This PR fixes it and sets the tax amount to 0 if it is not present

## Clickup
https://app.clickup.com/t/85zt2ux87
