### PR TITLE
test: 100% coverage of team reports page

### DIFF
--- a/src/app/core/mock-data/modal-controller.data.ts
+++ b/src/app/core/mock-data/modal-controller.data.ts
@@ -1,6 +1,6 @@
 import { FyFiltersComponent } from 'src/app/shared/components/fy-filters/fy-filters.component';
 import { filterOptions1 } from './filter.data';
-import { selectedFilters1, taskSelectedFiltersData } from './selected-filters.data';
+import { selectedFilters1, selectedFilters4, taskSelectedFiltersData } from './selected-filters.data';
 import { FilterOptionType } from 'src/app/shared/components/fy-filters/filter-option-type.enum';
 import { CreateNewReportComponent } from 'src/app/shared/components/create-new-report/create-new-report.component';
 import { apiExpenseRes } from './expense.data';
@@ -9,6 +9,7 @@ import { fyModalProperties } from './model-properties.data';
 import { AddTxnToReportDialogComponent } from 'src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component';
 import { PopupAlertComponent } from 'src/app/shared/components/popup-alert/popup-alert.component';
 import { FilterOptions } from 'src/app/shared/components/fy-filters/filter-options.interface';
+import { DateFilters } from 'src/app/shared/components/fy-filters/date-filters.enum';
 
 export const modalControllerParams = {
   component: FyFiltersComponent,
@@ -197,6 +198,114 @@ export const taskModalControllerParams2 = {
     ],
     selectedFilterValues: taskSelectedFiltersData,
     activeFilterInitialName: undefined,
+  },
+  cssClass: 'dialog-popover',
+};
+
+export const teamReportsModalControllerParams = {
+  component: FyFiltersComponent,
+  componentProps: {
+    filterOptions: [
+      {
+        name: 'State',
+        optionType: FilterOptionType.multiselect,
+        options: [
+          {
+            label: 'Reported',
+            value: 'APPROVER_PENDING',
+          },
+          {
+            label: 'Sent Back',
+            value: 'APPROVER_INQUIRY',
+          },
+          {
+            label: 'Approved',
+            value: 'APPROVED',
+          },
+          {
+            label: 'Paid',
+            value: 'PAID',
+          },
+        ],
+        optionsNewFlow: [
+          {
+            label: 'Submitted',
+            value: 'APPROVER_PENDING',
+          },
+          {
+            label: 'Sent Back',
+            value: 'APPROVER_INQUIRY',
+          },
+          {
+            label: 'Approved',
+            value: 'APPROVED',
+          },
+          {
+            label: 'Closed',
+            value: 'PAID',
+          },
+        ],
+      } as FilterOptions<string>,
+      {
+        name: 'Submitted Date',
+        optionType: FilterOptionType.date,
+        options: [
+          {
+            label: 'All',
+            value: DateFilters.all,
+          },
+          {
+            label: 'This Week',
+            value: DateFilters.thisWeek,
+          },
+          {
+            label: 'This Month',
+            value: DateFilters.thisMonth,
+          },
+          {
+            label: 'Last Month',
+            value: DateFilters.lastMonth,
+          },
+          {
+            label: 'Custom',
+            value: DateFilters.custom,
+          },
+        ],
+      } as FilterOptions<DateFilters>,
+      {
+        name: 'Sort By',
+        optionType: FilterOptionType.singleselect,
+        options: [
+          {
+            label: 'Submitted Date - New to Old',
+            value: 'dateNewToOld',
+          },
+          {
+            label: 'Submitted Date - Old to New',
+            value: 'dateOldToNew',
+          },
+          {
+            label: 'Amount - High to Low',
+            value: 'amountHighToLow',
+          },
+          {
+            label: 'Amount - Low to High',
+            value: 'amountLowToHigh',
+          },
+          {
+            label: 'Name - A to Z',
+            value: 'nameAToZ',
+          },
+          {
+            label: 'Name - Z to A',
+            value: 'nameZToA',
+          },
+        ],
+      } as FilterOptions<string>,
+    ],
+    simplifyReportsSettings$: undefined,
+    selectedFilterValues: selectedFilters4,
+    activeFilterInitialName: 'State',
   },
   cssClass: 'dialog-popover',
 };

--- a/src/app/core/mock-data/team-reports-filters.data.ts
+++ b/src/app/core/mock-data/team-reports-filters.data.ts
@@ -38,3 +38,26 @@ export const teamReportsFiltersData4: Partial<TeamReportsFilters> = {
   customDateStart: undefined,
   customDateEnd: undefined,
 };
+
+export const teamReportsFiltersParams3: Partial<TeamReportsFilters> = {
+  state: ['DRAFT', 'PAID', 'CANCELLED'],
+};
+
+export const teamReportsFiltersParams4: Partial<TeamReportsFilters> = {
+  sortParam: 'rp_submitted_at',
+  sortDir: 'asc',
+};
+
+export const teamReportsFiltersParams5: Partial<TeamReportsFilters> = {
+  sortParam: 'rp_amount',
+  sortDir: 'desc',
+};
+
+export const teamReportsFiltersParams6: Partial<TeamReportsFilters> = {
+  sortParam: 'rp_purpose',
+  sortDir: 'asc',
+};
+
+export const teamReportsFiltersParams7: Partial<TeamReportsFilters> = {
+  date: 'thisWeek',
+};

--- a/src/app/fyle/team-reports/team-reports-4.page.spec.ts
+++ b/src/app/fyle/team-reports/team-reports-4.page.spec.ts
@@ -1,0 +1,438 @@
+import { ComponentFixture, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { ModalController } from '@ionic/angular';
+
+import { TeamReportsPage } from './team-reports.page';
+import { NetworkService } from 'src/app/core/services/network.service';
+import { LoaderService } from 'src/app/core/services/loader.service';
+import { ReportService } from 'src/app/core/services/report.service';
+import { DateService } from 'src/app/core/services/date.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { CurrencyService } from 'src/app/core/services/currency.service';
+import { PopupService } from 'src/app/core/services/popup.service';
+import { TrackingService } from 'src/app/core/services/tracking.service';
+import { ApiV2Service } from 'src/app/core/services/api-v2.service';
+import { TasksService } from 'src/app/core/services/tasks.service';
+import { OrgSettingsService } from 'src/app/core/services/org-settings.service';
+import { BehaviorSubject, of } from 'rxjs';
+import { FilterPill } from 'src/app/shared/components/fy-filter-pills/filter-pill.interface';
+import {
+  teamReportsFiltersData,
+  teamReportsFiltersData2,
+  teamReportsFiltersData3,
+  teamReportsFiltersParams2,
+  teamReportsFiltersParams3,
+  teamReportsFiltersParams4,
+  teamReportsFiltersParams5,
+  teamReportsFiltersParams6,
+  teamReportsFiltersParams7,
+} from 'src/app/core/mock-data/team-reports-filters.data';
+import { cloneDeep } from 'lodash';
+import { TeamReportsFilters } from 'src/app/core/models/team-reports-filters.model';
+import { selectedFilters4 } from 'src/app/core/mock-data/selected-filters.data';
+import {
+  tasksQueryParamsWithFiltersData2,
+  tasksQueryParamsWithFiltersData3,
+} from 'src/app/core/mock-data/get-tasks-query-params-with-filters.data';
+import { creditTxnFilterPill } from 'src/app/core/mock-data/filter-pills.data';
+import { teamReportsModalControllerParams } from 'src/app/core/mock-data/modal-controller.data';
+
+export function TestCases4(getTestBed) {
+  return describe('test cases set 3', () => {
+    let component: TeamReportsPage;
+    let fixture: ComponentFixture<TeamReportsPage>;
+    let networkService: jasmine.SpyObj<NetworkService>;
+    let loaderService: jasmine.SpyObj<LoaderService>;
+    let reportService: jasmine.SpyObj<ReportService>;
+    let modalController: jasmine.SpyObj<ModalController>;
+    let dateService: jasmine.SpyObj<DateService>;
+    let router: jasmine.SpyObj<Router>;
+    let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+    let currencyService: jasmine.SpyObj<CurrencyService>;
+    let popupService: jasmine.SpyObj<PopupService>;
+    let trackingService: jasmine.SpyObj<TrackingService>;
+    let apiV2Service: jasmine.SpyObj<ApiV2Service>;
+    let tasksService: jasmine.SpyObj<TasksService>;
+    let orgSettingsService: jasmine.SpyObj<OrgSettingsService>;
+    let inputElement: HTMLInputElement;
+
+    beforeEach(waitForAsync(() => {
+      const TestBed = getTestBed();
+      fixture = TestBed.createComponent(TeamReportsPage);
+      component = fixture.componentInstance;
+      networkService = TestBed.inject(NetworkService) as jasmine.SpyObj<NetworkService>;
+      loaderService = TestBed.inject(LoaderService) as jasmine.SpyObj<LoaderService>;
+      reportService = TestBed.inject(ReportService) as jasmine.SpyObj<ReportService>;
+      modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
+      dateService = TestBed.inject(DateService) as jasmine.SpyObj<DateService>;
+      router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+      currencyService = TestBed.inject(CurrencyService) as jasmine.SpyObj<CurrencyService>;
+      popupService = TestBed.inject(PopupService) as jasmine.SpyObj<PopupService>;
+      trackingService = TestBed.inject(TrackingService) as jasmine.SpyObj<TrackingService>;
+      activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
+      apiV2Service = TestBed.inject(ApiV2Service) as jasmine.SpyObj<ApiV2Service>;
+      tasksService = TestBed.inject(TasksService) as jasmine.SpyObj<TasksService>;
+      orgSettingsService = TestBed.inject(OrgSettingsService) as jasmine.SpyObj<OrgSettingsService>;
+    }));
+
+    it('generateStateFilterPills(): should update filter pills', () => {
+      component.simplifyReportsSettings$ = of({
+        enabled: true,
+      });
+      const filterPill: FilterPill[] = [];
+      component.generateStateFilterPills(filterPill, teamReportsFiltersParams3);
+      expect(filterPill).toEqual([
+        {
+          label: 'State',
+          type: 'state',
+          value: 'draft, closed, cancelled',
+        },
+      ]);
+    });
+
+    describe('generateCustomDatePill(): ', () => {
+      it('should update filter pills with start and end date if customDateStart and customDateEnd are defined', () => {
+        const filterPill: FilterPill[] = [];
+        component.generateCustomDatePill(teamReportsFiltersData3, filterPill);
+
+        expect(filterPill).toEqual([
+          {
+            label: 'Submitted Date',
+            type: 'date',
+            value: '2023-01-1 to 2023-02-2',
+          },
+        ]);
+      });
+
+      it('should update filter pills with start date if customDateEnd is undefined', () => {
+        const filterPill: FilterPill[] = [];
+        const mockTeamReportsFiltersData3 = cloneDeep(teamReportsFiltersData3);
+        mockTeamReportsFiltersData3.customDateEnd = undefined;
+        component.generateCustomDatePill(mockTeamReportsFiltersData3, filterPill);
+
+        expect(filterPill).toEqual([
+          {
+            label: 'Submitted Date',
+            type: 'date',
+            value: '>= 2023-01-1',
+          },
+        ]);
+      });
+
+      it('should update filter pills with end date if customDateStart is undefined', () => {
+        const filterPill: FilterPill[] = [];
+        const mockTeamReportsFiltersData3 = cloneDeep(teamReportsFiltersData3);
+        mockTeamReportsFiltersData3.customDateStart = undefined;
+        component.generateCustomDatePill(mockTeamReportsFiltersData3, filterPill);
+
+        expect(filterPill).toEqual([
+          {
+            label: 'Submitted Date',
+            type: 'date',
+            value: '<= 2023-02-2',
+          },
+        ]);
+      });
+
+      it('should not update filter pills if customDateStart and customDateEnd are undefined', () => {
+        const filterPill: FilterPill[] = [];
+        component.generateCustomDatePill(teamReportsFiltersParams2, filterPill);
+
+        expect(filterPill).toEqual([]);
+      });
+    });
+
+    describe('generateDateFilterPills(): ', () => {
+      it('should update filter pills value to this Week if dateFilter is thisWeek', () => {
+        const mockTeamReportsFilters: Partial<TeamReportsFilters> = {
+          date: 'thisWeek',
+        };
+        const filterPill: FilterPill[] = [];
+        component.generateDateFilterPills(mockTeamReportsFilters, filterPill);
+        expect(filterPill).toEqual([
+          {
+            label: 'Submitted Date',
+            type: 'date',
+            value: 'this Week',
+          },
+        ]);
+      });
+
+      it('should update filter pills value to this Month if dateFilter is thisMonth', () => {
+        const mockTeamReportsFilters: Partial<TeamReportsFilters> = {
+          date: 'thisMonth',
+        };
+        const filterPill: FilterPill[] = [];
+        component.generateDateFilterPills(mockTeamReportsFilters, filterPill);
+        expect(filterPill).toEqual([
+          {
+            label: 'Submitted Date',
+            type: 'date',
+            value: 'this Month',
+          },
+        ]);
+      });
+
+      it('should update filter pills value to All if dateFilter is all', () => {
+        const mockTeamReportsFilters: Partial<TeamReportsFilters> = {
+          date: 'all',
+        };
+        const filterPill: FilterPill[] = [];
+        component.generateDateFilterPills(mockTeamReportsFilters, filterPill);
+        expect(filterPill).toEqual([
+          {
+            label: 'Submitted Date',
+            type: 'date',
+            value: 'All',
+          },
+        ]);
+      });
+
+      it('should update filter pills value to Last Month if dateFilter is lastMonth', () => {
+        const mockTeamReportsFilters: Partial<TeamReportsFilters> = {
+          date: 'lastMonth',
+        };
+        const filterPill: FilterPill[] = [];
+        component.generateDateFilterPills(mockTeamReportsFilters, filterPill);
+        expect(filterPill).toEqual([
+          {
+            label: 'Submitted Date',
+            type: 'date',
+            value: 'Last Month',
+          },
+        ]);
+      });
+
+      it('should call generateCustomDatePill if dateFilter is custom', () => {
+        spyOn(component, 'generateCustomDatePill').and.callThrough();
+        const mockTeamReportsFilters: Partial<TeamReportsFilters> = {
+          date: 'custom',
+          customDateStart: new Date('2023-01-01'),
+        };
+        const filterPill: FilterPill[] = [];
+        component.generateDateFilterPills(mockTeamReportsFilters, filterPill);
+        expect(component.generateCustomDatePill).toHaveBeenCalledOnceWith(mockTeamReportsFilters, filterPill);
+        expect(filterPill).toEqual([
+          {
+            label: 'Submitted Date',
+            type: 'date',
+            value: '>= 2023-01-1',
+          },
+        ]);
+      });
+    });
+
+    describe('generateSortRptDatePills(): ', () => {
+      it('should update filter pills value to old to new if sortParam is rp_submitted_at and direction is asc', () => {
+        const filterPill: FilterPill[] = [];
+        component.generateSortRptDatePills(teamReportsFiltersParams4, filterPill);
+        expect(filterPill).toEqual([
+          {
+            label: 'Sort By',
+            type: 'sort',
+            value: 'Submitted date - old to new',
+          },
+        ]);
+      });
+
+      it('should update filter pills value to new to old if sortParam is rp_submitted_at and direction is desc', () => {
+        const filterPill: FilterPill[] = [];
+        const mockTeamReportsFiltersParams = cloneDeep(teamReportsFiltersParams4);
+        mockTeamReportsFiltersParams.sortDir = 'desc';
+        component.generateSortRptDatePills(mockTeamReportsFiltersParams, filterPill);
+        expect(filterPill).toEqual([
+          {
+            label: 'Sort By',
+            type: 'sort',
+            value: 'Submitted date - new to old',
+          },
+        ]);
+      });
+    });
+
+    describe('generateSortAmountPills(): ', () => {
+      it('should update filter pills value to high to low if sortParam is rp_amount and direction is desc', () => {
+        const filterPill: FilterPill[] = [];
+        component.generateSortAmountPills(teamReportsFiltersParams5, filterPill);
+        expect(filterPill).toEqual([
+          {
+            label: 'Sort By',
+            type: 'sort',
+            value: 'amount - high to low',
+          },
+        ]);
+      });
+
+      it('should update filter pills value to new to old if sortParam is rp_submitted_at and direction is asc', () => {
+        const filterPill: FilterPill[] = [];
+        const mockTeamReportsFiltersParams = cloneDeep(teamReportsFiltersParams5);
+        mockTeamReportsFiltersParams.sortDir = 'asc';
+        component.generateSortAmountPills(mockTeamReportsFiltersParams, filterPill);
+        expect(filterPill).toEqual([
+          {
+            label: 'Sort By',
+            type: 'sort',
+            value: 'amount - low to high',
+          },
+        ]);
+      });
+    });
+
+    describe('generateSortNamePills(): ', () => {
+      it('should update filter pills value to a to z if sortParam is rp_purpose and direction is asc', () => {
+        const filterPill: FilterPill[] = [];
+        component.generateSortNamePills(teamReportsFiltersParams6, filterPill);
+        expect(filterPill).toEqual([
+          {
+            label: 'Sort By',
+            type: 'sort',
+            value: 'Name - a to z',
+          },
+        ]);
+      });
+
+      it('should update filter pills value to z to a if sortParam is rp_purpose and direction is desc', () => {
+        const filterPill: FilterPill[] = [];
+        const mockTeamReportsFiltersParams = cloneDeep(teamReportsFiltersParams6);
+        mockTeamReportsFiltersParams.sortDir = 'desc';
+        component.generateSortNamePills(mockTeamReportsFiltersParams, filterPill);
+        expect(filterPill).toEqual([
+          {
+            label: 'Sort By',
+            type: 'sort',
+            value: 'Name - z to a',
+          },
+        ]);
+      });
+    });
+
+    it('generateSortFilterPills(): should call generateSortRptDatePills, generateSortAmountPills, generateSortNamePills and update filter pills based on sortParam and sortDir', () => {
+      spyOn(component, 'generateSortRptDatePills').and.callThrough();
+      spyOn(component, 'generateSortAmountPills').and.callThrough();
+      spyOn(component, 'generateSortNamePills').and.callThrough();
+      const filterPill: FilterPill[] = [];
+      component.generateSortFilterPills(teamReportsFiltersParams5, filterPill);
+      expect(component.generateSortRptDatePills).toHaveBeenCalledOnceWith(teamReportsFiltersParams5, filterPill);
+      expect(component.generateSortAmountPills).toHaveBeenCalledOnceWith(teamReportsFiltersParams5, filterPill);
+      expect(component.generateSortNamePills).toHaveBeenCalledOnceWith(teamReportsFiltersParams5, filterPill);
+      expect(filterPill).toEqual([
+        {
+          label: 'Sort By',
+          type: 'sort',
+          value: 'amount - high to low',
+        },
+      ]);
+    });
+
+    describe('generateFilterPills(): ', () => {
+      beforeEach(() => {
+        component.simplifyReportsSettings$ = of({
+          enabled: true,
+        });
+        spyOn(component, 'generateSortRptDatePills').and.callThrough();
+        spyOn(component, 'generateSortAmountPills').and.callThrough();
+        spyOn(component, 'generateSortNamePills').and.callThrough();
+        spyOn(component, 'generateStateFilterPills').and.callThrough();
+        spyOn(component, 'generateDateFilterPills').and.callThrough();
+        spyOn(component, 'generateSortFilterPills').and.callThrough();
+      });
+
+      it('should call generateStateFilterPills if state is defined in filter and return the filter pill', () => {
+        const filterPill = component.generateFilterPills(teamReportsFiltersParams3);
+        expect(component.generateStateFilterPills).toHaveBeenCalledTimes(1);
+        expect(component.generateDateFilterPills).not.toHaveBeenCalled();
+        expect(component.generateSortFilterPills).not.toHaveBeenCalled();
+        expect(filterPill).toEqual([
+          {
+            label: 'State',
+            type: 'state',
+            value: 'draft, closed, cancelled',
+          },
+        ]);
+      });
+
+      it('should call generateDateFilterPills if date is defined in filter and return the filter pill', () => {
+        const filterPill = component.generateFilterPills(teamReportsFiltersParams7);
+        expect(component.generateDateFilterPills).toHaveBeenCalledTimes(1);
+        expect(component.generateStateFilterPills).not.toHaveBeenCalled();
+        expect(component.generateSortFilterPills).not.toHaveBeenCalled();
+        expect(filterPill).toEqual([
+          {
+            label: 'Submitted Date',
+            type: 'date',
+            value: 'this Week',
+          },
+        ]);
+      });
+
+      it('should call generateSortFilterPills if sortParam and sortDir are defined in filter and return the filter pill', () => {
+        const filterPill = component.generateFilterPills(teamReportsFiltersParams5);
+        expect(component.generateDateFilterPills).not.toHaveBeenCalled();
+        expect(component.generateStateFilterPills).not.toHaveBeenCalled();
+        expect(component.generateSortFilterPills).toHaveBeenCalledTimes(1);
+        expect(filterPill).toEqual([
+          {
+            label: 'Sort By',
+            type: 'sort',
+            value: 'amount - high to low',
+          },
+        ]);
+      });
+    });
+
+    describe('convertAmountSortToSelectedFilters(): ', () => {
+      it('should update the generatedFilters passed as argument if sortParam is rp_amount and direction is desc', () => {
+        const generatedFilters = [];
+        component.convertAmountSortToSelectedFilters(teamReportsFiltersParams5, generatedFilters);
+        expect(generatedFilters).toEqual([
+          {
+            name: 'Sort By',
+            value: 'amountHighToLow',
+          },
+        ]);
+      });
+
+      it('should update the generatedFilters passed as argument if sortParam is rp_amount and direction is asc', () => {
+        const generatedFilters = [];
+        const mockTeamReportsFiltersParams = cloneDeep(teamReportsFiltersParams5);
+        mockTeamReportsFiltersParams.sortDir = 'asc';
+        component.convertAmountSortToSelectedFilters(mockTeamReportsFiltersParams, generatedFilters);
+        expect(generatedFilters).toEqual([
+          {
+            name: 'Sort By',
+            value: 'amountLowToHigh',
+          },
+        ]);
+      });
+    });
+
+    it('should open a modal with filter options, set current page as 1 and call trackingService.TeamReportsFilterApplied', fakeAsync(() => {
+      const filterPopoverSpy = jasmine.createSpyObj('filterPopover', ['present', 'onWillDismiss']);
+      filterPopoverSpy.onWillDismiss.and.resolveTo({ data: selectedFilters4 });
+      modalController.create.and.resolveTo(filterPopoverSpy);
+      spyOn(component, 'convertFilters').and.returnValue(teamReportsFiltersData);
+      spyOn(component, 'addNewFiltersToParams').and.returnValue(tasksQueryParamsWithFiltersData3);
+      spyOn(component, 'generateFilterPills').and.returnValue(creditTxnFilterPill);
+      component.filters = cloneDeep(teamReportsFiltersData2);
+      spyOn(component, 'generateSelectedFilters').and.returnValue(selectedFilters4);
+      component.loadData$ = cloneDeep(new BehaviorSubject(tasksQueryParamsWithFiltersData2));
+
+      component.openFilters('State');
+      tick(100);
+
+      expect(modalController.create).toHaveBeenCalledOnceWith(teamReportsModalControllerParams);
+      expect(component.generateSelectedFilters).toHaveBeenCalledOnceWith(teamReportsFiltersData2);
+      expect(component.convertFilters).toHaveBeenCalledOnceWith(selectedFilters4);
+      expect(component.filters).toEqual(teamReportsFiltersData);
+      expect(component.currentPageNumber).toBe(1);
+      expect(component.addNewFiltersToParams).toHaveBeenCalledTimes(1);
+      component.loadData$.subscribe((data) => {
+        expect(data).toEqual(tasksQueryParamsWithFiltersData3);
+      });
+      expect(component.generateFilterPills).toHaveBeenCalledOnceWith(teamReportsFiltersData);
+      expect(component.filterPills).toEqual(creditTxnFilterPill);
+      expect(trackingService.TeamReportsFilterApplied).toHaveBeenCalledOnceWith({
+        ...teamReportsFiltersData,
+      });
+    }));
+  });
+}

--- a/src/app/fyle/team-reports/team-reports.page.setup.spec.ts
+++ b/src/app/fyle/team-reports/team-reports.page.setup.spec.ts
@@ -17,6 +17,7 @@ import { TestCases1 } from './team-reports-1.page.spec';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TestCases2 } from './team-reports-2.page.spec';
 import { TestCases3 } from './team-reports-3.page.spec';
+import { TestCases4 } from './team-reports-4.page.spec';
 
 describe('TeamReportsPage', () => {
   const getTestBed = () => {
@@ -77,4 +78,5 @@ describe('TeamReportsPage', () => {
   TestCases1(getTestBed);
   TestCases2(getTestBed);
   TestCases3(getTestBed);
+  TestCases4(getTestBed);
 });

--- a/src/app/fyle/team-reports/team-reports.page.ts
+++ b/src/app/fyle/team-reports/team-reports.page.ts
@@ -563,19 +563,19 @@ export class TeamReportsPage implements OnInit {
     return generatedFilters;
   }
 
-  generateStateFilterPills(filterPills: FilterPill[], filter) {
+  generateStateFilterPills(filterPills: FilterPill[], filter: Partial<TeamReportsFilters>) {
     this.simplifyReportsSettings$.subscribe((simplifyReportsSettings) => {
       filterPills.push({
         label: 'State',
         type: 'state',
-        value: filter.state
+        value: (filter.state as string[])
           .map((state) => this.reportStatePipe.transform(state, simplifyReportsSettings.enabled))
           .reduce((state1, state2) => `${state1}, ${state2}`),
       });
     });
   }
 
-  generateCustomDatePill(filter: any, filterPills: FilterPill[]) {
+  generateCustomDatePill(filter: Partial<TeamReportsFilters>, filterPills: FilterPill[]) {
     const startDate = filter.customDateStart && dayjs(filter.customDateStart).format('YYYY-MM-D');
     const endDate = filter.customDateEnd && dayjs(filter.customDateEnd).format('YYYY-MM-D');
 
@@ -600,7 +600,7 @@ export class TeamReportsPage implements OnInit {
     }
   }
 
-  generateDateFilterPills(filter, filterPills: FilterPill[]) {
+  generateDateFilterPills(filter: Partial<TeamReportsFilters>, filterPills: FilterPill[]) {
     if (filter.date === DateFilters.thisWeek) {
       filterPills.push({
         label: 'Submitted Date',
@@ -638,7 +638,7 @@ export class TeamReportsPage implements OnInit {
     }
   }
 
-  generateSortRptDatePills(filter: any, filterPills: FilterPill[]) {
+  generateSortRptDatePills(filter: Partial<TeamReportsFilters>, filterPills: FilterPill[]) {
     if (filter.sortParam === 'rp_submitted_at' && filter.sortDir === 'asc') {
       filterPills.push({
         label: 'Sort By',
@@ -654,7 +654,7 @@ export class TeamReportsPage implements OnInit {
     }
   }
 
-  generateSortAmountPills(filter: any, filterPills: FilterPill[]) {
+  generateSortAmountPills(filter: Partial<TeamReportsFilters>, filterPills: FilterPill[]) {
     if (filter.sortParam === 'rp_amount' && filter.sortDir === 'desc') {
       filterPills.push({
         label: 'Sort By',
@@ -670,7 +670,7 @@ export class TeamReportsPage implements OnInit {
     }
   }
 
-  generateSortNamePills(filter: any, filterPills: FilterPill[]) {
+  generateSortNamePills(filter: Partial<TeamReportsFilters>, filterPills: FilterPill[]) {
     if (filter.sortParam === 'rp_purpose' && filter.sortDir === 'asc') {
       filterPills.push({
         label: 'Sort By',
@@ -686,7 +686,7 @@ export class TeamReportsPage implements OnInit {
     }
   }
 
-  generateSortFilterPills(filter, filterPills: FilterPill[]) {
+  generateSortFilterPills(filter: Partial<TeamReportsFilters>, filterPills: FilterPill[]) {
     this.generateSortRptDatePills(filter, filterPills);
 
     this.generateSortAmountPills(filter, filterPills);


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 008aa62</samp>

Added and refactored tests and mock data for the team reports feature. Improved the type-safety of the filter parameter in `team-reports.page.ts`. Used `Partial<TeamReportsFilters>` instead of `any` for better readability and error prevention.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 008aa62</samp>

> _We mock the data, we test the code_
> _We filter the reports, we face the load_
> _We refactor the types, we avoid the `any`_
> _We rock the team, we defy the enemy_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 008aa62</samp>

*  Change the `filter` parameter type from `any` to `Partial<TeamReportsFilters>` in six methods of the `team-reports.page.ts` file to improve type safety and consistency ([link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-3ccc9338e2efb6f5e87dcb962c41933667b5e6a3477accd2534ccb98af447596L566-R571), [link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-3ccc9338e2efb6f5e87dcb962c41933667b5e6a3477accd2534ccb98af447596L578-R578), [link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-3ccc9338e2efb6f5e87dcb962c41933667b5e6a3477accd2534ccb98af447596L603-R603), [link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-3ccc9338e2efb6f5e87dcb962c41933667b5e6a3477accd2534ccb98af447596L641-R641), [link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-3ccc9338e2efb6f5e87dcb962c41933667b5e6a3477accd2534ccb98af447596L657-R657), [link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-3ccc9338e2efb6f5e87dcb962c41933667b5e6a3477accd2534ccb98af447596L673-R673), [link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-3ccc9338e2efb6f5e87dcb962c41933667b5e6a3477accd2534ccb98af447596L689-R689))
* Add mock data for the team reports filters component in the `modal-controller.data.ts` file, including the filter options, the selected filter values, and the active filter initial name ([link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-32f470962ca37f24fcdc6eaf809fb30dc2ce6a9e003b41b20b34908107e83805L3-R3), [link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-32f470962ca37f24fcdc6eaf809fb30dc2ce6a9e003b41b20b34908107e83805R12), [link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-32f470962ca37f24fcdc6eaf809fb30dc2ce6a9e003b41b20b34908107e83805R204-R311))
* Add mock data for the team reports filters parameters in the `team-reports-filters.data.ts` file, including different combinations of state, sort, and date filters ([link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-401236e03ce641ab4d611952b13e82e77b594e9354757be5ffb25132b48e1c90R41-R63))
* Add a test suite for the team reports page with different filter scenarios in the `team-reports.page.setup.spec.ts` file, using the `TestCases4` function from the `team-reports-4.page.spec` file ([link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-35c5d9087f10bb379b3c726e6e332f85a6d6f39dc932ad40ee50015db7164e5aR20), [link](https://github.com/fylein/fyle-mobile-app/pull/2171/files?diff=unified&w=0#diff-35c5d9087f10bb379b3c726e6e332f85a6d6f39dc932ad40ee50015db7164e5aR81))

## Clickup
https://app.clickup.com/t/85ztdnyya

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes