### PR TITLE
fix: Consistency of redirectionText

### DIFF
--- a/src/app/core/models/snackbar-properties.model.ts
+++ b/src/app/core/models/snackbar-properties.model.ts
@@ -3,7 +3,7 @@ export interface SnackbarProperties {
     icon: string;
     showCloseButton: boolean;
     message: string;
-    redirectiontext?: string;
+    redirectionText?: string;
   };
   duration: number;
 }

--- a/src/app/core/services/snackbar-properties.service.spec.ts
+++ b/src/app/core/services/snackbar-properties.service.spec.ts
@@ -40,10 +40,10 @@ describe('SnackbarPropertiesService', () => {
   it('should return redirection text in data', () => {
     const properties = service.setSnackbarProperties('success', {
       message: 'Success message',
-      redirectiontext: 'redirection',
+      redirectionText: 'redirection',
     });
     expect(properties.data.message).toEqual('Success message');
-    expect(properties.data.redirectiontext).toEqual('redirection');
+    expect(properties.data.redirectionText).toEqual('redirection');
   });
 
   it('should return showCloseButton as true', () => {

--- a/src/app/core/services/snackbar-properties.service.ts
+++ b/src/app/core/services/snackbar-properties.service.ts
@@ -16,7 +16,7 @@ export class SnackbarPropertiesService {
 
   setSnackbarProperties(
     toastMessageType: 'success' | 'failure' | 'information',
-    toastMessageData: { message: string; redirectiontext?: string }
+    toastMessageData: { message: string; redirectionText?: string }
   ): SnackbarProperties {
     let snackbarIcon: string;
     if (toastMessageType === 'success') {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bbe4166</samp>

Refactored the `SnackbarProperties` interface and related code to use camelCase for the `redirectionText` property. This improves code consistency, readability, and testing.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bbe4166</samp>

> _`redirectionText`_
> _camelCase for clarity_
> _autumn leaves no trace_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bbe4166</samp>

*  Rename `redirectiontext` to `redirectionText` in `SnackbarProperties` interface and all references to improve consistency and readability ([link](https://github.com/fylein/fyle-mobile-app/pull/2138/files?diff=unified&w=0#diff-ce01baace8b5d1a62eaeb0a09b28e8a3d8f3d6712c6274c63f53975880cd78cfL6-R6), [link](https://github.com/fylein/fyle-mobile-app/pull/2138/files?diff=unified&w=0#diff-e5faa5b2ce9256e52d6174cd67e85c1a9a38537e79b919cfc4db8b6db8f4a875L43-R46), [link](https://github.com/fylein/fyle-mobile-app/pull/2138/files?diff=unified&w=0#diff-f3bf34609cf2ce4c07d2ac0b1033a624dc539238056bbdc4b7d92980929ab636L19-R19))
*  Update test case for `setSnackbarProperties` method in `snackbar-properties.service.spec.ts` to match the interface and method signature changes ([link](https://github.com/fylein/fyle-mobile-app/pull/2138/files?diff=unified&w=0#diff-e5faa5b2ce9256e52d6174cd67e85c1a9a38537e79b919cfc4db8b6db8f4a875L43-R46))
*  Align parameter of `setSnackbarProperties` method in `snackbar-properties.service.ts` with the interface definition ([link](https://github.com/fylein/fyle-mobile-app/pull/2138/files?diff=unified&w=0#diff-f3bf34609cf2ce4c07d2ac0b1033a624dc539238056bbdc4b7d92980929ab636L19-R19))

## Clickup
app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes