### PR TITLE
test: 100% coverage of Split expense service

### DIFF
--- a/src/app/core/mock-data/transaction.data.ts
+++ b/src/app/core/mock-data/transaction.data.ts
@@ -2264,3 +2264,75 @@ export const txnParam2: Transaction = {
   categoryDisplayName: 'Food / Travelling - Inland',
   custom_attributes: null,
 };
+
+export const txnData5: Transaction = {
+  ...txnData,
+  orig_currency: 'USD',
+  orig_amount: 200,
+  amount: 2000,
+  split_group_id: 'txOJVaaPxo9O',
+  split_group_user_amount: 100,
+  id: null,
+  source: 'MOBILE_DASHCAM_BULK',
+  txn_dt: new Date('2023-01-31T17:00:00.000Z'),
+  project_id: null,
+  cost_center_id: null,
+  org_category_id: 117013,
+  billable: true,
+  tax_amount: 45,
+  custom_properties: [
+    {
+      name: 'userlist',
+      value: [],
+    },
+    {
+      name: 'User List',
+      value: [],
+    },
+  ],
+};
+
+export const expectedTxnParams: Transaction = {
+  ...txnData5,
+  split_group_id: 'txOJVaaPxo9O',
+  split_group_user_amount: 100,
+  orig_amount: 100,
+  amount: 1000,
+};
+
+export const expectedTxnParams2: Transaction = {
+  ...txnData5,
+  orig_amount: 100,
+  amount: 1000,
+  split_group_id: 'txOJVaaPxo9O',
+  split_group_user_amount: 100,
+  cost_center_id: 13795,
+  org_category_id: 123032,
+};
+
+export const expectedTxnParams3: Transaction = {
+  ...txnData5,
+  orig_currency: undefined,
+  split_group_user_amount: 100,
+  orig_amount: 200,
+  amount: null,
+  cost_center_id: null,
+  org_category_id: 117013,
+};
+
+export const expectedTxnParams4: Transaction = {
+  ...txnData5,
+  orig_currency: undefined,
+  split_group_user_amount: 100,
+  orig_amount: 200,
+  amount: null,
+  cost_center_id: 13795,
+  org_category_id: 123032,
+};
+
+export const expectedTxnParams5: Transaction = {
+  ...txnData5,
+  source: 'WEBAPP',
+  orig_amount: null,
+  amount: 0,
+};

--- a/src/app/core/mock-data/transaction.data.ts
+++ b/src/app/core/mock-data/transaction.data.ts
@@ -2332,7 +2332,7 @@ export const expectedTxnParams4: Transaction = {
 
 export const expectedTxnParams5: Transaction = {
   ...txnData5,
-  source: 'WEBAPP',
+  source: 'MOBILE_SPLIT',
   orig_amount: null,
   amount: 0,
 };

--- a/src/app/core/services/split-expense.service.spec.ts
+++ b/src/app/core/services/split-expense.service.spec.ts
@@ -19,6 +19,8 @@ import {
   txnParam2,
   createSourceTxn2,
   txnData2,
+  txnList,
+  txnData,
 } from '../mock-data/transaction.data';
 import { of } from 'rxjs';
 import { splitExpFileObj, splitExpFile2, splitExpFile3, fileObject4 } from '../mock-data/file-object.data';
@@ -39,7 +41,8 @@ import { violationComment1, violationComment2, violationComment3 } from '../mock
 import { unflattenExp1, unflattenExp2 } from '../mock-data/unflattened-expense.data';
 import { criticalPolicyViolation1, criticalPolicyViolation2 } from '../mock-data/crtical-policy-violations.data';
 import { UtilityService } from './utility.service';
-describe('SplitExpenseService', () => {
+import { cloneDeep } from 'lodash';
+fdescribe('SplitExpenseService', () => {
   let splitExpenseService: SplitExpenseService;
   let transactionService: jasmine.SpyObj<TransactionService>;
   let policyService: jasmine.SpyObj<PolicyService>;
@@ -199,14 +202,23 @@ describe('SplitExpenseService', () => {
       });
   });
 
-  it('formatDisplayName(): should get display name from list of categories', () => {
-    categoriesService.filterByOrgCategoryId.and.returnValue(transformedOrgCategories[0]);
-    const model = 141295;
+  describe('formatDisplayName(): ', () => {
+    it('should get display name from list of categories', () => {
+      categoriesService.filterByOrgCategoryId.and.returnValue(transformedOrgCategories[0]);
+      const model = 141295;
 
-    expect(splitExpenseService.formatDisplayName(model, transformedOrgCategories)).toEqual(
-      transformedOrgCategories[0].displayName
-    );
-    expect(categoriesService.filterByOrgCategoryId).toHaveBeenCalledOnceWith(model, transformedOrgCategories);
+      expect(splitExpenseService.formatDisplayName(model, transformedOrgCategories)).toEqual(
+        transformedOrgCategories[0].displayName
+      );
+      expect(categoriesService.filterByOrgCategoryId).toHaveBeenCalledOnceWith(model, transformedOrgCategories);
+    });
+    it('should return undefined if filterByOrgCategoryId returns undefined', () => {
+      categoriesService.filterByOrgCategoryId.and.returnValue(undefined);
+      const model = 141295;
+
+      expect(splitExpenseService.formatDisplayName(model, transformedOrgCategories)).toEqual(undefined);
+      expect(categoriesService.filterByOrgCategoryId).toHaveBeenCalledOnceWith(model, transformedOrgCategories);
+    });
   });
 
   describe('setupSplitExpensePurpose():', () => {
@@ -214,10 +226,10 @@ describe('SplitExpenseService', () => {
       const splitGroupId = 'txfwF576rExp';
       const index = 0;
       const numberOfTxn = 2;
+      const mockSplitPurposeTxn = cloneDeep(splitPurposeTxn);
 
-      //@ts-ignore
-      splitExpenseService.setupSplitExpensePurpose(splitPurposeTxn, splitGroupId, index, numberOfTxn);
-      expect(splitPurposeTxn.purpose).toEqual('test_term (1) (1)');
+      splitExpenseService.setupSplitExpensePurpose(mockSplitPurposeTxn, splitGroupId, index, numberOfTxn);
+      expect(mockSplitPurposeTxn.purpose).toEqual('test_term (1) (1)');
     });
 
     it('should modify split expense purpose without group ID', () => {
@@ -225,32 +237,37 @@ describe('SplitExpenseService', () => {
       const index = 0;
       const numberOfTxn = 2;
 
-      //@ts-ignore
       splitExpenseService.setupSplitExpensePurpose(txnData2, splitGroupId, index, numberOfTxn);
       expect(txnData2.purpose).toBeNull();
+    });
+
+    it('should modify split expense purpose if splitGroupId is undefined', () => {
+      const splitGroupId = null;
+      const index = 0;
+      const numberOfTxn = 2;
+      const mockSplitPurposeTxn = cloneDeep(splitPurposeTxn);
+
+      splitExpenseService.setupSplitExpensePurpose(mockSplitPurposeTxn, splitGroupId, index, numberOfTxn);
+      expect(mockSplitPurposeTxn.purpose).toEqual('test_term (1) (2)');
     });
   });
 
   it('setUpSplitExpenseBillable(): setup expense billable amount', () => {
-    //@ts-ignore
     expect(splitExpenseService.setUpSplitExpenseBillable(sourceSplitTxn, splitTxn)).toEqual(splitTxn.billable);
   });
 
   it('setUpSplitExpenseBillable(): setup expense billable amount with project ID', () => {
-    //@ts-ignore
     expect(splitExpenseService.setUpSplitExpenseBillable(sourceSplitTxn, { project_id: 123, ...splitTxn })).toEqual(
       splitTxn.billable
     );
   });
 
   it('setUpSplitExpenseTax(): setup expense tax', () => {
-    //@ts-ignore
     expect(splitExpenseService.setUpSplitExpenseTax(sourceSplitTxn, splitTxn)).toEqual(splitTxn.tax_amount);
   });
 
   it('setUpSplitExpenseTax(): setup expense tax', () => {
     const { tax_amount, ...newSourceTxn } = splitTxn;
-    //@ts-ignore
     expect(splitExpenseService.setUpSplitExpenseTax(sourceSplitTxn, newSourceTxn)).toEqual(sourceSplitTxn.tax_amount);
   });
 
@@ -320,38 +337,42 @@ describe('SplitExpenseService', () => {
     });
   });
 
-  it('mapViolationDataWithEtxn(): should map violation data with expenses', () => {
-    const formatDisplayNameSpy = spyOn(splitExpenseService, 'formatDisplayName');
-    formatDisplayNameSpy.and.returnValue('Food');
-    formatDisplayNameSpy.and.returnValue('Food / Travelling - Inland');
-    expect(
-      splitExpenseService.mapViolationDataWithEtxn(policyVoilationData2, splitExpData, transformedOrgCategories)
-    ).toEqual(policyVoilationData2);
-    expect(splitExpenseService.formatDisplayName).toHaveBeenCalledWith(
-      splitExpData[0].tx_org_category_id,
-      transformedOrgCategories
-    );
-    expect(splitExpenseService.formatDisplayName).toHaveBeenCalledWith(
-      splitExpData[1].tx_org_category_id,
-      transformedOrgCategories
-    );
-    expect(splitExpenseService.formatDisplayName).toHaveBeenCalledTimes(2);
-  });
+  describe('mapViolationDataWithEtxn(): ', () => {
+    beforeEach(() => {
+      const formatDisplayNameSpy = spyOn(splitExpenseService, 'formatDisplayName');
+      formatDisplayNameSpy.and.returnValue('Food / Travelling - Inland');
+    });
+    it('should map violation data with expenses', () => {
+      expect(
+        splitExpenseService.mapViolationDataWithEtxn(policyVoilationData2, splitExpData, transformedOrgCategories)
+      ).toEqual(policyVoilationData2);
+      expect(splitExpenseService.formatDisplayName).toHaveBeenCalledWith(
+        splitExpData[0].tx_org_category_id,
+        transformedOrgCategories
+      );
+      expect(splitExpenseService.formatDisplayName).toHaveBeenCalledWith(
+        splitExpData[1].tx_org_category_id,
+        transformedOrgCategories
+      );
+      expect(splitExpenseService.formatDisplayName).toHaveBeenCalledTimes(2);
+    });
+    it('should map violation data with expenses', () => {
+      const { tx_orig_amount, tx_orig_currency, ...newSplitData } = splitExpData[0];
 
-  it('mapViolationDataWithEtxn(): should map violation data with expenses', () => {
-    const formatDisplayNameSpy = spyOn(splitExpenseService, 'formatDisplayName');
-    formatDisplayNameSpy.and.returnValue('Food');
-    formatDisplayNameSpy.and.returnValue('Food / Travelling - Inland');
-
-    const { tx_orig_amount, tx_orig_currency, ...newSplitData } = splitExpData[0];
-
-    expect(
-      splitExpenseService.mapViolationDataWithEtxn(policyVoilationData2, [newSplitData], transformedOrgCategories)
-    ).toEqual(policyVoilationData2);
-    expect(splitExpenseService.formatDisplayName).toHaveBeenCalledOnceWith(
-      newSplitData.tx_org_category_id,
-      transformedOrgCategories
-    );
+      expect(
+        splitExpenseService.mapViolationDataWithEtxn(policyVoilationData2, [newSplitData], transformedOrgCategories)
+      ).toEqual(policyVoilationData2);
+      expect(splitExpenseService.formatDisplayName).toHaveBeenCalledOnceWith(
+        newSplitData.tx_org_category_id,
+        transformedOrgCategories
+      );
+    });
+    it('should not map violation data with expenses if tx_id is undefined', () => {
+      expect(
+        splitExpenseService.mapViolationDataWithEtxn(policyVoilationData2, [undefined], transformedOrgCategories)
+      ).toEqual(policyVoilationData2);
+      expect(splitExpenseService.formatDisplayName).not.toHaveBeenCalled();
+    });
   });
 
   it('formatPolicyViolations(): should format policy violations', () => {
@@ -425,6 +446,34 @@ describe('SplitExpenseService', () => {
         done();
       });
     });
+
+    it('should run policy check on expenses when files and user_amount are not defined', (done) => {
+      const mockUnflattenExp1 = cloneDeep(unflattenExp1);
+      mockUnflattenExp1.tx.user_amount = undefined;
+      dataTransformService.unflatten.withArgs(splitExpData2[0]).and.returnValue(mockUnflattenExp1);
+      dataTransformService.unflatten.withArgs(splitExpData2[1]).and.returnValue(unflattenExp2);
+
+      spyOn(splitExpenseService, 'checkPolicyForTransactions').and.returnValue(of(policyViolationData4));
+
+      splitExpenseService.runPolicyCheck(splitExpData2, undefined).subscribe((res) => {
+        expect(res).toEqual(policyViolationData4);
+        expect(dataTransformService.unflatten).toHaveBeenCalledWith(splitExpData2[0]);
+        expect(dataTransformService.unflatten).toHaveBeenCalledWith(splitExpData2[1]);
+        expect(dataTransformService.unflatten).toHaveBeenCalledTimes(2);
+        expect(splitExpenseService.checkPolicyForTransactions).toHaveBeenCalledOnceWith([
+          mockUnflattenExp1.tx,
+          unflattenExp2.tx,
+        ]);
+        done();
+      });
+    });
+
+    it('should return empty object when expenses are undefined', (done) => {
+      splitExpenseService.runPolicyCheck(undefined, fileObject4).subscribe((res) => {
+        expect(res).toEqual({});
+        done();
+      });
+    });
   });
 
   it('executePolicyCheck(): should execute policy check', (done) => {
@@ -462,5 +511,17 @@ describe('SplitExpenseService', () => {
         );
         done();
       });
+  });
+
+  xdescribe('createTxns(): ', () => {
+    beforeEach(() => {
+      spyOn(splitExpenseService, 'setUpSplitExpenseBillable');
+      spyOn(splitExpenseService, 'setUpSplitExpenseTax');
+    });
+    it('should return observable of transactions if orig_currency is defined in source transactions', () => {
+      const mockTxn = cloneDeep(txnData);
+      mockTxn.orig_currency = 'USD';
+      const mockSplitExpenses = cloneDeep(txnList);
+    });
   });
 });

--- a/src/app/core/services/split-expense.service.spec.ts
+++ b/src/app/core/services/split-expense.service.spec.ts
@@ -527,7 +527,7 @@ describe('SplitExpenseService', () => {
       spyOn(splitExpenseService, 'setupSplitExpensePurpose');
     });
 
-    it('should return observable of transactions if orig_currency is defined in source transactions', () => {
+    it('should set orig_amount of splitter expense and amount equals to (splitter amount * exchangeRate) if orig_currency is set', () => {
       const mockTxn = cloneDeep(txnData5);
       mockTxn.split_group_id = undefined;
       mockTxn.split_group_user_amount = undefined;
@@ -567,7 +567,7 @@ describe('SplitExpenseService', () => {
       expect(transactionService.upsert).toHaveBeenCalledWith(expectedTxnParams2);
     });
 
-    it('should return observable of transactions if orig_currency is undefined in source transactions', () => {
+    it('should set amount of the splitter expenses if orig_currency is not set', () => {
       const mockTxn = cloneDeep(txnData5);
       mockTxn.orig_currency = undefined;
       const mockSplitExpenses = cloneDeep(txnList);
@@ -602,7 +602,7 @@ describe('SplitExpenseService', () => {
       expect(transactionService.upsert).toHaveBeenCalledWith(expectedTxnParams4);
     });
 
-    it('should return observable of transactions if transactions.source is undefined', () => {
+    it('should create expenses with source as mobile app if source is undefined', () => {
       const mockTxn = cloneDeep(txnData5);
       mockTxn.source = undefined;
       const mockSplitExpenses = cloneDeep(txnList);

--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -294,7 +294,7 @@ export class SplitExpenseService {
     return forkJoin(txnsObservables);
   }
 
-  private setupSplitExpensePurpose(
+  setupSplitExpensePurpose(
     transaction: Transaction,
     splitGroupId: string,
     index: number,
@@ -312,11 +312,11 @@ export class SplitExpenseService {
     }
   }
 
-  private setUpSplitExpenseBillable(sourceTxn: Transaction, splitExpense: Transaction): boolean {
+  setUpSplitExpenseBillable(sourceTxn: Transaction, splitExpense: Transaction): boolean {
     return splitExpense.project_id ? splitExpense.billable : sourceTxn.billable;
   }
 
-  private setUpSplitExpenseTax(sourceTxn: Transaction, splitExpense: Transaction): number {
+  setUpSplitExpenseTax(sourceTxn: Transaction, splitExpense: Transaction): number {
     return splitExpense.tax_amount ? splitExpense.tax_amount : sourceTxn.tax_amount;
   }
 }

--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -275,7 +275,7 @@ export class SplitExpenseService {
       transaction.split_group_user_amount = sourceTxn.split_group_user_amount || splitGroupAmount;
 
       transaction.id = null;
-      transaction.source = transaction.source || 'WEBAPP';
+      transaction.source = transaction.source || 'MOBILE_SPLIT';
 
       transaction.txn_dt = splitExpense.txn_dt || sourceTxn.txn_dt;
       transaction.txn_dt = new Date(transaction.txn_dt);


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f00455</samp>

This pull request improves the unit testing of the `split-expense.service.ts` file by adding and modifying test cases, mock data, and helper methods. It also makes some minor changes to the service file to expose some methods for testing. The goal is to increase the code coverage and quality of the split expense service, which handles the logic and validation of splitting expenses in the app.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3f00455</samp>

> _To test the split expense service_
> _We need mock data and some purpose_
> _We also import clone_
> _And make some methods known_
> _And remove comments that are surplus_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f00455</samp>

*  Make some helper methods public for unit testing ([link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-bab29bd73c5e5f43534ff8d9b9bc4a680f26d582c82c182ec8cc0b0586aacfd4L297-R297), [link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-bab29bd73c5e5f43534ff8d9b9bc4a680f26d582c82c182ec8cc0b0586aacfd4L315-R319))
*  Add mock transaction data and expected parameters for testing split expense service ([link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-b8ffe3caa9c9df1506a4592f97c8d56122e9cf79615e9b20dbeceab72a329899R2267-R2338))
*  Import mock data and parameters from transaction.data.ts file ([link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-278f1659b9505b451567f9bed8a92b3d57a7cb6192238230e9bcbd31bc16a645R22-R29))
*  Import cloneDeep function from lodash library to create copies of mock data ([link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-278f1659b9505b451567f9bed8a92b3d57a7cb6192238230e9bcbd31bc16a645R50-R51))
*  Test formatDisplayName method for different cases of category display name and org category id ([link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-278f1659b9505b451567f9bed8a92b3d57a7cb6192238230e9bcbd31bc16a645L202-R228), [link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-278f1659b9505b451567f9bed8a92b3d57a7cb6192238230e9bcbd31bc16a645L217-R239))
*  Test setupSplitExpensePurpose method for different cases of split group id and purpose ([link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-278f1659b9505b451567f9bed8a92b3d57a7cb6192238230e9bcbd31bc16a645L228-R266))
*  Remove unnecessary ts-ignore comments from unit tests for setUpSplitExpenseBillable and setUpSplitExpenseTax methods ([link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-278f1659b9505b451567f9bed8a92b3d57a7cb6192238230e9bcbd31bc16a645L247), [link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-278f1659b9505b451567f9bed8a92b3d57a7cb6192238230e9bcbd31bc16a645L253))
*  Test mapViolationDataWithEtxn method for different cases of tx_id and category display name ([link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-278f1659b9505b451567f9bed8a92b3d57a7cb6192238230e9bcbd31bc16a645L323-R382))
*  Test runPolicyCheck method for different cases of files, user_amount, and split expenses ([link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-278f1659b9505b451567f9bed8a92b3d57a7cb6192238230e9bcbd31bc16a645R456-R483))
*  Test createTxns method for different cases of orig_currency, source, and split_group_id of source transaction ([link](https://github.com/fylein/fyle-mobile-app/pull/2149/files?diff=unified&w=0#diff-278f1659b9505b451567f9bed8a92b3d57a7cb6192238230e9bcbd31bc16a645R522-R639))

## Clickup
https://app.clickup.com/t/85ztbydnz

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes