### PR TITLE
test: Code Coverage: Add Edit Expense #6 Part 2

### DIFF
--- a/src/app/core/mock-data/unflattened-txn.data.ts
+++ b/src/app/core/mock-data/unflattened-txn.data.ts
@@ -1414,3 +1414,8 @@ export const unflattenedTxnDataWithoutCategoryData2: UnflattenedTransaction = {
     fyle_category: 'unspecified',
   },
 };
+
+export const unflattenedTransactionDataPersonalCard = {
+  ...expectedUnflattendedTxnData3.tx,
+  locations: null,
+};


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54206fb</samp>

This pull request improves the `add-edit-expense` component by adding and updating unit tests, refactoring the code, and adding a tracking event. It also adds a new mock data object for testing personal card transactions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 54206fb</samp>

> _To test expenses with a personal card_
> _They added a mock data object that's not hard_
> _They also wrote some tests_
> _For the component that adds and edits_
> _And refactored the code to make it less marred_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 54206fb</samp>

*  Extract trackEditExpense method to track the edit expense event with the tracking service ([link](https://github.com/fylein/fyle-mobile-app/pull/2175/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bR3179-R3198))
*  Replace duplicated code that tracks the edit expense event in saveExpense method with a call to trackEditExpense ([link](https://github.com/fylein/fyle-mobile-app/pull/2175/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL3277-R3267))
*  Extract criticalPolicyViolationErrorHandler and policyViolationErrorHandler methods to handle policy violation errors in addExpense and saveAndMatchWithPersonalCardTxn methods ([link](https://github.com/fylein/fyle-mobile-app/pull/2175/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL3232-R3254), [link](https://github.com/fylein/fyle-mobile-app/pull/2175/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL4143-R4118))
*  Add test cases for showAddToReportSuccessToast, addExpense, and saveAndMatchWithPersonalCardTxn methods in `add-edit-expense-4.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2175/files?diff=unified&w=0#diff-f43cd5c38b66131b82307192d0e690768498b3d43e4b378f36d321f42487ab57R294-R310), [link](https://github.com/fylein/fyle-mobile-app/pull/2175/files?diff=unified&w=0#diff-f43cd5c38b66131b82307192d0e690768498b3d43e4b378f36d321f42487ab57L354-R678))
*  Import mock data objects and components for testing the add-edit-expense component ([link](https://github.com/fylein/fyle-mobile-app/pull/2175/files?diff=unified&w=0#diff-f43cd5c38b66131b82307192d0e690768498b3d43e4b378f36d321f42487ab57L8-R16), [link](https://github.com/fylein/fyle-mobile-app/pull/2175/files?diff=unified&w=0#diff-f43cd5c38b66131b82307192d0e690768498b3d43e4b378f36d321f42487ab57R56-R60))
*  Add mock data object for unflattened transaction with personal card in `unflattened-txn.data.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2175/files?diff=unified&w=0#diff-21ae928ce640ad62cfada5fee7bf0bbc490300ab04a25f8309a9878e21b2f1cfR1417-R1421))

## Clickup
https://app.clickup.com/t/85zt9ph1p

## Code Coverage
`59.15% Statements 840/1420`
`50.25% Branches 774/1540`
`53.52% Functions 220/411`
`60.23% Lines 827/1373`

## UI Preview
Please add screenshots for UI changes