### PR TITLE
test: 50% coverage of Merge expense page

### DIFF
--- a/src/app/core/mock-data/combined-options.data.ts
+++ b/src/app/core/mock-data/combined-options.data.ts
@@ -5,9 +5,16 @@ import {
   optionsData12,
   optionsData13,
   optionsData14,
+  optionsData15,
+  optionsData16,
+  optionsData17,
   optionsData18,
+  optionsData19,
   optionsData2,
+  optionsData20,
+  optionsData21,
   optionsData3,
+  optionsData31,
   optionsData6,
   optionsData7,
   optionsData8,
@@ -26,4 +33,23 @@ export const combinedOptionsData1: CombinedOptions = {
   taxAmountOptionsData: optionsData12,
   constCenterOptionsData: optionsData13,
   purposeOptionsData: optionsData14,
+};
+
+export const combinedOptionsData2: CombinedOptions = {
+  userlist: optionsData3,
+  test: optionsData6,
+  category2: optionsData31,
+};
+
+export const combinedOptionsData3: CombinedOptions = {
+  location1OptionsData: optionsData15,
+  location2OptionsData: optionsData15,
+  onwardDateOptionsData: optionsData16,
+  returnDateOptionsData: optionsData16,
+  flightJourneyTravelClassOptionsData: optionsData17,
+  flightReturnTravelClassOptionsData: optionsData17,
+  trainTravelClassOptionsData: optionsData18,
+  busTravelClassOptionsData: optionsData19,
+  distanceOptionsData: optionsData20,
+  distanceUnitOptionsData: optionsData21,
 };

--- a/src/app/core/mock-data/cost-center-dependent-fields-mapping.data.ts
+++ b/src/app/core/mock-data/cost-center-dependent-fields-mapping.data.ts
@@ -1,0 +1,7 @@
+import { CostCenterDependentFieldsMapping } from '../models/cost-center-dependent-fields-mapping.model';
+import { dependentCustomProperties } from './custom-property.data';
+
+export const CostCenterDependentFieldsMappingData1: CostCenterDependentFieldsMapping = {
+  13795: dependentCustomProperties,
+  13796: dependentCustomProperties,
+};

--- a/src/app/core/mock-data/custom-field.data.ts
+++ b/src/app/core/mock-data/custom-field.data.ts
@@ -116,3 +116,38 @@ export const expectedCustomFieldsWithDate = [
     type: 'DATE',
   },
 ];
+
+export const expectedCustomInputFields: CustomField[] = [
+  {
+    name: 'userlist',
+    value: 'txKJAJ1flx7n',
+  },
+  {
+    name: 'User List',
+    value: null,
+  },
+  {
+    name: 'test',
+    value: null,
+  },
+  {
+    name: 'category2',
+    value: null,
+  },
+  {
+    name: 'pub create hola 1',
+    value: null,
+  },
+  {
+    name: 'test 112',
+    value: null,
+  },
+  {
+    name: '2232323',
+    value: null,
+  },
+  {
+    name: 'select all 2',
+    value: null,
+  },
+];

--- a/src/app/core/mock-data/generated-form-properties.data.ts
+++ b/src/app/core/mock-data/generated-form-properties.data.ts
@@ -1,4 +1,5 @@
 import { GeneratedFormProperties } from '../models/generated-form-properties.model';
+import { dependentCustomProperties } from './custom-property.data';
 
 export const generatedFormPropertiesData1: GeneratedFormProperties = {
   source_account_id: '1234',
@@ -35,4 +36,115 @@ export const generatedFormPropertiesData1: GeneratedFormProperties = {
   distance: 100,
   distance_unit: 'KM',
   locations: ['Mumbai', 'Pune'],
+};
+
+export const generatedFormPropertiesData2: GeneratedFormProperties = {
+  source_account_id: 'accDDeaVIs6p6',
+  billable: undefined,
+  currency: 'USD',
+  amount: 3,
+  project_id: 13795,
+  cost_center_id: 13796,
+  tax_amount: undefined,
+  tax_group_id: undefined,
+  org_category_id: undefined,
+  fyle_category: undefined,
+  vendor: undefined,
+  purpose: undefined,
+  txn_dt: undefined,
+  receipt_ids: [],
+  custom_properties: [
+    {
+      name: 'CUSTOM FIELD',
+      value: '',
+    },
+    {
+      name: 'Cost Code',
+      value: 'Cost Code 1',
+    },
+    ...dependentCustomProperties,
+    ...dependentCustomProperties,
+  ],
+  ccce_group_id: undefined,
+  from_dt: undefined,
+  to_dt: undefined,
+  flight_journey_travel_class: undefined,
+  flight_return_travel_class: undefined,
+  train_travel_class: undefined,
+  bus_travel_class: undefined,
+  distance: undefined,
+  distance_unit: undefined,
+  locations: ['Pune', 'Mumbai'],
+};
+
+export const generatedFormPropertiesData3: GeneratedFormProperties = {
+  source_account_id: 'accDDeaVIs6p6',
+  billable: undefined,
+  currency: 'USD',
+  amount: 3,
+  project_id: undefined,
+  cost_center_id: undefined,
+  tax_amount: undefined,
+  tax_group_id: undefined,
+  org_category_id: undefined,
+  fyle_category: undefined,
+  vendor: undefined,
+  purpose: undefined,
+  txn_dt: undefined,
+  receipt_ids: [],
+  custom_properties: [
+    {
+      name: 'CUSTOM FIELD',
+      value: '',
+    },
+    {
+      name: 'Cost Code',
+      value: 'Cost Code 1',
+    },
+  ],
+  ccce_group_id: undefined,
+  from_dt: undefined,
+  to_dt: undefined,
+  flight_journey_travel_class: undefined,
+  flight_return_travel_class: undefined,
+  train_travel_class: undefined,
+  bus_travel_class: undefined,
+  distance: undefined,
+  distance_unit: undefined,
+  locations: ['Pune', 'Mumbai'],
+};
+
+export const generatedFormPropertiesData4: GeneratedFormProperties = {
+  ...generatedFormPropertiesData3,
+  source_account_id: undefined,
+  currency: undefined,
+  amount: undefined,
+};
+
+export const generatedFormPropertiesData5: GeneratedFormProperties = {
+  source_account_id: 'accDDeaVIs6p6',
+  billable: undefined,
+  currency: 'USD',
+  amount: 3,
+  project_id: 13795,
+  cost_center_id: 13796,
+  tax_amount: undefined,
+  tax_group_id: undefined,
+  org_category_id: undefined,
+  fyle_category: undefined,
+  vendor: undefined,
+  purpose: undefined,
+  txn_dt: undefined,
+  receipt_ids: [],
+  custom_properties: [],
+  ccce_group_id: undefined,
+  from_dt: undefined,
+  to_dt: undefined,
+  flight_journey_travel_class: undefined,
+  flight_return_travel_class: undefined,
+  train_travel_class: undefined,
+  bus_travel_class: undefined,
+  distance: undefined,
+  distance_unit: undefined,
+  locations: ['Pune', 'Mumbai'],
 };

--- a/src/app/core/mock-data/generated-form-properties.data.ts
+++ b/src/app/core/mock-data/generated-form-properties.data.ts
@@ -1,0 +1,38 @@
+import { GeneratedFormProperties } from '../models/generated-form-properties.model';
+
+export const generatedFormPropertiesData1: GeneratedFormProperties = {
+  source_account_id: '1234',
+  billable: true,
+  currency: 'INR',
+  amount: 100,
+  project_id: 3943,
+  cost_center_id: 91842,
+  tax_amount: 100,
+  tax_group_id: '793812',
+  org_category_id: 85913,
+  fyle_category: 'Food',
+  vendor: 'Nilesh As Vendor',
+  purpose: 'Others',
+  txn_dt: new Date('2023-02-03'),
+  receipt_ids: ['tx3nHShG60zq'],
+  custom_properties: [
+    {
+      name: 'Custom Property 1',
+      value: 'Custom Property 1 Value',
+    },
+    {
+      name: 'Custom Property 2',
+      value: 'Custom Property 2 Value',
+    },
+  ],
+  ccce_group_id: '63291',
+  from_dt: new Date('2023-01-01'),
+  to_dt: new Date('2023-02-02'),
+  flight_journey_travel_class: 'Economy',
+  flight_return_travel_class: 'Economy',
+  train_travel_class: 'Economy',
+  bus_travel_class: 'Economy',
+  distance: 100,
+  distance_unit: 'KM',
+  locations: ['Mumbai', 'Pune'],
+};

--- a/src/app/core/mock-data/merge-expense-form-data.data.ts
+++ b/src/app/core/mock-data/merge-expense-form-data.data.ts
@@ -1,0 +1,116 @@
+export const mergeExpenseFormData1 = {
+  genericFields: {
+    paymentMode: 'CORPORATE_CARD',
+    amount: 'tx3nHShG60zq',
+    project: 13795,
+    costCenter: 13796,
+  },
+  custom_inputs: {
+    fields: [
+      {
+        name: 'CUSTOM FIELD',
+        value: '',
+      },
+      {
+        name: 'Cost Code',
+        value: 'Cost Code 1',
+      },
+    ],
+  },
+  categoryDependent: {
+    location_1: 'Pune',
+    location_2: 'Mumbai',
+  },
+};
+
+export const mergeExpenseFormData2 = {
+  genericFields: {
+    paymentMode: 'CORPORATE_CARD',
+    amount: 'tx3nHShG60zq',
+    project: 13795,
+    costCenter: 13796,
+  },
+  custom_inputs: {
+    fields: [
+      {
+        name: 'CUSTOM FIELD',
+        value: '',
+      },
+      {
+        name: 'Cost Code',
+        value: 'Cost Code 1',
+      },
+    ],
+  },
+  categoryDependent: {
+    location_1: 'Pune',
+  },
+};
+
+export const mergeExpenseFormData3 = {
+  genericFields: {
+    paymentMode: 'CORPORATE_CARD',
+    amount: 'tx3nHShG60zq',
+    project: 13795,
+    costCenter: 13796,
+  },
+  custom_inputs: {
+    fields: [
+      {
+        name: 'CUSTOM FIELD',
+        value: '',
+      },
+      {
+        name: 'Cost Code',
+        value: 'Cost Code 1',
+      },
+    ],
+  },
+  categoryDependent: {},
+};
+
+export const mergeExpenseFormData4 = {
+  genericFields: {
+    paymentMode: 'CORPORATE_CARD',
+    amount: 'tx3nHShG60zq',
+  },
+  custom_inputs: {
+    fields: [
+      {
+        name: 'CUSTOM FIELD',
+        value: '',
+      },
+      {
+        name: 'Cost Code',
+        value: 'Cost Code 1',
+      },
+    ],
+  },
+  categoryDependent: {
+    location_1: 'Pune',
+    location_2: 'Mumbai',
+  },
+};
+
+export const mergeExpenseFormData5 = {
+  genericFields: {
+    paymentMode: 'CORPORATE_CARD',
+    amount: 'tx3nHShG6035',
+  },
+  custom_inputs: {
+    fields: [
+      {
+        name: 'CUSTOM FIELD',
+        value: '',
+      },
+      {
+        name: 'Cost Code',
+        value: 'Cost Code 1',
+      },
+    ],
+  },
+  categoryDependent: {
+    location_1: 'Pune',
+    location_2: 'Mumbai',
+  },
+};

--- a/src/app/core/mock-data/merge-expenses-options-data.data.ts
+++ b/src/app/core/mock-data/merge-expenses-options-data.data.ts
@@ -461,3 +461,73 @@ export const optionsData30: MergeExpensesOptionsData[] = [
     name: 'customNumber',
   },
 ];
+
+export const optionsData31: MergeExpensesOptionsData = {
+  options: [
+    {
+      label: 'No',
+      value: false,
+    },
+    {
+      label: 'No',
+      value: false,
+    },
+  ],
+  areSameValues: true,
+};
+
+export const optionsData32: MergeExpensesOptionsData[] = [
+  {
+    id: 200227,
+    name: 'userlist',
+    options: [],
+    value: [],
+  },
+  {
+    id: 210649,
+    name: 'User List',
+    options: [],
+    value: [],
+  },
+  {
+    id: 210281,
+    name: 'test',
+    options: [],
+    value: '',
+  },
+  {
+    id: 212819,
+    name: 'category2',
+    options: [],
+    value: '',
+  },
+  {
+    id: 206206,
+    name: 'pub create hola 1',
+    options: [],
+    value: null,
+  },
+  {
+    id: 211321,
+    name: 'test 112',
+    options: [],
+    value: null,
+  },
+  {
+    id: 206198,
+    name: '2232323',
+    options: [],
+    value: null,
+  },
+  {
+    id: 211326,
+    name: 'select all 2',
+    options: [
+      {
+        label: '2023-02-13T17:00:00.000Z',
+        value: '2023-02-13T17:00:00.000Z',
+      },
+    ],
+    value: '2023-02-13T17:00:00.000Z',
+  },
+];

--- a/src/app/core/mock-data/project-dependent-fields-mapping.data.ts
+++ b/src/app/core/mock-data/project-dependent-fields-mapping.data.ts
@@ -1,0 +1,7 @@
+import { ProjectDependentFieldsMapping } from '../models/project-dependent-fields-mapping.model';
+import { dependentCustomProperties } from './custom-property.data';
+
+export const projectDependentFieldsMappingData1: ProjectDependentFieldsMapping = {
+  3943: dependentCustomProperties,
+  3944: dependentCustomProperties,
+};

--- a/src/app/core/mock-data/snackbar-properties.data.ts
+++ b/src/app/core/mock-data/snackbar-properties.data.ts
@@ -33,3 +33,12 @@ export const snackbarPropertiesRes4 = {
   },
   duration: 3000,
 };
+
+export const snackbarPropertiesRes5 = {
+  data: {
+    icon: 'success',
+    showCloseButton: true,
+    message: 'Expenses merged Successfully',
+  },
+  duration: 3000,
+};

--- a/src/app/core/mock-data/txn-custom-properties.data.ts
+++ b/src/app/core/mock-data/txn-custom-properties.data.ts
@@ -434,3 +434,59 @@ export const expectedTxnCustomProperties: TxnCustomProperties[] = [
     value: new Date('2023-02-13T17:00:00.000Z'),
   },
 ];
+
+export const expectedTxnCustomProperties2: TxnCustomProperties[] = [
+  {
+    id: 200227,
+    name: 'userlist',
+    options: [],
+    value: [],
+  },
+  {
+    id: 210649,
+    name: 'User List',
+    options: [],
+    value: [],
+  },
+  {
+    id: 210281,
+    name: 'test',
+    options: [],
+    value: '',
+  },
+  {
+    id: 212819,
+    name: 'category2',
+    options: [],
+    value: '',
+  },
+  {
+    id: 206206,
+    name: 'pub create hola 1',
+    options: [],
+    value: null,
+  },
+  {
+    id: 211321,
+    name: 'test 112',
+    options: [],
+    value: null,
+  },
+  {
+    id: 206198,
+    name: '2232323',
+    options: [],
+    value: null,
+  },
+  {
+    id: 211326,
+    name: 'select all 2',
+    options: [
+      {
+        label: '2023-02-13T17:00:00.000Z',
+        value: '2023-02-13T17:00:00.000Z',
+      },
+    ],
+    value: '2023-02-13T17:00:00.000Z',
+  },
+];

--- a/src/app/core/models/cost-center-dependent-fields-mapping.model.ts
+++ b/src/app/core/models/cost-center-dependent-fields-mapping.model.ts
@@ -1,0 +1,5 @@
+import { CustomProperty } from './custom-properties.model';
+
+export interface CostCenterDependentFieldsMapping {
+  [costCenterId: number]: CustomProperty<string>[];
+}

--- a/src/app/core/models/generated-form-properties.model.ts
+++ b/src/app/core/models/generated-form-properties.model.ts
@@ -1,0 +1,29 @@
+import { CustomProperty } from './custom-properties.model';
+
+export interface GeneratedFormProperties {
+  source_account_id: string;
+  billable: boolean;
+  currency: string;
+  amount: number;
+  project_id: number;
+  cost_center_id: number;
+  tax_amount: number;
+  tax_group_id: string;
+  org_category_id: number;
+  fyle_category: string;
+  vendor: string;
+  purpose: string;
+  txn_dt: Date;
+  receipt_ids: string[];
+  custom_properties: CustomProperty<string>[];
+  ccce_group_id: string;
+  from_dt: Date;
+  to_dt: Date;
+  flight_journey_travel_class: string;
+  flight_return_travel_class: string;
+  train_travel_class: string;
+  bus_travel_class: string;
+  distance: number;
+  distance_unit: string;
+  locations: string[];
+}

--- a/src/app/core/models/project-dependent-fields-mapping.model.ts
+++ b/src/app/core/models/project-dependent-fields-mapping.model.ts
@@ -1,0 +1,5 @@
+import { CustomProperty } from './custom-properties.model';
+
+export interface ProjectDependentFieldsMapping {
+  [projectId: number]: CustomProperty<string>[];
+}

--- a/src/app/core/services/merge-expenses.service.ts
+++ b/src/app/core/services/merge-expenses.service.ts
@@ -570,7 +570,7 @@ export class MergeExpensesService {
     );
   }
 
-  getCustomInputValues(expenses: Expense[]): CustomInputs[] {
+  getCustomInputValues(expenses: Expense[]): TxnCustomProperties[] {
     //Create a copy so that we don't modify the expense object
     const expensesCopy = cloneDeep(expenses);
     return expensesCopy

--- a/src/app/fyle/merge-expense/merge-expense-2.page.spec.ts
+++ b/src/app/fyle/merge-expense/merge-expense-2.page.spec.ts
@@ -5,7 +5,7 @@ import { CategoriesService } from 'src/app/core/services/categories.service';
 import { CustomInputsService } from 'src/app/core/services/custom-inputs.service';
 import { CustomFieldsService } from 'src/app/core/services/custom-fields.service';
 import { NavController } from '@ionic/angular';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar';
 import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
 import { MergeExpensesService } from 'src/app/core/services/merge-expenses.service';
 import { TrackingService } from 'src/app/core/services/tracking.service';
@@ -14,7 +14,7 @@ import { DependentFieldsService } from 'src/app/core/services/dependent-fields.s
 import { FormBuilder, Validators } from '@angular/forms';
 import { cloneDeep } from 'lodash';
 import { expenseList2 } from 'src/app/core/mock-data/expense.data';
-import { of } from 'rxjs';
+import { BehaviorSubject, Observable, Subscription, of } from 'rxjs';
 import {
   optionsData10,
   optionsData11,
@@ -39,7 +39,23 @@ import { combinedOptionsData1 } from 'src/app/core/mock-data/combined-options.da
 import { fileObject7 } from 'src/app/core/mock-data/file-object.data';
 import { projectDependentFieldsMappingData1 } from 'src/app/core/mock-data/project-dependent-fields-mapping.data';
 import { CostCenterDependentFieldsMappingData1 } from 'src/app/core/mock-data/cost-center-dependent-fields-mapping.data';
-import { generatedFormPropertiesData1 } from 'src/app/core/mock-data/generated-form-properties.data';
+import {
+  generatedFormPropertiesData1,
+  generatedFormPropertiesData2,
+  generatedFormPropertiesData3,
+  generatedFormPropertiesData4,
+  generatedFormPropertiesData5,
+} from 'src/app/core/mock-data/generated-form-properties.data';
+import { ToastMessageComponent } from 'src/app/shared/components/toast-message/toast-message.component';
+import { snackbarPropertiesRes5 } from 'src/app/core/mock-data/snackbar-properties.data';
+import {
+  mergeExpenseFormData1,
+  mergeExpenseFormData2,
+  mergeExpenseFormData3,
+  mergeExpenseFormData4,
+  mergeExpenseFormData5,
+} from 'src/app/core/mock-data/merge-expense-form-data.data';
+import { dependentCustomFields } from 'src/app/core/mock-data/expense-field.data';
 
 export function TestCases2(getTestBed) {
   return describe('test cases set 2', () => {
@@ -393,6 +409,111 @@ export function TestCases2(getTestBed) {
         expect(trackingService.expensesMerged).toHaveBeenCalledTimes(1);
         expect(component.showMergedSuccessToast).toHaveBeenCalledTimes(1);
         expect(component.goBack).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('goBack(): ', () => {
+      beforeEach(() => {
+        component.redirectedFrom = 'EDIT_EXPENSE';
+      });
+
+      it('should navigate to my_expenses page if user is redirected from EDIT_EXPENSE', () => {
+        component.goBack();
+        expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_expenses']);
+        expect(navController.back).not.toHaveBeenCalled();
+      });
+
+      it('should navigate to previous page if user is not redirected from EDIT_EXPENSE', () => {
+        component.redirectedFrom = 'TASK';
+        component.goBack();
+        expect(navController.back).toHaveBeenCalledTimes(1);
+        expect(router.navigate).not.toHaveBeenCalled();
+      });
+    });
+
+    it('showMergedSuccessToast(): should show Expenses merged Successfully toast', () => {
+      matSnackBar.openFromComponent.and.returnValue({
+        onAction: () => ({
+          subscribe: () => {},
+        }),
+      } as MatSnackBarRef<ToastMessageComponent>);
+      snackbarProperties.setSnackbarProperties.and.returnValue(snackbarPropertiesRes5);
+
+      component.showMergedSuccessToast();
+
+      expect(snackbarProperties.setSnackbarProperties).toHaveBeenCalledOnceWith('success', {
+        message: 'Expenses merged Successfully',
+      });
+      expect(matSnackBar.openFromComponent).toHaveBeenCalledOnceWith(ToastMessageComponent, {
+        ...snackbarPropertiesRes5,
+        panelClass: ['msb-success-with-camera-icon'],
+      });
+    });
+
+    describe('generateFromFg(): ', () => {
+      beforeEach(() => {
+        const mockExpense = cloneDeep(expenseList2);
+        mockExpense[1].source_account_type = 'CORPORATE_CARD';
+        component.expenses = cloneDeep(mockExpense);
+        component.fg = formBuilder.group(mergeExpenseFormData1);
+      });
+
+      it('should return generated form properties with locations consist of source and destination address', () => {
+        const generatedFormProperties = component.generateFromFg(CostCenterDependentFieldsMappingData1);
+        expect(generatedFormProperties).toEqual(generatedFormPropertiesData2);
+      });
+
+      it('should return generated form properties with locations as a single element if location_2 is undefined', () => {
+        component.fg.patchValue(mergeExpenseFormData2);
+        const generatedFormProperties = component.generateFromFg(CostCenterDependentFieldsMappingData1);
+        expect(generatedFormProperties).toEqual({ ...generatedFormPropertiesData2, locations: ['Pune'] });
+      });
+
+      it('should return generated form properties with locations as empty array if location_1 and locations_2 are undefined', () => {
+        component.fg.patchValue(mergeExpenseFormData3);
+        const generatedFormProperties = component.generateFromFg(CostCenterDependentFieldsMappingData1);
+        expect(generatedFormProperties).toEqual({ ...generatedFormPropertiesData2, locations: [] });
+      });
+
+      it('should return generated form properties with projectDependantFieldValues and costCenterDependentFieldValues as empty array if project and costCenter are undefined in genericFields', () => {
+        component.fg.patchValue(mergeExpenseFormData4);
+        const generatedFormProperties = component.generateFromFg(CostCenterDependentFieldsMappingData1);
+        expect(generatedFormProperties).toEqual(generatedFormPropertiesData3);
+      });
+
+      it('should return generated form properties with source_account_id, currency and amount as undefined if sourceExpense and amountExpense are undefined', () => {
+        component.expenses = cloneDeep(expenseList2);
+        component.fg.patchValue(mergeExpenseFormData5);
+        const generatedFormProperties = component.generateFromFg(CostCenterDependentFieldsMappingData1);
+        expect(generatedFormProperties).toEqual(generatedFormPropertiesData4);
+      });
+
+      it('should return generated form properties with ccce_group_id if tx_corporate_credit_card_expense_group_id is present in expense', () => {
+        const mockExpense = cloneDeep(expenseList2);
+        mockExpense[1].tx_corporate_credit_card_expense_group_id = 'ae593zqtepw';
+        mockExpense[1].source_account_type = 'CORPORATE_CARD';
+        component.expenses = cloneDeep(mockExpense);
+        const generatedFormProperties = component.generateFromFg(CostCenterDependentFieldsMappingData1);
+        expect(generatedFormProperties).toEqual({ ...generatedFormPropertiesData2, ccce_group_id: 'ae593zqtepw' });
+      });
+
+      it('should return generated form properties with custom_properties as empty array if dependentFieldsMapping is empty', () => {
+        const mockFormData = cloneDeep(mergeExpenseFormData1);
+        mockFormData.custom_inputs.fields = [];
+        component.fg = formBuilder.group(mockFormData);
+        const generatedFormProperties = component.generateFromFg({});
+        expect(generatedFormProperties).toEqual(generatedFormPropertiesData5);
+      });
+    });
+
+    it('onCategoryChanged(): should update selectedCategoryName and loadCustomFields$', () => {
+      component.loadCustomFields$ = new BehaviorSubject(null);
+      mergeExpensesService.getCategoryName.and.returnValue(of('Food'));
+      component.onCategoryChanged('201952');
+      expect(mergeExpensesService.getCategoryName).toHaveBeenCalledOnceWith('201952');
+      expect(component.selectedCategoryName).toEqual('Food');
+      component.loadCustomFields$.subscribe((customFields) => {
+        expect(customFields).toEqual('201952');
       });
     });
   });

--- a/src/app/fyle/merge-expense/merge-expense-2.page.spec.ts
+++ b/src/app/fyle/merge-expense/merge-expense-2.page.spec.ts
@@ -1,0 +1,399 @@
+import { ComponentFixture, waitForAsync } from '@angular/core/testing';
+import { MergeExpensePage } from './merge-expense.page';
+import { ActivatedRoute, Router } from '@angular/router';
+import { CategoriesService } from 'src/app/core/services/categories.service';
+import { CustomInputsService } from 'src/app/core/services/custom-inputs.service';
+import { CustomFieldsService } from 'src/app/core/services/custom-fields.service';
+import { NavController } from '@ionic/angular';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
+import { MergeExpensesService } from 'src/app/core/services/merge-expenses.service';
+import { TrackingService } from 'src/app/core/services/tracking.service';
+import { ExpenseFieldsService } from 'src/app/core/services/expense-fields.service';
+import { DependentFieldsService } from 'src/app/core/services/dependent-fields.service';
+import { FormBuilder, Validators } from '@angular/forms';
+import { cloneDeep } from 'lodash';
+import { expenseList2 } from 'src/app/core/mock-data/expense.data';
+import { of } from 'rxjs';
+import {
+  optionsData10,
+  optionsData11,
+  optionsData12,
+  optionsData13,
+  optionsData14,
+  optionsData15,
+  optionsData16,
+  optionsData17,
+  optionsData18,
+  optionsData19,
+  optionsData2,
+  optionsData20,
+  optionsData21,
+  optionsData3,
+  optionsData6,
+  optionsData7,
+  optionsData8,
+  optionsData9,
+} from 'src/app/core/mock-data/merge-expenses-options-data.data';
+import { combinedOptionsData1 } from 'src/app/core/mock-data/combined-options.data';
+import { fileObject7 } from 'src/app/core/mock-data/file-object.data';
+import { projectDependentFieldsMappingData1 } from 'src/app/core/mock-data/project-dependent-fields-mapping.data';
+import { CostCenterDependentFieldsMappingData1 } from 'src/app/core/mock-data/cost-center-dependent-fields-mapping.data';
+import { generatedFormPropertiesData1 } from 'src/app/core/mock-data/generated-form-properties.data';
+
+export function TestCases2(getTestBed) {
+  return describe('test cases set 2', () => {
+    let component: MergeExpensePage;
+    let fixture: ComponentFixture<MergeExpensePage>;
+    let router: jasmine.SpyObj<Router>;
+    let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+    let categoriesService: jasmine.SpyObj<CategoriesService>;
+    let customInputsService: jasmine.SpyObj<CustomInputsService>;
+    let customFieldsService: jasmine.SpyObj<CustomFieldsService>;
+    let navController: jasmine.SpyObj<NavController>;
+    let matSnackBar: jasmine.SpyObj<MatSnackBar>;
+    let snackbarProperties: jasmine.SpyObj<SnackbarPropertiesService>;
+    let mergeExpensesService: jasmine.SpyObj<MergeExpensesService>;
+    let trackingService: jasmine.SpyObj<TrackingService>;
+    let expenseFieldsService: jasmine.SpyObj<ExpenseFieldsService>;
+    let dependantFieldsService: jasmine.SpyObj<DependentFieldsService>;
+    let formBuilder: FormBuilder;
+
+    beforeEach(waitForAsync(() => {
+      const TestBed = getTestBed();
+      fixture = TestBed.createComponent(MergeExpensePage);
+      component = fixture.componentInstance;
+      router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+      activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
+      categoriesService = TestBed.inject(CategoriesService) as jasmine.SpyObj<CategoriesService>;
+      customInputsService = TestBed.inject(CustomInputsService) as jasmine.SpyObj<CustomInputsService>;
+      customFieldsService = TestBed.inject(CustomFieldsService) as jasmine.SpyObj<CustomFieldsService>;
+      navController = TestBed.inject(NavController) as jasmine.SpyObj<NavController>;
+      matSnackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
+      snackbarProperties = TestBed.inject(SnackbarPropertiesService) as jasmine.SpyObj<SnackbarPropertiesService>;
+      mergeExpensesService = TestBed.inject(MergeExpensesService) as jasmine.SpyObj<MergeExpensesService>;
+      trackingService = TestBed.inject(TrackingService) as jasmine.SpyObj<TrackingService>;
+      expenseFieldsService = TestBed.inject(ExpenseFieldsService) as jasmine.SpyObj<ExpenseFieldsService>;
+      dependantFieldsService = TestBed.inject(DependentFieldsService) as jasmine.SpyObj<DependentFieldsService>;
+      formBuilder = TestBed.inject(FormBuilder);
+      component.fg = formBuilder.group({
+        target_txn_id: [, Validators.required],
+        genericFields: [],
+        categoryDependent: [],
+        custom_inputs: [],
+      });
+    }));
+
+    describe('onExpenseChanged(): ', () => {
+      beforeEach(() => {
+        component.genericFieldsOptions$ = of(cloneDeep(combinedOptionsData1));
+        component.expenses = cloneDeep(expenseList2);
+        mergeExpensesService.getFieldValueOnChange.and.returnValues(
+          'tx3nHShG60zq',
+          new Date('2023-03-13T11:30:00.000Z'),
+          'PERSONAL_ACCOUNT',
+          '3943',
+          false,
+          207484,
+          'Nilesh As Vendor',
+          'tgXEJA6YUoZ1',
+          0.01,
+          '213',
+          'Outing'
+        );
+      });
+
+      it('should call getFieldValueOnChange 11 times', () => {
+        component.onExpenseChanged(1);
+
+        expect(mergeExpensesService.getFieldValueOnChange).toHaveBeenCalledTimes(11);
+      });
+
+      it('should update receipt_ids to null if expense is undefined', () => {
+        component.onExpenseChanged(-1);
+        expect(component.fg.controls.genericFields.value.receipt_ids).toEqual(null);
+      });
+
+      it('should update receipt_ids to null if tx_file_ids is undefined', () => {
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.receipt_ids).toEqual(null);
+      });
+
+      it('should update receipt_ids to null if tx_file_ids is empty', () => {
+        component.expenses[1].tx_file_ids = [];
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.receipt_ids).toEqual(null);
+      });
+
+      it('should set receipt_ids to tx_split_group_id if tx_file_ids is not empty and touchedGenericFields is undefined', () => {
+        component.expenses[1].tx_file_ids = ['fiGLwwPtYD8X'];
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.receipt_ids).toEqual('tx3nHShG60zq');
+      });
+
+      it('should set receipt_ids to tx_split_group_id if tx_file_ids is not empty and receipt_ids field is not touched in the form', () => {
+        component.expenses[1].tx_file_ids = ['fiGLwwPtYD8X'];
+        component.touchedGenericFields = ['dateOfSpend', 'paymentMode'];
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.receipt_ids).toEqual('tx3nHShG60zq');
+      });
+
+      it('should call getFieldValueOnChange for updating amount with correct arguments', () => {
+        component.touchedGenericFields = ['amount'];
+        component.genericFieldsForm.patchValue({ amount: 99 });
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.amount).toEqual('tx3nHShG60zq');
+        const amountCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(0);
+        expect(amountCall[0]).toEqual(optionsData3);
+        expect(amountCall[1]).toEqual(true);
+        expect(amountCall[2]).toEqual('tx3nHShG60zq');
+        expect(amountCall[3]).toEqual(99);
+      });
+
+      it('should call getFieldValueOnChange for updating dateOfSpend with correct arguments', () => {
+        component.touchedGenericFields = ['amount'];
+        component.genericFieldsForm.patchValue({ dateOfSpend: new Date('2023-03-13T11:30:00.000Z') });
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.dateOfSpend).toEqual(new Date('2023-03-13T11:30:00.000Z'));
+        const dateOfSpendCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(1);
+        expect(dateOfSpendCall[0]).toEqual(optionsData6);
+        expect(dateOfSpendCall[1]).toEqual(false);
+        expect(dateOfSpendCall[2]).toEqual(new Date('2021-07-29T06:30:00.000Z'));
+        expect(dateOfSpendCall[3]).toEqual(new Date('2023-03-13T11:30:00.000Z'));
+      });
+
+      it('should call getFieldValueOnChange for updating paymentMode with correct arguments', () => {
+        component.touchedGenericFields = ['paymentMode'];
+        component.genericFieldsForm.patchValue({ paymentMode: 'PERSONAL_ACCOUNT' });
+        component.onExpenseChanged(-1);
+        expect(component.fg.controls.genericFields.value.paymentMode).toEqual('PERSONAL_ACCOUNT');
+        const paymentModeCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(2);
+        expect(paymentModeCall[0]).toEqual(optionsData7);
+        expect(paymentModeCall[1]).toEqual(true);
+        expect(paymentModeCall[2]).toEqual(undefined);
+        expect(paymentModeCall[3]).toEqual('PERSONAL_ACCOUNT');
+      });
+
+      it('should call getFieldValueOnChange for updating project with correct arguments', () => {
+        component.touchedGenericFields = ['amount'];
+        component.genericFieldsForm.patchValue({ project: 'PROJECT_1' });
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.project).toEqual('3943');
+        const projectCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(3);
+        expect(projectCall[0]).toEqual(optionsData9);
+        expect(projectCall[1]).toEqual(false);
+        expect(projectCall[2]).toEqual(3812);
+        expect(projectCall[3]).toEqual('PROJECT_1');
+      });
+
+      it('should call getFieldValueOnChange for updating billable with correct arguments', () => {
+        component.touchedGenericFields = ['billable'];
+        component.genericFieldsForm.patchValue({ billable: false });
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.billable).toEqual(false);
+        const billableCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(4);
+        expect(billableCall[0]).toEqual(optionsData2);
+        expect(billableCall[1]).toEqual(true);
+        expect(billableCall[2]).toEqual(false);
+        expect(billableCall[3]).toEqual(false);
+      });
+
+      it('should call getFieldValueOnChange for updating category with correct arguments', () => {
+        component.touchedGenericFields = ['category'];
+        component.genericFieldsForm.patchValue({ category: 213 });
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.category).toEqual(207484);
+        const categoryCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(5);
+        expect(categoryCall[0]).toEqual(optionsData10);
+        expect(categoryCall[1]).toEqual(true);
+        expect(categoryCall[2]).toEqual(207484);
+        expect(categoryCall[3]).toEqual(213);
+      });
+
+      it('should call getFieldValueOnChange for updating vendor with correct arguments', () => {
+        component.touchedGenericFields = ['category'];
+        component.genericFieldsForm.patchValue({ vendor: 'VENDOR_1' });
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.vendor).toEqual('Nilesh As Vendor');
+        const vendorCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(6);
+        expect(vendorCall[0]).toEqual(optionsData8);
+        expect(vendorCall[1]).toEqual(false);
+        expect(vendorCall[2]).toEqual('ramdev baba');
+        expect(vendorCall[3]).toEqual('VENDOR_1');
+      });
+
+      it('should call getFieldValueOnChange for updating tax_group with correct arguments', () => {
+        component.touchedGenericFields = ['tax_group'];
+        component.genericFieldsForm.patchValue({ tax_group: 'TAX_GROUP_1' });
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.tax_group).toEqual('tgXEJA6YUoZ1');
+        const taxGroupCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(7);
+        expect(taxGroupCall[0]).toEqual(optionsData11);
+        expect(taxGroupCall[1]).toEqual(true);
+        expect(taxGroupCall[2]).toEqual('tgFDWBpJL3vy');
+        expect(taxGroupCall[3]).toEqual('TAX_GROUP_1');
+      });
+
+      it('should call getFieldValueOnChange for updating tax_amount with correct arguments', () => {
+        component.touchedGenericFields = ['tax_amount'];
+        component.genericFieldsForm.patchValue({ tax_amount: 99 });
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.tax_amount).toEqual(0.01);
+        const taxAmountCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(8);
+        expect(taxAmountCall[0]).toEqual(optionsData12);
+        expect(taxAmountCall[1]).toEqual(true);
+        expect(taxAmountCall[2]).toEqual(0.32);
+        expect(taxAmountCall[3]).toEqual(99);
+      });
+
+      it('should call getFieldValueOnChange for updating costCenter with correct arguments', () => {
+        component.touchedGenericFields = ['costCenter'];
+        component.genericFieldsForm.patchValue({ costCenter: 'COST_CENTER_1' });
+        component.onExpenseChanged(1);
+
+        expect(component.fg.controls.genericFields.value.costCenter).toEqual('213');
+        const costCenterCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(9);
+        expect(costCenterCall[0]).toEqual(optionsData13);
+        expect(costCenterCall[1]).toEqual(true);
+        expect(costCenterCall[2]).toEqual('213');
+        expect(costCenterCall[3]).toEqual('COST_CENTER_1');
+      });
+
+      it('should call getFieldValueOnChange for updating purpose with correct arguments', () => {
+        component.touchedGenericFields = ['purpose'];
+        component.genericFieldsForm.patchValue({ purpose: 'PURPOSE_1' });
+        component.onExpenseChanged(1);
+        expect(component.fg.controls.genericFields.value.purpose).toEqual('Outing');
+        const customFieldsCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(10);
+        expect(customFieldsCall[0]).toEqual(optionsData14);
+        expect(customFieldsCall[1]).toEqual(true);
+        expect(customFieldsCall[2]).toEqual('Others');
+        expect(customFieldsCall[3]).toEqual('PURPOSE_1');
+      });
+    });
+
+    describe('loadCategoryDependentFields(): ', () => {
+      beforeEach(() => {
+        component.location1OptionsData$ = of(optionsData15);
+        component.location2OptionsData$ = of(optionsData15);
+        component.onwardDateOptionsData$ = of(optionsData16);
+        component.returnDateOptionsData$ = of(optionsData16);
+        component.flightJourneyTravelClassOptionsData$ = of(optionsData17);
+        component.flightReturnTravelClassOptionsData$ = of(optionsData17);
+        component.trainTravelClassOptionsData$ = of(optionsData18);
+        component.busTravelClassOptionsData$ = of(optionsData19);
+        component.distanceOptionsData$ = of(optionsData20);
+        component.distanceUnitOptionsData$ = of(optionsData21);
+        mergeExpensesService.getFieldValue.and.returnValues(
+          null,
+          null,
+          new Date('2023-03-13T05:31:00.000Z'),
+          new Date('2023-03-13T05:31:00.000Z'),
+          'ECONOMY',
+          'ECONOMY',
+          null,
+          'AC',
+          null,
+          null
+        );
+      });
+
+      it('should set categoryDependent fields in the form correctly', () => {
+        component.loadCategoryDependentFields();
+
+        expect(component.fg.controls.categoryDependent.value.location_1).toEqual(null);
+        expect(component.fg.controls.categoryDependent.value.location_2).toEqual(null);
+        expect(component.fg.controls.categoryDependent.value.from_dt).toEqual(new Date('2023-03-13T05:31:00.000Z'));
+        expect(component.fg.controls.categoryDependent.value.to_dt).toEqual(new Date('2023-03-13T05:31:00.000Z'));
+        expect(component.fg.controls.categoryDependent.value.flight_journey_travel_class).toEqual('ECONOMY');
+        expect(component.fg.controls.categoryDependent.value.flight_return_travel_class).toEqual('ECONOMY');
+        expect(component.fg.controls.categoryDependent.value.train_travel_class).toEqual(null);
+        expect(component.fg.controls.categoryDependent.value.bus_travel_class).toEqual('AC');
+        expect(component.fg.controls.categoryDependent.value.distance).toEqual(null);
+        expect(component.fg.controls.categoryDependent.value.distance_unit).toEqual(null);
+      });
+
+      it('should call mergeExpensesService.getFieldValue with correct arguments', () => {
+        component.loadCategoryDependentFields();
+
+        expect(mergeExpensesService.getFieldValue).toHaveBeenCalledTimes(10);
+        const location1Call = mergeExpensesService.getFieldValue.calls.argsFor(0);
+        expect(location1Call).toEqual([optionsData15]);
+        const location2Call = mergeExpensesService.getFieldValue.calls.argsFor(1);
+        expect(location2Call).toEqual([optionsData15]);
+        const onwardDateCall = mergeExpensesService.getFieldValue.calls.argsFor(2);
+        expect(onwardDateCall).toEqual([optionsData16]);
+        const returnDateCall = mergeExpensesService.getFieldValue.calls.argsFor(3);
+        expect(returnDateCall).toEqual([optionsData16]);
+        const flightJourneyTravelClassCall = mergeExpensesService.getFieldValue.calls.argsFor(4);
+        expect(flightJourneyTravelClassCall).toEqual([optionsData17]);
+        const flightReturnTravelClassCall = mergeExpensesService.getFieldValue.calls.argsFor(5);
+        expect(flightReturnTravelClassCall).toEqual([optionsData17]);
+        const trainTravelClassCall = mergeExpensesService.getFieldValue.calls.argsFor(6);
+        expect(trainTravelClassCall).toEqual([optionsData18]);
+        const busTravelClassCall = mergeExpensesService.getFieldValue.calls.argsFor(7);
+        expect(busTravelClassCall).toEqual([optionsData19]);
+        const distanceCall = mergeExpensesService.getFieldValue.calls.argsFor(8);
+        expect(distanceCall).toEqual([optionsData20]);
+        const distanceUnitCall = mergeExpensesService.getFieldValue.calls.argsFor(9);
+        expect(distanceUnitCall).toEqual([optionsData21]);
+      });
+    });
+
+    it('onReceiptChanged(): should set selectedReceiptsId and attachments correctly after calling mergeExpensesService.getAttachements', () => {
+      const receiptId = 'txz2vohKxBXu';
+      const expectedSelectedReceiptsId = ['ficaDEJBVhjm', 'firDjjutGXfT'];
+      mergeExpensesService.getAttachements.and.returnValue(of(fileObject7));
+      component.onReceiptChanged(receiptId);
+
+      expect(mergeExpensesService.getAttachements).toHaveBeenCalledOnceWith(receiptId);
+      expect(component.selectedReceiptsId).toEqual(expectedSelectedReceiptsId);
+      expect(component.attachments).toEqual(fileObject7);
+    });
+
+    describe('mergeExpense(): ', () => {
+      beforeEach(() => {
+        component.fg = formBuilder.group({
+          target_txn_id: 'txBphgnCHHeO',
+          genericFields: [],
+          categoryDependent: [],
+          custom_inputs: [],
+        });
+        spyOn(component.fg, 'markAllAsTouched');
+        component.expenses = cloneDeep(expenseList2);
+        component.projectDependentFieldsMapping$ = of(projectDependentFieldsMappingData1);
+        component.costCenterDependentFieldsMapping$ = of(CostCenterDependentFieldsMappingData1);
+        mergeExpensesService.mergeExpenses.and.returnValue(of('txVNpvgTPW4Z'));
+        spyOn(component, 'generateFromFg').and.returnValue(generatedFormPropertiesData1);
+        spyOn(component, 'showMergedSuccessToast');
+        spyOn(component, 'goBack');
+      });
+
+      it('should call fg.markAllAsTouched once and set isMerging to false', () => {
+        component.mergeExpense();
+        expect(component.fg.markAllAsTouched).toHaveBeenCalledTimes(1);
+        expect(component.isMerging).toEqual(false);
+      });
+
+      it('should call mergeExpensesService.mergeExpenses once', () => {
+        component.mergeExpense();
+        expect(mergeExpensesService.mergeExpenses).toHaveBeenCalledOnceWith(
+          ['tx3nHShG60zq'],
+          'txBphgnCHHeO',
+          generatedFormPropertiesData1
+        );
+        expect(component.generateFromFg).toHaveBeenCalledOnceWith({
+          ...projectDependentFieldsMappingData1,
+          ...CostCenterDependentFieldsMappingData1,
+        });
+      });
+
+      it('should call trackingService.expensesMerged, showMergedSuccessToast and goBack method once', () => {
+        component.mergeExpense();
+        expect(trackingService.expensesMerged).toHaveBeenCalledTimes(1);
+        expect(component.showMergedSuccessToast).toHaveBeenCalledTimes(1);
+        expect(component.goBack).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+}

--- a/src/app/fyle/merge-expense/merge-expense-3.page.spec.ts
+++ b/src/app/fyle/merge-expense/merge-expense-3.page.spec.ts
@@ -1,0 +1,629 @@
+import { ComponentFixture, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { MergeExpensePage } from './merge-expense.page';
+import { ActivatedRoute, Router } from '@angular/router';
+import { CategoriesService } from 'src/app/core/services/categories.service';
+import { CustomInputsService } from 'src/app/core/services/custom-inputs.service';
+import { CustomFieldsService } from 'src/app/core/services/custom-fields.service';
+import { NavController } from '@ionic/angular';
+import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar';
+import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
+import { MergeExpensesService } from 'src/app/core/services/merge-expenses.service';
+import { TrackingService } from 'src/app/core/services/tracking.service';
+import { ExpenseFieldsService } from 'src/app/core/services/expense-fields.service';
+import { DependentFieldsService } from 'src/app/core/services/dependent-fields.service';
+import { FormBuilder, Validators } from '@angular/forms';
+import { cloneDeep } from 'lodash';
+import { apiExpenseRes, expenseList2 } from 'src/app/core/mock-data/expense.data';
+import { BehaviorSubject, Observable, Subscription, of, skip, take } from 'rxjs';
+import {
+  optionsData10,
+  optionsData11,
+  optionsData12,
+  optionsData13,
+  optionsData14,
+  optionsData15,
+  optionsData16,
+  optionsData17,
+  optionsData18,
+  optionsData19,
+  optionsData2,
+  optionsData20,
+  optionsData21,
+  optionsData3,
+  optionsData32,
+  optionsData6,
+  optionsData7,
+  optionsData8,
+  optionsData9,
+} from 'src/app/core/mock-data/merge-expenses-options-data.data';
+import {
+  combinedOptionsData1,
+  combinedOptionsData2,
+  combinedOptionsData3,
+} from 'src/app/core/mock-data/combined-options.data';
+import { fileObject7 } from 'src/app/core/mock-data/file-object.data';
+import { projectDependentFieldsMappingData1 } from 'src/app/core/mock-data/project-dependent-fields-mapping.data';
+import { CostCenterDependentFieldsMappingData1 } from 'src/app/core/mock-data/cost-center-dependent-fields-mapping.data';
+import {
+  generatedFormPropertiesData1,
+  generatedFormPropertiesData2,
+  generatedFormPropertiesData3,
+  generatedFormPropertiesData4,
+} from 'src/app/core/mock-data/generated-form-properties.data';
+import { ToastMessageComponent } from 'src/app/shared/components/toast-message/toast-message.component';
+import { snackbarPropertiesRes5 } from 'src/app/core/mock-data/snackbar-properties.data';
+import {
+  mergeExpenseFormData1,
+  mergeExpenseFormData2,
+  mergeExpenseFormData3,
+  mergeExpenseFormData4,
+  mergeExpenseFormData5,
+} from 'src/app/core/mock-data/merge-expense-form-data.data';
+import { dependentCustomFields } from 'src/app/core/mock-data/expense-field.data';
+import {
+  expectedTxnCustomProperties,
+  expectedTxnCustomProperties2,
+  txnCustomPropertiesData,
+  txnCustomPropertiesData2,
+} from 'src/app/core/mock-data/txn-custom-properties.data';
+import { filterTestData } from 'src/app/core/test-data/custom-inputs.spec.data';
+import { responseAfterAppliedFilter } from 'src/app/core/test-data/custom-inputs.spec.data';
+import { expenseFieldsMapResponse, expenseFieldsMapResponse4 } from 'src/app/core/mock-data/expense-fields-map.data';
+import { dependentFieldsMappingForProject } from 'src/app/core/mock-data/dependent-field-mapping.data';
+import { expectedCustomInputFields } from 'src/app/core/mock-data/custom-field.data';
+import { apiCardV2Transactions } from 'src/app/core/mock-data/ccc-api-response';
+import { expenseInfoWithoutDefaultExpense, expensesInfo } from 'src/app/core/mock-data/expenses-info.data';
+
+export function TestCases3(getTestBed) {
+  return describe('test cases set 3', () => {
+    let component: MergeExpensePage;
+    let fixture: ComponentFixture<MergeExpensePage>;
+    let router: jasmine.SpyObj<Router>;
+    let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+    let categoriesService: jasmine.SpyObj<CategoriesService>;
+    let customInputsService: jasmine.SpyObj<CustomInputsService>;
+    let customFieldsService: jasmine.SpyObj<CustomFieldsService>;
+    let navController: jasmine.SpyObj<NavController>;
+    let matSnackBar: jasmine.SpyObj<MatSnackBar>;
+    let snackbarProperties: jasmine.SpyObj<SnackbarPropertiesService>;
+    let mergeExpensesService: jasmine.SpyObj<MergeExpensesService>;
+    let trackingService: jasmine.SpyObj<TrackingService>;
+    let expenseFieldsService: jasmine.SpyObj<ExpenseFieldsService>;
+    let dependantFieldsService: jasmine.SpyObj<DependentFieldsService>;
+    let formBuilder: FormBuilder;
+
+    beforeEach(waitForAsync(() => {
+      const TestBed = getTestBed();
+      fixture = TestBed.createComponent(MergeExpensePage);
+      component = fixture.componentInstance;
+      router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+      activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
+      categoriesService = TestBed.inject(CategoriesService) as jasmine.SpyObj<CategoriesService>;
+      customInputsService = TestBed.inject(CustomInputsService) as jasmine.SpyObj<CustomInputsService>;
+      customFieldsService = TestBed.inject(CustomFieldsService) as jasmine.SpyObj<CustomFieldsService>;
+      navController = TestBed.inject(NavController) as jasmine.SpyObj<NavController>;
+      matSnackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
+      snackbarProperties = TestBed.inject(SnackbarPropertiesService) as jasmine.SpyObj<SnackbarPropertiesService>;
+      mergeExpensesService = TestBed.inject(MergeExpensesService) as jasmine.SpyObj<MergeExpensesService>;
+      trackingService = TestBed.inject(TrackingService) as jasmine.SpyObj<TrackingService>;
+      expenseFieldsService = TestBed.inject(ExpenseFieldsService) as jasmine.SpyObj<ExpenseFieldsService>;
+      dependantFieldsService = TestBed.inject(DependentFieldsService) as jasmine.SpyObj<DependentFieldsService>;
+      formBuilder = TestBed.inject(FormBuilder);
+      component.fg = formBuilder.group({
+        target_txn_id: [, Validators.required],
+        genericFields: [],
+        categoryDependent: [],
+        custom_inputs: [],
+      });
+    }));
+
+    describe('setupCustomInputs(): ', () => {
+      beforeEach(() => {
+        customInputsService.getAll.and.returnValue(of(filterTestData));
+        component.loadCustomFields$ = new BehaviorSubject(null);
+        customFieldsService.standardizeCustomFields.and.returnValue(txnCustomPropertiesData);
+        customInputsService.filterByCategory.and.returnValue(responseAfterAppliedFilter);
+        spyOn(component, 'patchCustomInputsValues');
+        spyOn(component, 'getDependentFieldsMapping').and.returnValues(
+          of(projectDependentFieldsMappingData1),
+          of(CostCenterDependentFieldsMappingData1)
+        );
+      });
+
+      it('should call customInputsService.getAll() once with true', () => {
+        component.setupCustomInputs();
+        expect(customInputsService.getAll).toHaveBeenCalledOnceWith(true);
+      });
+
+      it('should call customFieldsService.standardizeCustomFields with empty array if fields are not defined in custom_inputs', (done) => {
+        component.loadCustomFields$ = new BehaviorSubject('201952');
+        component.setupCustomInputs();
+
+        component.customInputs$.pipe(skip(1)).subscribe(() => {
+          expect(customFieldsService.standardizeCustomFields).toHaveBeenCalledTimes(2);
+          expect(customInputsService.filterByCategory).toHaveBeenCalledTimes(2);
+          expect(customFieldsService.standardizeCustomFields).toHaveBeenCalledWith([], responseAfterAppliedFilter);
+          const firstFilterByCategoryCall = customInputsService.filterByCategory.calls.argsFor(0);
+          expect(firstFilterByCategoryCall).toEqual([filterTestData, null]);
+          const secondFilterByCategoryCall = customInputsService.filterByCategory.calls.argsFor(1);
+          expect(secondFilterByCategoryCall).toEqual([filterTestData, '201952']);
+          done();
+        });
+      });
+
+      it('should call customFieldsService.standardizeCustomFields with custom_inputs if fields are defined in custom_inputs', (done) => {
+        component.fg = formBuilder.group(mergeExpenseFormData1);
+        component.loadCustomFields$ = new BehaviorSubject('201952');
+        component.setupCustomInputs();
+
+        component.customInputs$.pipe(skip(1)).subscribe(() => {
+          expect(customFieldsService.standardizeCustomFields).toHaveBeenCalledTimes(2);
+          expect(customFieldsService.standardizeCustomFields).toHaveBeenCalledWith(
+            mergeExpenseFormData1.custom_inputs.fields,
+            responseAfterAppliedFilter
+          );
+          expect(customInputsService.filterByCategory).toHaveBeenCalledTimes(2);
+          const firstFilterByCategoryCall = customInputsService.filterByCategory.calls.argsFor(0);
+          expect(firstFilterByCategoryCall).toEqual([filterTestData, null]);
+          const secondFilterByCategoryCall = customInputsService.filterByCategory.calls.argsFor(1);
+          expect(secondFilterByCategoryCall).toEqual([filterTestData, '201952']);
+          done();
+        });
+      });
+
+      it('should return customFields correctly', (done) => {
+        component.setupCustomInputs();
+        component.customInputs$.pipe(skip(1)).subscribe((customInputs) => {
+          expect(customInputs).toEqual(txnCustomPropertiesData);
+          done();
+        });
+      });
+
+      it('should call patchCustomInputsValues if isMerging is false', (done) => {
+        component.isMerging = false;
+        component.setupCustomInputs();
+
+        component.customInputs$.pipe(skip(1)).subscribe(() => {
+          expect(component.patchCustomInputsValues).toHaveBeenCalledTimes(2);
+          expect(component.patchCustomInputsValues).toHaveBeenCalledWith(txnCustomPropertiesData);
+          done();
+        });
+      });
+
+      it('should not call patchCustomInputsValues if isMerging is true', (done) => {
+        component.isMerging = true;
+        component.setupCustomInputs();
+
+        component.customInputs$.pipe(skip(1)).subscribe(() => {
+          expect(component.patchCustomInputsValues).not.toHaveBeenCalled();
+          done();
+        });
+      });
+
+      it('should assign projectDependentFieldsMapping$ and costCenterDependentFieldsMapping$ correctly', () => {
+        component.setupCustomInputs();
+        component.projectDependentFieldsMapping$.subscribe((projectDependentFields) => {
+          expect(projectDependentFields).toEqual(projectDependentFieldsMappingData1);
+        });
+        component.costCenterDependentFieldsMapping$.subscribe((costCenterDependentFields) => {
+          expect(costCenterDependentFields).toEqual(CostCenterDependentFieldsMappingData1);
+        });
+        expect(component.getDependentFieldsMapping).toHaveBeenCalledTimes(2);
+        expect(component.getDependentFieldsMapping).toHaveBeenCalledWith('PROJECT');
+        expect(component.getDependentFieldsMapping).toHaveBeenCalledWith('COST_CENTER');
+      });
+    });
+
+    describe('getDependentFieldsMapping(): ', () => {
+      beforeEach(() => {
+        expenseFieldsService.getAllMap.and.returnValue(of(expenseFieldsMapResponse4));
+        dependantFieldsService.getDependentFieldsForBaseField.and.returnValue(of(dependentCustomFields));
+        customFieldsService.standardizeCustomFields.and.returnValue(expectedTxnCustomProperties);
+        mergeExpensesService.getDependentFieldsMapping.and.returnValue(dependentFieldsMappingForProject);
+      });
+
+      it('should call expenseFieldsService.getAllMap() once', () => {
+        component.getDependentFieldsMapping('PROJECT');
+        expect(expenseFieldsService.getAllMap).toHaveBeenCalledTimes(1);
+      });
+
+      it('should call dependantFieldsService.getDependentFieldsForBaseField() once with project_id.id if parentField is PROJECT', () => {
+        component.getDependentFieldsMapping('PROJECT').subscribe((res) => {
+          expect(dependantFieldsService.getDependentFieldsForBaseField).toHaveBeenCalledOnceWith(1);
+        });
+      });
+
+      it('should call dependantFieldsService.getDependentFieldsForBaseField() once with cost_center_id.id if parentField is COST_CENTER', () => {
+        component.getDependentFieldsMapping('COST_CENTER').subscribe((res) => {
+          expect(dependantFieldsService.getDependentFieldsForBaseField).toHaveBeenCalledOnceWith(3);
+        });
+      });
+
+      it('should call customFieldsService.standardizeCustomFields() once with customFields', () => {
+        component.getDependentFieldsMapping('PROJECT').subscribe((res) => {
+          expect(customFieldsService.standardizeCustomFields).toHaveBeenCalledOnceWith([], dependentCustomFields);
+        });
+      });
+
+      it('should call mergeExpensesService.getDependentFieldsMapping() once with expense, dependentField and parentField if parentField is PROJECT', () => {
+        component.expenses = expenseList2;
+        component.getDependentFieldsMapping('PROJECT').subscribe((res) => {
+          expect(mergeExpensesService.getDependentFieldsMapping).toHaveBeenCalledOnceWith(
+            expenseList2,
+            expectedTxnCustomProperties,
+            'PROJECT'
+          );
+        });
+      });
+
+      it('should call mergeExpensesService.getDependentFieldsMapping() once with expense, dependentField and parentField if parentField is COST_CENTER', () => {
+        component.expenses = expenseList2;
+        component.getDependentFieldsMapping('COST_CENTER').subscribe((res) => {
+          expect(mergeExpensesService.getDependentFieldsMapping).toHaveBeenCalledOnceWith(
+            expenseList2,
+            expectedTxnCustomProperties,
+            'COST_CENTER'
+          );
+        });
+      });
+
+      it('should return the dependentFieldsMapping correctly', () => {
+        const dependentFieldsMapping$ = component.getDependentFieldsMapping('COST_CENTER');
+        dependentFieldsMapping$.subscribe((dependentFieldsMapping) => {
+          expect(dependentFieldsMapping).toEqual(dependentFieldsMappingForProject);
+        });
+      });
+    });
+
+    it('patchCustomInputsValues(): should patch customInputsValues correctly', () => {
+      component.combinedCustomProperties = combinedOptionsData2;
+      component.patchCustomInputsValues(txnCustomPropertiesData);
+      expect(component.fg.controls.custom_inputs.value).toEqual(expectedCustomInputFields);
+    });
+
+    it('onPaymentModeChanged(): should call mergeExpensesService.getCorporateCardTransactions() once and assign CCCTxns correctly', () => {
+      component.expenses = expenseList2;
+      mergeExpensesService.getCorporateCardTransactions.and.returnValue(of(apiCardV2Transactions.data));
+      component.onPaymentModeChanged();
+      expect(mergeExpensesService.getCorporateCardTransactions).toHaveBeenCalledOnceWith(expenseList2);
+      expect(component.CCCTxns).toEqual(apiCardV2Transactions.data);
+    });
+
+    describe('generateCustomInputOptions(): ', () => {
+      beforeEach(() => {
+        component.expenses = expenseList2;
+        mergeExpensesService.getCustomInputValues.and.returnValue(cloneDeep(expectedTxnCustomProperties2));
+        mergeExpensesService.formatCustomInputOptions.and.returnValue({
+          'select all 2': optionsData32[7],
+        });
+      });
+
+      it('should return customInput options correctly', () => {
+        const customInputOptions = component.generateCustomInputOptions();
+        expect(mergeExpensesService.formatCustomInputOptions).toHaveBeenCalledOnceWith(optionsData32);
+        expect(customInputOptions).toEqual({
+          'select all 2': optionsData32[7],
+        });
+      });
+    });
+
+    describe('setAdvanceOrApprovedAndAbove(): ', () => {
+      beforeEach(() => {
+        component.expenses = apiExpenseRes;
+        mergeExpensesService.isApprovedAndAbove.and.returnValue(apiExpenseRes);
+      });
+
+      it('should call mergeExpensesService.isApprovedAndAbove() once with expenses', () => {
+        component.setAdvanceOrApprovedAndAbove(expensesInfo);
+        expect(mergeExpensesService.isApprovedAndAbove).toHaveBeenCalledOnceWith(apiExpenseRes);
+      });
+
+      it('should set disableFormElements to true if isApprovedAndAbove length is greater than zero', () => {
+        component.setAdvanceOrApprovedAndAbove(expensesInfo);
+        expect(component.disableFormElements).toEqual(true);
+      });
+
+      it('should set disableFormElements to false if isApprovedAndAbove length is zero and isAdvancePresent is false', () => {
+        mergeExpensesService.isApprovedAndAbove.and.returnValue([]);
+        const mockExpenseInfo = cloneDeep(expensesInfo);
+        mockExpenseInfo.isAdvancePresent = false;
+        component.setAdvanceOrApprovedAndAbove(mockExpenseInfo);
+        expect(component.disableFormElements).toEqual(false);
+      });
+
+      it('should set disableFormElements to true if expensesInfo.isAdvancePresent is true', () => {
+        mergeExpensesService.isApprovedAndAbove.and.returnValue([]);
+        component.setAdvanceOrApprovedAndAbove(expensesInfo);
+        expect(component.disableFormElements).toEqual(true);
+      });
+    });
+
+    describe('setIsReported(): ', () => {
+      beforeEach(() => {
+        component.expenses = expenseList2;
+        mergeExpensesService.isReportedPresent.and.returnValue([expenseList2[0]]);
+      });
+
+      it('should call mergeExpensesService.isReportedPresent() once and set isReportedExpensePresent to true if isReported length is greater than zero', () => {
+        component.setIsReported(expensesInfo);
+        expect(mergeExpensesService.isReportedPresent).toHaveBeenCalledOnceWith(expenseList2);
+        expect(component.isReportedExpensePresent).toEqual(true);
+      });
+
+      it('should set isReportedExpensePresent to false if isReported length is zero', () => {
+        mergeExpensesService.isReportedPresent.and.returnValue([]);
+        component.setIsReported(expensesInfo);
+        expect(component.isReportedExpensePresent).toEqual(false);
+      });
+
+      it('should set disableFormElements and showReceiptSelection to true if isReportedExpensePresent and expensesInfo.isAdvancePresent is true', () => {
+        component.disableFormElements = false;
+        component.showReceiptSelection = false;
+        component.setIsReported(expensesInfo);
+        expect(component.disableFormElements).toEqual(true);
+        expect(component.showReceiptSelection).toEqual(true);
+      });
+
+      it('should not modify disableFormElements and showReceiptSelection if isReportedExpensePresent is false', () => {
+        component.disableFormElements = false;
+        component.showReceiptSelection = false;
+        mergeExpensesService.isReportedPresent.and.returnValue([]);
+        component.setIsReported(expensesInfo);
+        expect(component.disableFormElements).toEqual(false);
+        expect(component.showReceiptSelection).toEqual(false);
+      });
+
+      it('should not modify disableFormElements and showReceiptSelection if expensesInfo.isAdvancePresent is false', () => {
+        component.disableFormElements = false;
+        component.showReceiptSelection = false;
+        const mockExpenseInfo = cloneDeep(expensesInfo);
+        mockExpenseInfo.isAdvancePresent = false;
+        component.setIsReported(mockExpenseInfo);
+        expect(component.disableFormElements).toEqual(false);
+        expect(component.showReceiptSelection).toEqual(false);
+      });
+    });
+
+    describe('setInitialExpenseToKeepDetails(): ', () => {
+      beforeEach(() => {
+        mergeExpensesService.isReportedOrAbove.and.returnValue(false);
+        mergeExpensesService.isMoreThanOneAdvancePresent.and.returnValue(false);
+        mergeExpensesService.isAdvancePresent.and.returnValue(false);
+        spyOn(component, 'setAdvanceOrApprovedAndAbove');
+      });
+
+      it('should not call isReportedOrAbove, isMoreThanOneAdvancePresent and isAdvancePresent methods of mergeExpensesService and should not call setAdvanceOrApprovedAndAbove method', () => {
+        component.setInitialExpenseToKeepDetails(expenseInfoWithoutDefaultExpense, true);
+        expect(mergeExpensesService.isReportedOrAbove).not.toHaveBeenCalled();
+        expect(mergeExpensesService.isMoreThanOneAdvancePresent).not.toHaveBeenCalled();
+        expect(mergeExpensesService.isAdvancePresent).not.toHaveBeenCalled();
+        expect(component.setAdvanceOrApprovedAndAbove).not.toHaveBeenCalled();
+      });
+
+      it('should call mergeExpensesService.isReportedOrAbove once and set disableExpenseToKeep, expenseToKeepInfoText and modify target_txn_id in form', () => {
+        mergeExpensesService.isReportedOrAbove.and.returnValue(true);
+        spyOn(component, 'setIsReported');
+        component.disableExpenseToKeep = false;
+        component.expenseToKeepInfoText = '';
+
+        component.setInitialExpenseToKeepDetails(expensesInfo, true);
+        expect(mergeExpensesService.isReportedOrAbove).toHaveBeenCalledOnceWith(expensesInfo);
+        expect(component.setIsReported).toHaveBeenCalledOnceWith(expensesInfo);
+        expect(component.disableExpenseToKeep).toEqual(true);
+        expect(component.expenseToKeepInfoText).toEqual(
+          'You are required to keep the expense that has already been submitted.'
+        );
+        expect(component.fg.controls.target_txn_id.value).toEqual('txB1rVZJ4Pxl');
+      });
+
+      it('should call mergeExpensesService.isMoreThanOneAdvancePresent once and modify showReceiptSelection and expenseToKeepInfoText', () => {
+        mergeExpensesService.isMoreThanOneAdvancePresent.and.returnValue(true);
+        spyOn(component, 'setIsReported');
+        component.disableExpenseToKeep = false;
+        component.showReceiptSelection = false;
+        component.expenseToKeepInfoText = '';
+
+        component.setInitialExpenseToKeepDetails(expensesInfo, true);
+
+        expect(mergeExpensesService.isMoreThanOneAdvancePresent).toHaveBeenCalledOnceWith(expensesInfo, true);
+        expect(component.setIsReported).not.toHaveBeenCalled();
+        expect(component.disableExpenseToKeep).toEqual(false);
+        expect(component.showReceiptSelection).toEqual(true);
+        expect(component.expenseToKeepInfoText).toEqual(
+          'You cannot make changes to an expense paid from ‘advance’. Edit each expense separately if you wish to make any changes.'
+        );
+        expect(component.fg.controls.target_txn_id.value).not.toEqual('txB1rVZJ4Pxl');
+      });
+
+      it('should call mergeExpensesService.isAdvancePresent once and modify disableExpenseToKeep, expenseToKeepInfoText and target_txn_id property in form', () => {
+        mergeExpensesService.isAdvancePresent.and.returnValue(true);
+        spyOn(component, 'setIsReported');
+        component.disableExpenseToKeep = false;
+        component.showReceiptSelection = false;
+        component.expenseToKeepInfoText = '';
+
+        component.setInitialExpenseToKeepDetails(expensesInfo, true);
+
+        expect(mergeExpensesService.isAdvancePresent).toHaveBeenCalledOnceWith(expensesInfo);
+        expect(component.setIsReported).not.toHaveBeenCalled();
+        expect(component.disableExpenseToKeep).toEqual(true);
+        expect(component.showReceiptSelection).toEqual(false);
+        expect(component.expenseToKeepInfoText).toEqual(
+          'You are required to keep the expense paid from ‘advance’. Edit each expense separately if you wish to make any changes.'
+        );
+        expect(component.fg.controls.target_txn_id.value).toEqual('txB1rVZJ4Pxl');
+      });
+
+      it('should call setAdvanceOrApprovedAndAbove once', () => {
+        component.setInitialExpenseToKeepDetails(expensesInfo, true);
+        expect(component.setAdvanceOrApprovedAndAbove).toHaveBeenCalledOnceWith(expensesInfo);
+      });
+    });
+
+    it('onGenericFieldsTouched(): should update touchedGenericFields with the touched generic fields', () => {
+      component.touchedGenericFields = [];
+      component.onGenericFieldsTouched(['currency', 'amount']);
+      expect(component.touchedGenericFields).toEqual(['currency', 'amount']);
+    });
+
+    it('onCategoryDependentFieldsTouched(): should update touchedCategoryDependentFields with the touched category dependent fields', () => {
+      component.touchedCategoryDepedentFields = [];
+      component.onCategoryDependentFieldsTouched(['category', 'sub_category']);
+      expect(component.touchedCategoryDepedentFields).toEqual(['category', 'sub_category']);
+    });
+
+    describe('patchCategoryDependentFields(): ', () => {
+      beforeEach(() => {
+        const mockExpense = cloneDeep(expenseList2);
+        mockExpense[1].tx_locations = ['Mumbai', 'Pune'];
+        mockExpense[1].tx_flight_journey_travel_class = 'ECONOMY';
+        mockExpense[1].tx_flight_return_travel_class = 'BUSINESS';
+        mockExpense[1].tx_distance = 23;
+        mockExpense[1].tx_distance_unit = 'KM';
+        component.expenses = mockExpense;
+        component.categoryDependentFieldsOptions$ = of(combinedOptionsData3);
+        mergeExpensesService.getFieldValueOnChange.and.returnValues(
+          'Mumbai',
+          'Pune',
+          new Date('2023-03-13T11:30:00.000Z'),
+          new Date('2023-03-13T11:30:00.000Z'),
+          'ECONOMY',
+          'BUSINESS',
+          'SLEEPER',
+          'AC',
+          23,
+          'KM'
+        );
+      });
+
+      it('should call getFieldValueOnChange 10 times', () => {
+        component.patchCategoryDependentFields(1);
+        expect(mergeExpensesService.getFieldValueOnChange).toHaveBeenCalledTimes(10);
+      });
+
+      it('should call getFieldValueOnChange with correct args', () => {
+        component.touchedGenericFields = ['location_1', 'from_dt', 'flight_journey_travel_class'];
+        component.genericFieldsForm.patchValue({
+          location_1: 'Mumbai',
+          location_2: 'Pune',
+          flight_journey_travel_class: 'ECONOMY',
+          train_travel_class: 'SLEEPER',
+          distance: 23,
+          distance_unit: 'KM',
+        });
+        component.patchCategoryDependentFields(1);
+        const location1Call = mergeExpensesService.getFieldValueOnChange.calls.argsFor(0);
+        expect(location1Call).toEqual([optionsData15, true, 'Mumbai', 'Mumbai']);
+        const location2Call = mergeExpensesService.getFieldValueOnChange.calls.argsFor(1);
+        expect(location2Call).toEqual([optionsData15, false, 'Pune', 'Pune']);
+        const fromDtCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(2);
+        expect(fromDtCall).toEqual([optionsData16, true, null, undefined]);
+        const toDtCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(3);
+        expect(toDtCall).toEqual([optionsData16, false, null, undefined]);
+        const flightJourneytravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(4);
+        expect(flightJourneytravelClassCall).toEqual([optionsData17, true, 'ECONOMY', 'ECONOMY']);
+        const flightOnwardtravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(5);
+        expect(flightOnwardtravelClassCall).toEqual([optionsData17, false, 'BUSINESS', undefined]);
+        const trainJourneytravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(6);
+        expect(trainJourneytravelClassCall).toEqual([optionsData18, false, null, 'SLEEPER']);
+        const busTravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(7);
+        expect(busTravelClassCall).toEqual([optionsData19, false, null, undefined]);
+        const distanceCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(8);
+        expect(distanceCall).toEqual([optionsData20, false, 23, 23]);
+        const distanceUnitCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(9);
+        expect(distanceUnitCall).toEqual([optionsData21, false, 'KM', 'KM']);
+      });
+
+      it('should call getFieldValueOnChange with correct args if expense is undefined', () => {
+        component.touchedGenericFields = ['location_1', 'from_dt', 'flight_journey_travel_class'];
+        component.genericFieldsForm.patchValue({
+          location_1: 'Mumbai',
+          location_2: 'Pune',
+          flight_journey_travel_class: 'ECONOMY',
+          train_travel_class: 'SLEEPER',
+          distance: 23,
+          distance_unit: 'KM',
+        });
+        component.patchCategoryDependentFields(2);
+        const location1Call = mergeExpensesService.getFieldValueOnChange.calls.argsFor(0);
+        expect(location1Call).toEqual([optionsData15, true, undefined, 'Mumbai']);
+        const location2Call = mergeExpensesService.getFieldValueOnChange.calls.argsFor(1);
+        expect(location2Call).toEqual([optionsData15, false, undefined, 'Pune']);
+        const fromDtCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(2);
+        expect(fromDtCall).toEqual([optionsData16, true, undefined, undefined]);
+        const toDtCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(3);
+        expect(toDtCall).toEqual([optionsData16, false, undefined, undefined]);
+        const flightJourneytravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(4);
+        expect(flightJourneytravelClassCall).toEqual([optionsData17, true, undefined, 'ECONOMY']);
+        const flightOnwardtravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(5);
+        expect(flightOnwardtravelClassCall).toEqual([optionsData17, false, undefined, undefined]);
+        const trainJourneytravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(6);
+        expect(trainJourneytravelClassCall).toEqual([optionsData18, false, undefined, 'SLEEPER']);
+        const busTravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(7);
+        expect(busTravelClassCall).toEqual([optionsData19, false, undefined, undefined]);
+        const distanceCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(8);
+        expect(distanceCall).toEqual([optionsData20, false, undefined, 23]);
+        const distanceUnitCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(9);
+        expect(distanceUnitCall).toEqual([optionsData21, false, undefined, 'KM']);
+      });
+
+      it('should call getFieldValueOnChange with correct args if touchedGenericFields is undefined', () => {
+        component.touchedGenericFields = undefined;
+        component.genericFieldsForm.patchValue({
+          location_1: 'Mumbai',
+          location_2: 'Pune',
+          flight_journey_travel_class: 'ECONOMY',
+          train_travel_class: 'SLEEPER',
+          distance: 23,
+          distance_unit: 'KM',
+        });
+        component.patchCategoryDependentFields(1);
+        const location1Call = mergeExpensesService.getFieldValueOnChange.calls.argsFor(0);
+        expect(location1Call).toEqual([optionsData15, undefined, 'Mumbai', 'Mumbai']);
+        const location2Call = mergeExpensesService.getFieldValueOnChange.calls.argsFor(1);
+        expect(location2Call).toEqual([optionsData15, undefined, 'Pune', 'Pune']);
+        const fromDtCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(2);
+        expect(fromDtCall).toEqual([optionsData16, undefined, null, undefined]);
+        const toDtCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(3);
+        expect(toDtCall).toEqual([optionsData16, undefined, null, undefined]);
+        const flightJourneytravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(4);
+        expect(flightJourneytravelClassCall).toEqual([optionsData17, undefined, 'ECONOMY', 'ECONOMY']);
+        const flightOnwardtravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(5);
+        expect(flightOnwardtravelClassCall).toEqual([optionsData17, undefined, 'BUSINESS', undefined]);
+        const trainJourneytravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(6);
+        expect(trainJourneytravelClassCall).toEqual([optionsData18, undefined, null, 'SLEEPER']);
+        const busTravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(7);
+        expect(busTravelClassCall).toEqual([optionsData19, undefined, null, undefined]);
+        const distanceCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(8);
+        expect(distanceCall).toEqual([optionsData20, undefined, 23, 23]);
+        const distanceUnitCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(9);
+        expect(distanceUnitCall).toEqual([optionsData21, undefined, 'KM', 'KM']);
+      });
+
+      it('should call getFieldValueOnChange with correct args if genericFields form is undefined', () => {
+        component.touchedGenericFields = ['location_1', 'from_dt', 'flight_journey_travel_class'];
+        component.patchCategoryDependentFields(1);
+        const location1Call = mergeExpensesService.getFieldValueOnChange.calls.argsFor(0);
+        expect(location1Call).toEqual([optionsData15, true, 'Mumbai', undefined]);
+        const location2Call = mergeExpensesService.getFieldValueOnChange.calls.argsFor(1);
+        expect(location2Call).toEqual([optionsData15, false, 'Pune', undefined]);
+        const fromDtCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(2);
+        expect(fromDtCall).toEqual([optionsData16, true, null, undefined]);
+        const toDtCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(3);
+        expect(toDtCall).toEqual([optionsData16, false, null, undefined]);
+        const flightJourneytravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(4);
+        expect(flightJourneytravelClassCall).toEqual([optionsData17, true, 'ECONOMY', undefined]);
+        const flightOnwardtravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(5);
+        expect(flightOnwardtravelClassCall).toEqual([optionsData17, false, 'BUSINESS', undefined]);
+        const trainJourneytravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(6);
+        expect(trainJourneytravelClassCall).toEqual([optionsData18, false, null, undefined]);
+        const busTravelClassCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(7);
+        expect(busTravelClassCall).toEqual([optionsData19, false, null, undefined]);
+        const distanceCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(8);
+        expect(distanceCall).toEqual([optionsData20, false, 23, undefined]);
+        const distanceUnitCall = mergeExpensesService.getFieldValueOnChange.calls.argsFor(9);
+        expect(distanceUnitCall).toEqual([optionsData21, false, 'KM', undefined]);
+      });
+    });
+  });
+}

--- a/src/app/fyle/merge-expense/merge-expense.page.setup.spec.ts
+++ b/src/app/fyle/merge-expense/merge-expense.page.setup.spec.ts
@@ -18,6 +18,7 @@ import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TestCases1 } from './merge-expense-1.page.spec';
 import { TestCases2 } from './merge-expense-2.page.spec';
+import { TestCases3 } from './merge-expense-3.page.spec';
 
 describe('MergeExpensePage', () => {
   const getTestBed = () => {
@@ -114,4 +115,5 @@ describe('MergeExpensePage', () => {
 
   TestCases1(getTestBed);
   TestCases2(getTestBed);
+  TestCases3(getTestBed);
 });

--- a/src/app/fyle/merge-expense/merge-expense.page.setup.spec.ts
+++ b/src/app/fyle/merge-expense/merge-expense.page.setup.spec.ts
@@ -17,6 +17,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TestCases1 } from './merge-expense-1.page.spec';
+import { TestCases2 } from './merge-expense-2.page.spec';
 
 describe('MergeExpensePage', () => {
   const getTestBed = () => {
@@ -112,4 +113,5 @@ describe('MergeExpensePage', () => {
   };
 
   TestCases1(getTestBed);
+  TestCases2(getTestBed);
 });

--- a/src/app/fyle/merge-expense/merge-expense.page.ts
+++ b/src/app/fyle/merge-expense/merge-expense.page.ts
@@ -25,18 +25,7 @@ import { CombinedOptions } from 'src/app/core/models/combined-options.model';
 import { ProjectDependentFieldsMapping } from 'src/app/core/models/project-dependent-fields-mapping.model';
 import { CostCenterDependentFieldsMapping } from 'src/app/core/models/cost-center-dependent-fields-mapping.model';
 import { GeneratedFormProperties } from 'src/app/core/models/generated-form-properties.model';
-
-type CustomInputs = Partial<{
-  control: FormControl;
-  id: string;
-  mandatory: boolean;
-  name: string;
-  options: MergeExpensesOption[];
-  placeholder: string;
-  prefix: string;
-  type: string;
-  value: string;
-}>;
+import { TxnCustomProperties } from 'src/app/core/models/txn-custom-properties.model';
 
 @Component({
   selector: 'app-merge-expense',
@@ -104,7 +93,7 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
 
   selectedReceiptsId: string[] = [];
 
-  customInputs$: Observable<CustomInputs[]>;
+  customInputs$: Observable<TxnCustomProperties[]>;
 
   attachments: FileObject[];
 
@@ -521,15 +510,15 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
 
   generateFromFg(dependentFieldsMapping: { [id: number]: CustomProperty<string>[] }): GeneratedFormProperties {
     const sourceExpense = this.expenses.find(
-      (expense) => expense.source_account_type === this.genericFieldsForm?.value?.paymentMode
+      (expense) => expense.source_account_type === this.genericFieldsForm.value.paymentMode
     );
     const amountExpense = this.expenses.find((expense) => expense.tx_id === this.genericFieldsForm.value.amount);
     const CCCMatchedExpense = this.expenses.find((expense) => !!expense.tx_corporate_credit_card_expense_group_id);
     let locations: string[];
-    if (this.fg.value.location_1 && this.fg.value.location_2) {
-      locations = [this.genericFieldsForm.value.location_1, this.genericFieldsForm.value.location_2];
-    } else if (this.fg.value.location_1) {
-      locations = [this.genericFieldsForm.value.location_1];
+    if (this.categoryDependentForm.value.location_1 && this.categoryDependentForm.value.location_2) {
+      locations = [this.categoryDependentForm.value.location_1, this.categoryDependentForm.value.location_2];
+    } else if (this.categoryDependentForm.value.location_1) {
+      locations = [this.categoryDependentForm.value.location_1];
     }
     const projectDependantFieldValues = dependentFieldsMapping[this.genericFieldsForm.value.project] || [];
     const costCenterDependentFieldValues = dependentFieldsMapping[this.genericFieldsForm.value.costCenter] || [];
@@ -567,7 +556,7 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
     };
   }
 
-  onCategoryChanged(categoryId) {
+  onCategoryChanged(categoryId: string) {
     this.mergeExpensesService.getCategoryName(categoryId).subscribe((categoryName) => {
       this.selectedCategoryName = categoryName;
     });
@@ -584,7 +573,7 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
           map((fields) => fields.filter((field) => field.type !== 'DEPENDENT_SELECT')),
           switchMap((fields) => {
             const customFields = this.customFieldsService.standardizeCustomFields(
-              this.fg.controls.custom_inputs?.value?.fields || [],
+              this.fg.controls.custom_inputs.value?.fields || [],
               this.customInputsService.filterByCategory(fields, categoryId)
             );
             return customFields;
@@ -630,7 +619,7 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
     );
   }
 
-  patchCustomInputsValues(customInputs) {
+  patchCustomInputsValues(customInputs: TxnCustomProperties[]) {
     const customInputValues = customInputs.map((customInput) => {
       if (
         this.combinedCustomProperties[customInput.name]?.areSameValues &&
@@ -665,21 +654,21 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
       if (field.value && field.value instanceof Array) {
         field.options = [
           {
-            label: field.value?.toString(),
+            label: field.value.toString(),
             value: field.value,
           },
         ];
-        if (field.value?.length === 0) {
+        if (field.value.length === 0) {
           field.options = [];
         }
       } else {
-        if (!field.value || field.value !== '') {
+        if (!field.value) {
           field.options = [];
         } else {
           field.options = [
             {
-              label: field?.value,
-              value: field?.value,
+              label: field.value,
+              value: field.value,
             },
           ];
         }
@@ -728,11 +717,11 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
     }
   }
 
-  onGenericFieldsTouched(touchedGenericFields) {
+  onGenericFieldsTouched(touchedGenericFields: string[]) {
     this.touchedGenericFields = touchedGenericFields;
   }
 
-  onCategoryDependentFieldsTouched(touchedGenericFields) {
+  onCategoryDependentFieldsTouched(touchedGenericFields: string[]) {
     this.touchedCategoryDepedentFields = touchedGenericFields;
   }
 
@@ -809,8 +798,8 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
             distance_unit: this.mergeExpensesService.getFieldValueOnChange(
               distanceUnitOptionsData,
               this.touchedGenericFields?.includes('distance_unit'),
-              this.expenses[selectedIndex]?.tx_flight_journey_travel_class,
-              this.genericFieldsForm.value?.tx_distance_unit
+              this.expenses[selectedIndex]?.tx_distance_unit,
+              this.genericFieldsForm.value?.distance_unit
             ),
           },
         });

--- a/src/app/fyle/merge-expense/merge-expense.page.ts
+++ b/src/app/fyle/merge-expense/merge-expense.page.ts
@@ -22,6 +22,9 @@ import { MergeExpensesOptionsData } from 'src/app/core/models/merge-expenses-opt
 import { DependentFieldsService } from 'src/app/core/services/dependent-fields.service';
 import { ExpenseFieldsService } from 'src/app/core/services/expense-fields.service';
 import { CombinedOptions } from 'src/app/core/models/combined-options.model';
+import { ProjectDependentFieldsMapping } from 'src/app/core/models/project-dependent-fields-mapping.model';
+import { CostCenterDependentFieldsMapping } from 'src/app/core/models/cost-center-dependent-fields-mapping.model';
+import { GeneratedFormProperties } from 'src/app/core/models/generated-form-properties.model';
 
 type CustomInputs = Partial<{
   control: FormControl;
@@ -129,9 +132,9 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
 
   systemCategories: string[];
 
-  projectDependentFieldsMapping$: Observable<{ [projectId: number]: CustomProperty<string>[] }>;
+  projectDependentFieldsMapping$: Observable<ProjectDependentFieldsMapping>;
 
-  costCenterDependentFieldsMapping$: Observable<{ [costCenterId: number]: CustomProperty<string>[] }>;
+  costCenterDependentFieldsMapping$: Observable<CostCenterDependentFieldsMapping>;
 
   constructor(
     private router: Router,
@@ -335,7 +338,7 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
             receipt_ids:
               this.expenses[selectedIndex]?.tx_file_ids?.length > 0 &&
               !this.touchedGenericFields?.includes('receipt_ids')
-                ? this.expenses[selectedIndex]?.tx_split_group_id
+                ? this.expenses[selectedIndex].tx_split_group_id
                 : null,
             amount: this.mergeExpensesService.getFieldValueOnChange(
               amountOptionsData,
@@ -454,7 +457,7 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
     );
   }
 
-  onReceiptChanged(receipt_ids) {
+  onReceiptChanged(receipt_ids: string) {
     this.mergeExpensesService.getAttachements(receipt_ids).subscribe((receipts) => {
       this.selectedReceiptsId = receipts.map((receipt) => receipt.id);
       this.attachments = receipts;
@@ -516,13 +519,13 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
       .subscribe(noop);
   }
 
-  generateFromFg(dependentFieldsMapping: { [id: number]: CustomProperty<string>[] }) {
+  generateFromFg(dependentFieldsMapping: { [id: number]: CustomProperty<string>[] }): GeneratedFormProperties {
     const sourceExpense = this.expenses.find(
       (expense) => expense.source_account_type === this.genericFieldsForm?.value?.paymentMode
     );
     const amountExpense = this.expenses.find((expense) => expense.tx_id === this.genericFieldsForm.value.amount);
     const CCCMatchedExpense = this.expenses.find((expense) => !!expense.tx_corporate_credit_card_expense_group_id);
-    let locations;
+    let locations: string[];
     if (this.fg.value.location_1 && this.fg.value.location_2) {
       locations = [this.genericFieldsForm.value.location_1, this.genericFieldsForm.value.location_2];
     } else if (this.fg.value.location_1) {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ec4c7c</samp>

This pull request adds and updates several files related to the merge expense page component. It improves the test coverage and quality of the component by adding test cases, mock data, and models. It also enhances the type safety and readability of the component by using models and type annotations.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4ec4c7c</samp>

> _We're testing the `merge-expense` page, me hearties_
> _We're testing it with mock data and models_
> _We're testing it with different inputs and scenarios_
> _We're testing it on the count of three_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ec4c7c</samp>

*  Add mock data files for testing the merge expense page component ([link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-e840853e728950c92aeddfc642945d6972dd2084aa186e26dec8cbc97dd96395R1-R7), [link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-7812c7d6195fe12d9898fe592c50091ce779bc0dc8dc8bab6224e1c6ffb90b71R1-R38), [link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-f775cff0de61d2bafc4d6ea071bf35ca4e5930d556d456ab6872032cc51c412cR1-R7))
*  Add model files for defining the types of the data used by the merge expense page component ([link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-a05a1e081ba2e091ec43507d1d0f267e63d2771a57acc32883275618b80dcb02R1-R5), [link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-9fc5202f14166a90647cf5252d5ae338625b0ee3a41ccd916ad54e125fe8efa4R1-R29), [link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-3612676fc1092c1a163ee60b8866f228911dd8bf31efccf9270432b87d4a4155R1-R5))
*  Update the import statements and the types of the properties and parameters in the `merge-expense.page.ts` file to use the models instead of the generic object type ([link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20R25-R27), [link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L132-R137), [link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L457-R460), [link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L519-R522), [link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L525-R528))
*  Remove the unnecessary optional chaining operator from the `tx_split_group_id` property of the expense object in the `onExpenseChanged` method of the merge expense page component ([link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L338-R341))
*  Add test cases for the `loadGenericFieldsOptions` and `subscribeExpenseChange` methods of the merge expense page component in the test cases set 1 ([link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-75b0424c25a69a138bfb9457ca97510efa89934234b18adfd574ba40f52ce4ddR343-R401))
*  Initialize the form group for the merge expense page component in the test cases set 1 ([link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-75b0424c25a69a138bfb9457ca97510efa89934234b18adfd574ba40f52ce4ddR77-R82))
*  Import the mock data file for expenses info in the test cases set 1 ([link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-75b0424c25a69a138bfb9457ca97510efa89934234b18adfd574ba40f52ce4ddR40))
*  Add a test file for the merge expense page component that contains the test cases set 2 ([link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-0f975d349db82e08088b21e2e8710192ad195fc53cca850ce3f6df2a43950379R1-R399))
*  Import and execute the test cases set 2 in the merge expense page setup file ([link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-ae0bec00722c67416a4ca6a96a6f95fead9fdcbf5de026035d2b5bb6012287c7R20), [link](https://github.com/fylein/fyle-mobile-app/pull/2187/files?diff=unified&w=0#diff-ae0bec00722c67416a4ca6a96a6f95fead9fdcbf5de026035d2b5bb6012287c7R116))

## Clickup
https://app.clickup.com/t/85zt9c366

## Code Coverage
51.11% Statements 
40.37% Branches 
42.85% Functions 
50.86% Lines

## UI Preview
Please add screenshots for UI changes