### PR TITLE
feat: Added eslint rules for whole codebase

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,7 +60,20 @@
         "max-params-no-constructor/max-params-no-constructor": ["error", 4],
         "max-len": "off",
         "space-before-function-paren": "off",
-        "@typescript-eslint/quotes": "off"
+        "@typescript-eslint/quotes": "off",
+        "@typescript-eslint/no-unsafe-call": 1,
+        "@typescript-eslint/no-unsafe-member-access": 1,
+        "@typescript-eslint/no-unsafe-assignment": 1,
+        "@typescript-eslint/no-unsafe-return": 1,
+        "@typescript-eslint/no-unsafe-argument": 1,
+        "@typescript-eslint/explicit-function-return-type": 1,
+        "@typescript-eslint/no-unnecessary-type-assertion": 1,
+        "@typescript-eslint/no-unused-vars": 1,
+        "@typescript-eslint/no-explicit-any": 1,
+        "@typescript-eslint/no-empty-function": 1,
+        "@typescript-eslint/no-empty-interface": 1,
+        "@typescript-eslint/no-inferrable-types": 1,
+        "no-unused-expressions": 1
       }
     },
     {
@@ -68,19 +81,6 @@
       "extends": ["plugin:@angular-eslint/template/recommended"],
       "rules": {
         "@angular-eslint/template/no-negated-async": "off"
-      }
-    },
-    {
-      "files": ["./src/app/shared/**/*.ts", "./src/app/core/**/*.ts"],
-      "excludedFiles": ["*.spec.ts", "*.data.ts"],
-      "rules": {
-        "@typescript-eslint/no-unsafe-call": 1,
-        "@typescript-eslint/no-unsafe-member-access": 1,
-        "@typescript-eslint/no-unsafe-assignment": 1,
-        "@typescript-eslint/no-unsafe-return": 1,
-        "@typescript-eslint/no-unsafe-argument": 1,
-        "@typescript-eslint/explicit-function-return-type": 1,
-        "@typescript-eslint/no-unnecessary-type-assertion": 1
       }
     }
   ]


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1Phn1xuOQX2g66DAdorZECn4QpKPgEus%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=BkzU6Bb)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 01f561a</samp>

This pull request improves the TypeScript linting setup by adding and removing some ESLint rules in `.eslintrc.json`. The rules are set to warn to facilitate incremental code improvement.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 01f561a</samp>

> _To improve TypeScript code quality_
> _This pull request updates ESLint_
> _It adds some rules to warn_
> _And removes some that are worn_
> _But it does not make errors imminent_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 01f561a</samp>

*  Add TypeScript rules to ESLint configuration for type safety and code quality ([link](https://github.com/fylein/fyle-mobile-app/pull/2185/files?diff=unified&w=0#diff-6884918dc8291219be508e05e28965b958c734def85324f3b53858ea4702090fL63-R76))
* Remove redundant override of TypeScript rules for some files ([link](https://github.com/fylein/fyle-mobile-app/pull/2185/files?diff=unified&w=0#diff-6884918dc8291219be508e05e28965b958c734def85324f3b53858ea4702090fL72-L84))

## Clickup
https://app.clickup.com/t/85zth54w3
