### PR TITLE
feat:session inactivity fix

### DIFF
--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -197,6 +197,7 @@ describe('AuthService', () => {
       expect(tokenService.setAccessToken).toHaveBeenCalledOnceWith(apiAuthResponseRes.access_token);
       expect(apiService.post).toHaveBeenCalledOnceWith('/auth/access_token', {
         refresh_token: access_token_2,
+        access_token,
       });
       expect(authService.refreshEou).toHaveBeenCalledTimes(1);
       done();

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -180,7 +180,7 @@ describe('AuthService', () => {
     storageService.delete.withArgs('user').and.returnValue(Promise.resolve(null));
     storageService.delete.withArgs('role').and.returnValue(Promise.resolve(null));
     tokenService.resetAccessToken.and.returnValue(Promise.resolve({ value: true }));
-    tokenService.getAccessToken.and.returnValue(Promise.resolve(null));
+    tokenService.getAccessToken.and.returnValue(Promise.resolve(access_token));
     tokenService.setRefreshToken.withArgs(access_token_2).and.returnValue(Promise.resolve({ value: true }));
     apiService.post.and.returnValue(of(apiAuthResponseRes));
     tokenService.setAccessToken
@@ -197,7 +197,7 @@ describe('AuthService', () => {
       expect(tokenService.setRefreshToken).toHaveBeenCalledOnceWith(access_token_2);
       expect(tokenService.setAccessToken).toHaveBeenCalledOnceWith(apiAuthResponseRes.access_token);
       expect(tokenService.getAccessToken).toHaveBeenCalledTimes(1);
-      expect(apiService.post).toHaveBeenCalledOnceWith('/auth/access_token', {
+      expect(apiService.post).toHaveBeenCalledWith('/auth/access_token', {
         refresh_token: access_token_2,
         access_token,
       });

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -180,8 +180,8 @@ describe('AuthService', () => {
     storageService.delete.withArgs('user').and.returnValue(Promise.resolve(null));
     storageService.delete.withArgs('role').and.returnValue(Promise.resolve(null));
     tokenService.resetAccessToken.and.returnValue(Promise.resolve({ value: true }));
-    tokenService.getAccessToken.and.returnValue(Promise.resolve(access_token));
     tokenService.setRefreshToken.withArgs(access_token_2).and.returnValue(Promise.resolve({ value: true }));
+    tokenService.getAccessToken.and.returnValue(Promise.resolve(access_token));
     apiService.post.and.returnValue(of(apiAuthResponseRes));
     tokenService.setAccessToken
       .withArgs(apiAuthResponseRes.access_token)
@@ -196,7 +196,7 @@ describe('AuthService', () => {
       expect(tokenService.resetAccessToken).toHaveBeenCalledOnceWith();
       expect(tokenService.setRefreshToken).toHaveBeenCalledOnceWith(access_token_2);
       expect(tokenService.setAccessToken).toHaveBeenCalledOnceWith(apiAuthResponseRes.access_token);
-      expect(tokenService.getAccessToken).toHaveBeenCalledTimes(1);
+      expect(tokenService.getAccessToken).toHaveBeenCalledOnceWith();
       expect(apiService.post).toHaveBeenCalledWith('/auth/access_token', {
         refresh_token: access_token_2,
         access_token,

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -197,7 +197,7 @@ describe('AuthService', () => {
       expect(tokenService.setAccessToken).toHaveBeenCalledOnceWith(apiAuthResponseRes.access_token);
       expect(apiService.post).toHaveBeenCalledOnceWith('/auth/access_token', {
         refresh_token: access_token_2,
-        access_token,
+        access_token: access_token_2,
       });
       expect(authService.refreshEou).toHaveBeenCalledTimes(1);
       done();

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -180,6 +180,7 @@ describe('AuthService', () => {
     storageService.delete.withArgs('user').and.returnValue(Promise.resolve(null));
     storageService.delete.withArgs('role').and.returnValue(Promise.resolve(null));
     tokenService.resetAccessToken.and.returnValue(Promise.resolve({ value: true }));
+    tokenService.getAccessToken.and.returnValue(Promise.resolve(null));
     tokenService.setRefreshToken.withArgs(access_token_2).and.returnValue(Promise.resolve({ value: true }));
     apiService.post.and.returnValue(of(apiAuthResponseRes));
     tokenService.setAccessToken
@@ -195,9 +196,10 @@ describe('AuthService', () => {
       expect(tokenService.resetAccessToken).toHaveBeenCalledOnceWith();
       expect(tokenService.setRefreshToken).toHaveBeenCalledOnceWith(access_token_2);
       expect(tokenService.setAccessToken).toHaveBeenCalledOnceWith(apiAuthResponseRes.access_token);
+      expect(tokenService.getAccessToken).toHaveBeenCalledTimes(1);
       expect(apiService.post).toHaveBeenCalledOnceWith('/auth/access_token', {
         refresh_token: access_token_2,
-        access_token: access_token_2,
+        access_token,
       });
       expect(authService.refreshEou).toHaveBeenCalledTimes(1);
       done();

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -40,6 +40,8 @@ export class AuthService {
 
   newRefreshToken(token: string): Observable<ExtendedOrgUser> {
     const that = this;
+    const accessToken = this.tokenService.getAccessToken();
+
     return forkJoin([
       that.storageService.delete('user'),
       that.storageService.delete('role'),
@@ -50,6 +52,7 @@ export class AuthService {
         that.apiService
           .post<AuthResponse>('/auth/access_token', {
             refresh_token: token,
+            access_token: accessToken,
           })
           .pipe(
             switchMap((res) => from(that.tokenService.setAccessToken(res.access_token))),

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -40,15 +40,16 @@ export class AuthService {
 
   newRefreshToken(token: string): Observable<ExtendedOrgUser> {
     const that = this;
-    const accessToken = this.tokenService.getAccessToken();
+    const accessToken = from(this.tokenService.getAccessToken());
 
     return forkJoin([
+      accessToken,
       that.storageService.delete('user'),
       that.storageService.delete('role'),
       that.tokenService.resetAccessToken(),
       that.tokenService.setRefreshToken(token),
     ]).pipe(
-      switchMap(() =>
+      switchMap(([accessToken]) =>
         that.apiService
           .post<AuthResponse>('/auth/access_token', {
             refresh_token: token,

--- a/src/app/core/services/router-auth.service.spec.ts
+++ b/src/app/core/services/router-auth.service.spec.ts
@@ -212,13 +212,16 @@ describe('RouterAuthService', () => {
 
   it('fetchAccessToken(): should fetch access token', fakeAsync(() => {
     routerApiService.post.and.returnValue(of(apiAuthRes));
+    tokenService.getAccessToken.and.returnValue(Promise.resolve(access_token));
 
     tick();
-    routerAuthService.fetchAccessToken(refresh_token).then((res) => {
-      expect(res).toEqual(apiAuthRes);
-      expect(routerApiService.post).toHaveBeenCalledOnceWith('/auth/access_token', {
-        refresh_token,
-        access_token,
+    tokenService.getAccessToken().then((access_token) => {
+      routerAuthService.fetchAccessToken(refresh_token).then((res) => {
+        expect(res).toEqual(apiAuthRes);
+        expect(routerApiService.post).toHaveBeenCalledOnceWith('/auth/access_token', {
+          refresh_token,
+          access_token,
+        });
       });
     });
   }));

--- a/src/app/core/services/router-auth.service.spec.ts
+++ b/src/app/core/services/router-auth.service.spec.ts
@@ -218,6 +218,7 @@ describe('RouterAuthService', () => {
       expect(res).toEqual(apiAuthRes);
       expect(routerApiService.post).toHaveBeenCalledOnceWith('/auth/access_token', {
         refresh_token,
+        access_token,
       });
     });
   }));

--- a/src/app/core/services/router-auth.service.spec.ts
+++ b/src/app/core/services/router-auth.service.spec.ts
@@ -215,13 +215,12 @@ describe('RouterAuthService', () => {
     tokenService.getAccessToken.and.returnValue(Promise.resolve(access_token));
 
     tick();
-    tokenService.getAccessToken().then((access_token) => {
-      routerAuthService.fetchAccessToken(refresh_token).then((res) => {
-        expect(res).toEqual(apiAuthRes);
-        expect(routerApiService.post).toHaveBeenCalledOnceWith('/auth/access_token', {
-          refresh_token,
-          access_token,
-        });
+
+    routerAuthService.fetchAccessToken(refresh_token).then((res) => {
+      expect(res).toEqual(apiAuthRes);
+      expect(routerApiService.post).toHaveBeenCalledOnceWith('/auth/access_token', {
+        refresh_token,
+        access_token,
       });
     });
   }));

--- a/src/app/core/services/router-auth.service.ts
+++ b/src/app/core/services/router-auth.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Injectable } from '@angular/core';
 import { RouterApiService } from './router-api.service';
 import { tap, switchMap, map } from 'rxjs/operators';
@@ -74,9 +75,12 @@ export class RouterAuthService {
 
   async fetchAccessToken(refreshToken): Promise<AuthResponse> {
     // this function is called from multiple places, token should be returned and not saved from here
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    const accessToken = await this.tokenService.getAccessToken();
     return await this.routerApiService
       .post('/auth/access_token', {
         refresh_token: refreshToken,
+        access_token: accessToken,
       })
       .toPromise();
   }

--- a/src/app/core/services/router-auth.service.ts
+++ b/src/app/core/services/router-auth.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Injectable } from '@angular/core';
 import { RouterApiService } from './router-api.service';
 import { tap, switchMap, map } from 'rxjs/operators';
@@ -75,7 +74,6 @@ export class RouterAuthService {
 
   async fetchAccessToken(refreshToken): Promise<AuthResponse> {
     // this function is called from multiple places, token should be returned and not saved from here
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     const accessToken = await this.tokenService.getAccessToken();
     return await this.routerApiService
       .post('/auth/access_token', {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad9beef</samp>

This pull request enables the use of the access token from the token service for the router API service authentication in the `AuthService` and `RouterAuthService` classes. It also updates the test for the `RouterAuthService` class to use the access token.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ad9beef</samp>

> _We'll use the `access token` to sail the router sea_
> _We'll fetch the `token service` and post it merrily_
> _We'll heed the linting rule and comment as we please_
> _We'll pull the code together on the count of three_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad9beef</samp>

*  Add and use access token for router API service authentication ([link](https://github.com/fylein/fyle-mobile-app/pull/2184/files?diff=unified&w=0#diff-54ffc766441f21f11e63851c09e17e4c6e2a3c0c282662c069608965281a258eR43-R44), [link](https://github.com/fylein/fyle-mobile-app/pull/2184/files?diff=unified&w=0#diff-54ffc766441f21f11e63851c09e17e4c6e2a3c0c282662c069608965281a258eR55), [link](https://github.com/fylein/fyle-mobile-app/pull/2184/files?diff=unified&w=0#diff-f844a6a1024ed2efa3ca2ba71f0d8975e3b1849d66a7e62c997ea61beac97049R221), [link](https://github.com/fylein/fyle-mobile-app/pull/2184/files?diff=unified&w=0#diff-ad3428039dbde906d2957e4708af02b29e8ee60add1e52caf8ef97bd067cdcf5L77-R83))
* Disable eslint rule for unknown or any return type from router API service ([link](https://github.com/fylein/fyle-mobile-app/pull/2184/files?diff=unified&w=0#diff-ad3428039dbde906d2957e4708af02b29e8ee60add1e52caf8ef97bd067cdcf5R1), [link](https://github.com/fylein/fyle-mobile-app/pull/2184/files?diff=unified&w=0#diff-ad3428039dbde906d2957e4708af02b29e8ee60add1e52caf8ef97bd067cdcf5L77-R83))

## Clickup
https://app.clickup.com/t/85ztg262f

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes