### PR TITLE
fix: merging expense not showing category dependent fields

### DIFF
--- a/src/app/core/services/merge-expenses.service.spec.ts
+++ b/src/app/core/services/merge-expenses.service.spec.ts
@@ -784,9 +784,9 @@ describe('MergeExpensesService', () => {
 
   it('getCategoryName(): should return the category name', () => {
     categoriesService.getAll.and.returnValue(of(orgCategoryData1));
-    const categoryId = '201952';
+    const categoryId = 201952;
     mergeExpensesService.getCategoryName(categoryId).subscribe((res) => {
-      expect(res).toEqual('Food');
+      expect(res).toEqual('Others');
       expect(categoriesService.getAll).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/app/core/services/merge-expenses.service.ts
+++ b/src/app/core/services/merge-expenses.service.ts
@@ -561,11 +561,11 @@ export class MergeExpensesService {
     );
   }
 
-  getCategoryName(categoryId: string): Observable<string> {
+  getCategoryName(categoryId: number): Observable<string> {
     return this.categoriesService.getAll().pipe(
       map((categories) => {
-        const category = categories.find((category) => category?.id?.toString() === categoryId);
-        return category?.name;
+        const category = categories.find((category) => category?.id === categoryId);
+        return category?.fyle_category;
       })
     );
   }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f89f86e</samp>

Refactored `MergeExpensesService` to use `number` type and `fyle_category` property for expense categories. This is part of a larger effort to align the mobile app with the Fyle API.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f89f86e</samp>

> _`getCategoryName`_
> _Changed to match Fyle API_
> _Autumn of refactor_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f89f86e</samp>

* Change the type of `categoryId` parameter and the return value of `getCategoryName` method in `MergeExpensesService` class to match the updated `Category` interface ([link](https://github.com/fylein/fyle-mobile-app/pull/2177/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L564-R568))
* Use `fyle_category` property instead of `name` property to get the expense category name from the `Category` interface ([link](https://github.com/fylein/fyle-mobile-app/pull/2177/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L564-R568))

## Clickup
app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Before:
https://www.loom.com/share/8745e888a6ce4054a0cbc8dc41e164aa?sid=c38f9330-b43e-4a03-8ea0-788513d855fd
After:
https://www.loom.com/share/0a13e0de701b4339b949978a144e776b?sid=7dd56ef3-dd64-4c4f-b12a-2b506b41f77a