### PR TITLE
fix: Fix button loader

### DIFF
--- a/src/app/fyle/my-profile/verify-number-popover/verify-number-popover.component.html
+++ b/src/app/fyle/my-profile/verify-number-popover/verify-number-popover.component.html
@@ -52,6 +52,7 @@
       >
         Resend OTP
       </button>
+      <!-- TODO: Handle this case in directive and fix it property -->
       <div *ngIf="disableResendOtp" class="verify-number-popover__input-container__label__resend--disabled">
         Resend OTP
       </div>

--- a/src/app/fyle/my-profile/verify-number-popover/verify-number-popover.component.html
+++ b/src/app/fyle/my-profile/verify-number-popover/verify-number-popover.component.html
@@ -42,17 +42,19 @@
     </ng-container>
     <ng-template #resendOtpCta>
       <button
+        *ngIf="!disableResendOtp"
         class="verify-number-popover__input-container__label__resend"
-        [ngClass]="{ 'verify-number-popover__input-container__label__resend--disabled': disableResendOtp }"
         (click)="resendOtp('CLICK')"
         appFormButtonValidation
         buttonType="secondary"
         [loading]="sendingOtp"
         loadingText="Sending OTP"
-        [disabled]="disableResendOtp"
       >
         Resend OTP
       </button>
+      <div *ngIf="disableResendOtp" class="verify-number-popover__input-container__label__resend--disabled">
+        Resend OTP
+      </div>
     </ng-template>
   </div>
   <input

--- a/src/app/fyle/my-profile/verify-number-popover/verify-number-popover.component.scss
+++ b/src/app/fyle/my-profile/verify-number-popover/verify-number-popover.component.scss
@@ -39,6 +39,7 @@
         font-weight: 500;
 
         &--disabled {
+          @extend .verify-number-popover__input-container__label__resend;
           color: $grey-light;
         }
       }

--- a/src/app/shared/directive/form-button-validation.directive.ts
+++ b/src/app/shared/directive/form-button-validation.directive.ts
@@ -13,8 +13,6 @@ export class FormButtonValidationDirective implements OnInit, OnChanges {
 
   @Input() loaderPosition: LoaderPosition = LoaderPosition.postfix;
 
-  @Input() disabled: boolean;
-
   defaultText;
 
   loaderAdded = false;
@@ -44,13 +42,7 @@ export class FormButtonValidationDirective implements OnInit, OnChanges {
   constructor(private elementRef: ElementRef) {}
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.disabled) {
-      this.disableButton();
-      this.elementRef.nativeElement.classList.remove('disabled');
-      this.elementRef.nativeElement.innerHTML = this.defaultText;
-    } else {
-      this.onLoading(this.loading);
-    }
+    this.onLoading(this.loading);
   }
 
   disableButton() {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0905ddc</samp>

Improved the UI and functionality of the verify number popover component and cleaned up the form button validation directive. Fixed a bug with the resend OTP button and loading spinner.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0905ddc</samp>

> _`Resend` the code of doom, or face the spinner of despair_
> _`Conditional rendering` is the only way to escape the snare_
> _`FormButtonValidationDirective` has no mercy for the weak_
> _`Disabled` input is removed_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0905ddc</samp>

*  Add conditional rendering to resend OTP button and disabled text in verify number popover component ([link](https://github.com/fylein/fyle-mobile-app/pull/2176/files?diff=unified&w=0#diff-5b3bf657dca65db124c8f7585dc5ce23ef198cce2f0b32f81d50e96b99490ebfL45-R46), [link](https://github.com/fylein/fyle-mobile-app/pull/2176/files?diff=unified&w=0#diff-5b3bf657dca65db124c8f7585dc5ce23ef198cce2f0b32f81d50e96b99490ebfL52-R57), [link](https://github.com/fylein/fyle-mobile-app/pull/2176/files?diff=unified&w=0#diff-d316d9a2b003b13fa93cd929aa16b3b8e52faf88f92b61efd346c473ec308c63R42))
* Remove `disabled` input property from form button validation directive ([link](https://github.com/fylein/fyle-mobile-app/pull/2176/files?diff=unified&w=0#diff-82b70e6aba5eea70b1b4c3695375977320ca1800ca6ebd972232bd4d6c5968acL16-L17), [link](https://github.com/fylein/fyle-mobile-app/pull/2176/files?diff=unified&w=0#diff-82b70e6aba5eea70b1b4c3695375977320ca1800ca6ebd972232bd4d6c5968acL47-R45))

## Clickup
https://app.clickup.com/t/85zt045d4

## Description
This fixes the issue where the button is getting renamed to undefined when loading

## UI Preview
Please add screenshots for UI changes