### PR TITLE
fix: changing date of spend to local time

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
@@ -66,6 +66,8 @@ import { ToastMessageComponent } from 'src/app/shared/components/toast-message/t
 import { AddEditExpensePage } from './add-edit-expense.page';
 import { setFormValid } from './add-edit-expense.setup.spec';
 import { SuggestedDuplicatesComponent } from './suggested-duplicates/suggested-duplicates.component';
+import { orgUserSettingsData } from 'src/app/core/mock-data/org-user-settings.data';
+import { cloneDeep } from 'lodash';
 
 const properties = {
   cssClass: 'fy-modal',
@@ -1056,5 +1058,38 @@ export function TestCases2(getTestBed) {
         cssClass: 'pop-up-in-center',
       });
     }));
+
+    describe('updateCardTransactionDate(): ', () => {
+      beforeEach(() => {
+        component.orgUserSettings$ = of(orgUserSettingsData);
+        component.selectedCCCTransaction = {
+          txn_dt: '2023-07-07T20:19:47.514Z',
+        };
+      });
+
+      it('should set card transaction date to Canberra timezone if user has selected Australia/Canberra timezone', () => {
+        const mockOrgUserSettingsData = cloneDeep(orgUserSettingsData);
+        mockOrgUserSettingsData.locale = {
+          timezone: 'Australia/Canberra',
+          abbreviation: 'AEST',
+          offset: '10:00:00',
+        };
+        component.orgUserSettings$ = of(mockOrgUserSettingsData);
+        component.updateCardTransactionDate();
+        expect(component.selectedCCCTransaction.txn_dt).toEqual('Jul 08, 2023');
+      });
+
+      it('should set card transaction date to New York timezone if user has selected America/New_York timezone', () => {
+        const mockOrgUserSettingsData = cloneDeep(orgUserSettingsData);
+        mockOrgUserSettingsData.locale = {
+          timezone: 'America/New_York',
+          abbreviation: 'EDT',
+          offset: '-04:00:00',
+        };
+        component.orgUserSettings$ = of(mockOrgUserSettingsData);
+        component.updateCardTransactionDate();
+        expect(component.selectedCCCTransaction.txn_dt).toEqual('Jul 07, 2023');
+      });
+    });
   });
 }

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -143,9 +143,7 @@
               </ion-col>
               <ion-col>
                 <div class="add-edit-expense--card-container__label">Spend Date</div>
-                <div class="add-edit-expense--card-container__value">
-                  {{ selectedCCCTransaction?.txn_dt | date: 'MMM dd, YYYY' }}
-                </div>
+                <div class="add-edit-expense--card-container__value">{{ selectedCCCTransaction?.txn_dt }}</div>
               </ion-col>
               <ion-col>
                 <div class="add-edit-expense--card-container__label">Spend Amount</div>

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1638,7 +1638,7 @@ export class AddEditExpensePage implements OnInit {
             {
               project,
               category,
-              dateOfSpend: etxn.tx.txn_dt && dayjs(this.dateService.getLocalDate(etxn.tx.txn_dt)).format('YYYY-MM-DD'),
+              dateOfSpend: etxn.tx.txn_dt && dayjs(etxn.tx.txn_dt).format('YYYY-MM-DD'),
               vendor_id: etxn.tx.vendor
                 ? {
                     display_name: etxn.tx.vendor,

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -2357,6 +2357,14 @@ export class AddEditExpensePage implements OnInit {
     }
   }
 
+  updateCardTransactionDate() {
+    this.orgUserSettings$.subscribe((orgUserSettings) => {
+      const localDate = new Date(this.selectedCCCTransaction.txn_dt);
+      const localDateString = localDate.toLocaleString('en-US', { timeZone: orgUserSettings.locale.timezone });
+      this.selectedCCCTransaction.txn_dt = dayjs(localDateString).format('MMM DD, YYYY');
+    });
+  }
+
   ionViewWillEnter() {
     this.isNewReportsFlowEnabled = false;
     this.onPageExit$ = new Subject();
@@ -2647,11 +2655,7 @@ export class AddEditExpensePage implements OnInit {
           .subscribe((matchedExpense: CCCExpUnflattened[]) => {
             this.matchedCCCTransaction = matchedExpense[0].ccce;
             this.selectedCCCTransaction = this.matchedCCCTransaction;
-            this.orgUserSettings$.subscribe((orgUserSettings) => {
-              const localDate = new Date(this.selectedCCCTransaction.txn_dt);
-              const localDateString = localDate.toLocaleString('en-US', { timeZone: orgUserSettings.locale.timezone });
-              this.selectedCCCTransaction.txn_dt = dayjs(localDateString).format('MMM DD, YYYY');
-            });
+            this.updateCardTransactionDate();
             this.cardEndingDigits = (
               this.selectedCCCTransaction.cxorporate_credit_card_account_number
                 ? this.selectedCCCTransaction.corporate_credit_card_account_number

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -2647,6 +2647,11 @@ export class AddEditExpensePage implements OnInit {
           .subscribe((matchedExpense: CCCExpUnflattened[]) => {
             this.matchedCCCTransaction = matchedExpense[0].ccce;
             this.selectedCCCTransaction = this.matchedCCCTransaction;
+            this.orgUserSettings$.subscribe((orgUserSettings) => {
+              const localDate = new Date(this.selectedCCCTransaction.txn_dt);
+              const localDateString = localDate.toLocaleString('en-US', { timeZone: orgUserSettings.locale.timezone });
+              this.selectedCCCTransaction.txn_dt = dayjs(localDateString).format('MMM DD, YYYY');
+            });
             this.cardEndingDigits = (
               this.selectedCCCTransaction.cxorporate_credit_card_account_number
                 ? this.selectedCCCTransaction.corporate_credit_card_account_number

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1638,7 +1638,7 @@ export class AddEditExpensePage implements OnInit {
             {
               project,
               category,
-              dateOfSpend: etxn.tx.txn_dt && dayjs(etxn.tx.txn_dt).format('YYYY-MM-DD'),
+              dateOfSpend: etxn.tx.txn_dt && dayjs(this.dateService.getLocalDate(etxn.tx.txn_dt)).format('YYYY-MM-DD'),
               vendor_id: etxn.tx.vendor
                 ? {
                     display_name: etxn.tx.vendor,


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 162a29f</samp>

Fixed the formatting and timezone conversion of the spend date for corporate credit card transactions in the `add-edit-expense` page. Used the `dayjs` library and the org user settings to display the date correctly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 162a29f</samp>

> _`spendDate` formatted_
> _with timezone and dayjs_
> _autumn leaves fall_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 162a29f</samp>

*  Format the spend date of corporate credit card transactions according to the org user settings timezone and dayjs library ([link](https://github.com/fylein/fyle-mobile-app/pull/2168/files?diff=unified&w=0#diff-222fd948c0d0cdfd9422c33d7e78705dddeb3bb00664d65ab64f77331691bf2cL146-R146), [link](https://github.com/fylein/fyle-mobile-app/pull/2168/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bR2650-R2654))

## Clickup
app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes