### PR TITLE
fix: strandhogg - FLAG_ACTIVITY_NEW_TASK 

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,6 @@
             android:taskAffinity=""
             android:screenOrientation="portrait"
             android:exported="true"
-            android:noHistory="true"
             >
 
             <intent-filter android:autoVerify="true">

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
             android:taskAffinity=""
             android:screenOrientation="portrait"
             android:exported="true"
+            android:noHistory="true"
             >
 
             <intent-filter android:autoVerify="true">

--- a/hooks/prebuild.js
+++ b/hooks/prebuild.js
@@ -22,6 +22,14 @@ module.exports = function (ctx) {
     'utf8'
   );
 
+  const appPluginPath = path.resolve(process.cwd(), 'node_modules/@capacitor/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java');
+  const appPluginContent = fs.readFileSync(appPluginPath).toString();
+  fs.writeFileSync(
+    appPluginPath,
+    appPluginContent.replace('startMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)', 'startMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK)'),
+    'utf8'
+  );
+
   if (!process.env.NATIVE_CONFIG) {
     return;
   }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 646669a</samp>

Add a flag to the capacitor app plugin to clear the activity stack on logout. This prevents the user from accessing the app after logging out by pressing the back button.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 646669a</samp>

> _`startMain` intent_
> _adds a clear task flag now_
> _autumn leaves the past_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 646669a</samp>

*  Add the Intent.FLAG_ACTIVITY_CLEAR_TASK flag to the startMain intent in AppPlugin.java to clear the activity stack when launching the main activity ([link](https://github.com/fylein/fyle-mobile-app/pull/2153/files?diff=unified&w=0#diff-17e476b0cdcbe5e09e43f71ba2b3803f4ba1718144b81f15388ddd6cf4a7a355R25-R32))

## Clickup
https://app.clickup.com/t/85zt0ahaa

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes