### PR TITLE
fix:  Zero state overlap with input in ios

### DIFF
--- a/src/app/fyle/my-create-report/my-create-report.page.html
+++ b/src/app/fyle/my-create-report/my-create-report.page.html
@@ -17,7 +17,7 @@
   </div>
 </ion-header>
 
-<ion-content>
+<ion-content class="no-keyboard-adjust">
   <div class="my-create-report--container full-height">
     <div class="my-create-report--report-card">
       <div class="my-create-report--report-title">Report Name</div>


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ff6952</samp>

Added a class to prevent content from being pushed up by keyboard. This fixes a bug where the report name input field was not visible on some devices.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7ff6952</samp>

> _`ion-content` class_
> _no keyboard adjust for bug_
> _spring cleaning the code_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ff6952</samp>

*  Prevent content from being pushed up by keyboard on report name input ([link](https://github.com/fylein/fyle-mobile-app/pull/2134/files?diff=unified&w=0#diff-e701d3a765409cabbd5c4367c7db4e695ea8863b9f4456848b6dae9580c04ecbL20-R20))

## Description
https://github.com/ionic-team/ionic-framework/issues/22922#issuecomment-780609726
This is happening only in IOS because capacitor webview is interfering with ionic scroll functionality. Have used the recommended fix

## Clickup
- https://app.clickup.com/t/85zt6vb35
- https://app.clickup.com/t/85zt3vz1m


## UI Preview

Before the fix:
<img src="https://github.com/fylein/fyle-mobile-app/assets/39493102/5a918613-aecc-4fa3-a553-72fba2788321" height="400px">


After the fix in the same device:
<img src="https://github.com/fylein/fyle-mobile-app/assets/39493102/ab208041-c0c8-47bc-b19d-1abbfe7477c1" height="400px">
