### PR TITLE
fix: Show tax amount as 0 when user selects 0% tax group

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -507,7 +507,7 @@ export class AddEditExpensePage implements OnInit {
     combineLatest(this.fg.controls.currencyObj.valueChanges, this.fg.controls.tax_group.valueChanges).subscribe(() => {
       if (
         this.fg.controls.tax_group.value &&
-        this.fg.controls.tax_group.value.percentage &&
+        isNumber(this.fg.controls.tax_group.value.percentage) &&
         this.fg.controls.currencyObj.value
       ) {
         const amount =
@@ -2824,7 +2824,7 @@ export class AddEditExpensePage implements OnInit {
             orig_currency: this.fg.value?.currencyObj?.orig_currency,
             orig_amount: this.fg.value?.currencyObj?.orig_amount,
             project_id: this.fg.value?.project?.project_id,
-            tax_amount: this.fg.value?.tax_amount || 0,
+            tax_amount: this.fg.value?.tax_amount,
             tax_group_id: this.fg.value?.tax_group?.id,
             org_category_id: this.fg.value?.category?.id,
             fyle_category: this.fg.value?.category?.fyle_category,


### PR DESCRIPTION
### Description
copilot:summary

copilot:poem

### Walkthrough
copilot:walkthrough

## Clickup
https://app.clickup.com/t/85zt2ux87

## Code Coverage
Please add code coverage here

## UI Preview
https://github.com/fylein/fyle-mobile-app/assets/39493102/ff817912-2198-4aae-be6f-5eb032e496d0

## What Changes?
Earlier, I had fixed it only from the pov of fixing exports, but ideally the tax amount in the UI should also be 0 instead of an empty field
