### PR TITLE
fix: Fix cost center and cost center code not visible to some users

### DIFF
--- a/src/app/fyle/view-expense/view-expense.page.html
+++ b/src/app/fyle/view-expense/view-expense.page.html
@@ -315,8 +315,10 @@
         </ion-row>
       </ion-grid>
 
-      <ng-container *ngIf="costCenterDependentCustomProperties$ | async as costCenterDependentCustomProperties">
-        <ng-container *ngIf="!costCenterDependentCustomProperties">
+      <ng-container
+        *ngIf="{ costCenterDependentCustomProperties: costCenterDependentCustomProperties$ | async} as data"
+      >
+        <ng-container *ngIf="!data.costCenterDependentCustomProperties?.length">
           <ion-grid *ngIf="orgSettings?.cost_centers?.enabled && etxn.tx_cost_center_id" class="view-expense--grid">
             <ion-row>
               <ion-col size="6">

--- a/src/app/fyle/view-mileage/view-mileage.page.html
+++ b/src/app/fyle/view-mileage/view-mileage.page.html
@@ -373,8 +373,8 @@
       </ion-row>
     </ion-grid>
 
-    <ng-container *ngIf="costCenterDependentCustomProperties$ | async as costCenterDependentCustomProperties">
-      <ng-container *ngIf="!costCenterDependentCustomProperties">
+    <ng-container *ngIf="{ costCenterDependentCustomProperties: costCenterDependentCustomProperties$ | async} as data">
+      <ng-container *ngIf="!data.costCenterDependentCustomProperties?.length">
         <ion-grid
           *ngIf="orgSettings?.cost_centers?.enabled && extendedMileage.tx_cost_center_id"
           class="view-mileage--grid"

--- a/src/app/fyle/view-per-diem/view-per-diem.page.html
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.html
@@ -257,8 +257,8 @@
       </ion-row>
     </ion-grid>
 
-    <ng-container *ngIf="costCenterDependentCustomProperties$ | async as costCenterDependentCustomProperties">
-      <ng-container *ngIf="!costCenterDependentCustomProperties">
+    <ng-container *ngIf="{ costCenterDependentCustomProperties: costCenterDependentCustomProperties$ | async} as data">
+      <ng-container *ngIf="!data.costCenterDependentCustomProperties?.length">
         <ion-grid
           *ngIf="orgSettings?.cost_centers?.enabled && extendedPerDiem.tx_cost_center_id"
           class="view-per-diem--grid"


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b9bee4c</samp>

Fix cost center grid rendering in view expense, view mileage, and view per diem templates. Check for the presence of `costCenterDependentCustomProperties` and use `data` alias for async pipe results.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b9bee4c</samp>

> _`ngIf` checks length_
> _cost center grid hides or shows_
> _autumn leaves are sparse_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b9bee4c</samp>

*  Modify `ngIf` conditions to check for the length of `costCenterDependentCustomProperties` array in three templates: `view-expense`, `view-mileage`, and `view-per-diem` ([link](https://github.com/fylein/fyle-mobile-app/pull/2178/files?diff=unified&w=0#diff-38bc8efb9ce49f72845a76cfe9045d647245f157542e5281df732a05304ba5dcL318-R321), [link](https://github.com/fylein/fyle-mobile-app/pull/2178/files?diff=unified&w=0#diff-52c28d7749dea1c87c22dc8b0949ba9eae9a53488b0861818624029d1c09032bL376-R377), [link](https://github.com/fylein/fyle-mobile-app/pull/2178/files?diff=unified&w=0#diff-1832dda9cae0b28d660ccdbc9c69cb37d3bb461cc699eea8d9561beee4f29ca0L260-R261))
*  Use `data` alias for the result of the async pipe in the same templates for readability and consistency ([link](https://github.com/fylein/fyle-mobile-app/pull/2178/files?diff=unified&w=0#diff-38bc8efb9ce49f72845a76cfe9045d647245f157542e5281df732a05304ba5dcL318-R321), [link](https://github.com/fylein/fyle-mobile-app/pull/2178/files?diff=unified&w=0#diff-52c28d7749dea1c87c22dc8b0949ba9eae9a53488b0861818624029d1c09032bL376-R377), [link](https://github.com/fylein/fyle-mobile-app/pull/2178/files?diff=unified&w=0#diff-1832dda9cae0b28d660ccdbc9c69cb37d3bb461cc699eea8d9561beee4f29ca0L260-R261))

## Clickup
https://app.clickup.com/t/85ztfe3yu

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes