### PR TITLE
fix: Draft State Header in Report View Page

### DIFF
--- a/src/app/fyle/my-view-report/my-view-report.page.html
+++ b/src/app/fyle/my-view-report/my-view-report.page.html
@@ -73,7 +73,10 @@
                     <span class="view-reports--submitted-date__text"
                       >{{erpt.rp_state === "DRAFT" ? "Created on : " : "Submitted on : " }}
                     </span>
-                    <span class="view-reports--submitted-date__date"
+                    <span *ngIf="erpt.rp_state === 'DRAFT'" class="view-reports--submitted-date__date"
+                      >{{erpt.rp_created_at | date: 'MMM dd, YYYY'}}</span
+                    >
+                    <span *ngIf="erpt.rp_state !== 'DRAFT'" class="view-reports--submitted-date__date"
                       >{{erpt.rp_submitted_at | date: 'MMM dd, YYYY'}}</span
                     >
                   </div>


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f7dc59</samp>

Fix submission date display for draft reports. Use report creation date instead of submission date for draft reports in `my-view-report.page.html`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3f7dc59</samp>

> _Show `report` date_
> _Based on its state: draft or_
> _Submitted. Bug fixed._

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f7dc59</samp>

*  Add conditional rendering of report date based on report state ([link](https://github.com/fylein/fyle-mobile-app/pull/2146/files?diff=unified&w=0#diff-a52aaafa54cc049d42c344ff3d466b8f46ad3b7aca50bda871b8f6258071f3d4L76-R79))

## Clickup
https://app.clickup.com/t/85zrzcjmc

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes