### PR TITLE
feat: Show mobile number card only for verified users and add trackers

### DIFF
--- a/src/app/core/mock-data/info-card-data.data.ts
+++ b/src/app/core/mock-data/info-card-data.data.ts
@@ -6,12 +6,13 @@ export const allInfoCardsData: InfoCardData[] = [
     content: 'Message your receipts to Fyle at (302) 440-2921.',
     contentToCopy: '(302) 440-2921',
     toastMessageContent: 'Phone Number Copied Successfully',
-    isHidden: false,
+    isShown: true,
   },
   {
     title: 'Email Receipts',
     content: 'Forward your receipts to Fyle at receipts@fylehq.com.',
     contentToCopy: 'receipts@fylehq.com',
     toastMessageContent: 'Email Copied Successfully',
+    isShown: true,
   },
 ];

--- a/src/app/core/models/info-card-data.model.ts
+++ b/src/app/core/models/info-card-data.model.ts
@@ -3,5 +3,5 @@ export interface InfoCardData {
   content: string;
   contentToCopy: string;
   toastMessageContent: string;
-  isHidden?: boolean;
+  isShown: boolean;
 }

--- a/src/app/core/services/deep-link.service.spec.ts
+++ b/src/app/core/services/deep-link.service.spec.ts
@@ -2,14 +2,14 @@ import { TestBed } from '@angular/core/testing';
 import { DeepLinkService } from './deep-link.service';
 import { Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Location } from '@angular/common';
 import { appRoutes } from '../../app-routing.module';
 import { fyleRoutes } from '../../fyle/fyle-routing.module';
+import { TrackingService } from './tracking.service';
 
 describe('DeepLinkService', () => {
   let deepLinkService: DeepLinkService;
   let router: jasmine.SpyObj<Router>;
-  let location: jasmine.SpyObj<Location>;
+  let trackingService: jasmine.SpyObj<TrackingService>;
 
   const baseURL = 'https://app.fylehq.com/app';
 
@@ -22,8 +22,10 @@ describe('DeepLinkService', () => {
   };
 
   beforeEach(() => {
-    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
-    const locationSpy = jasmine.createSpyObj('Location', ['path']);
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']) as jasmine.SpyObj<Router>;
+    const trackingServiceSpy = jasmine.createSpyObj('TrackingService', [
+      'smsDeepLinkOpened',
+    ]) as jasmine.SpyObj<TrackingService>;
 
     TestBed.configureTestingModule({
       imports: [RouterTestingModule.withRoutes(routes)],
@@ -34,14 +36,14 @@ describe('DeepLinkService', () => {
           useValue: routerSpy,
         },
         {
-          provide: Location,
-          useValue: locationSpy,
+          provide: TrackingService,
+          useValue: trackingServiceSpy,
         },
       ],
     });
     deepLinkService = TestBed.inject(DeepLinkService);
     router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
-    location = TestBed.inject(Location) as jasmine.SpyObj<Location>;
+    trackingService = TestBed.inject(TrackingService) as jasmine.SpyObj<TrackingService>;
   });
 
   it('should be created', () => {

--- a/src/app/core/services/deep-link.service.ts
+++ b/src/app/core/services/deep-link.service.ts
@@ -2,12 +2,13 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Redirect } from '../models/redirect.model';
 import { UnflattenedTransaction } from '../models/unflattened-transaction.model';
+import { TrackingService } from './tracking.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class DeepLinkService {
-  constructor(private router: Router) {}
+  constructor(private router: Router, private trackingService: TrackingService) {}
 
   getJsonFromUrl(url?: string): Redirect {
     const query = url?.split('?')[1];
@@ -104,6 +105,10 @@ export class DeepLinkService {
         } else {
           this.router.navigate(['/', 'auth', 'switch_org', { choose: true }]);
         }
+        this.trackingService.smsDeepLinkOpened({
+          orgId,
+          txnId,
+        });
       } else {
         this.router.navigate(['/', 'auth', 'switch_org', { choose: true }]);
       }

--- a/src/app/core/services/tracking.service.ts
+++ b/src/app/core/services/tracking.service.ts
@@ -597,4 +597,8 @@ export class TrackingService {
   mobileNumberVerified() {
     this.eventTrack('Mobile Number Verified');
   }
+
+  smsDeepLinkOpened(properties = {}) {
+    this.eventTrack('SMS Deep Link Opened', properties);
+  }
 }

--- a/src/app/fyle/my-profile/my-profile.page.spec.ts
+++ b/src/app/fyle/my-profile/my-profile.page.spec.ts
@@ -19,7 +19,7 @@ import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-proper
 import { MyProfilePage } from './my-profile.page';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ToastMessageComponent } from 'src/app/shared/components/toast-message/toast-message.component';
-import { apiEouRes } from 'src/app/core/mock-data/extended-org-user.data';
+import { apiEouRes, eouRes3 } from 'src/app/core/mock-data/extended-org-user.data';
 import { postOrgUser } from 'src/app/core/test-data/org-user.service.spec.data';
 import { BehaviorSubject, of } from 'rxjs';
 import { CurrencyService } from 'src/app/core/services/currency.service';
@@ -27,6 +27,7 @@ import { ActivatedRoute } from '@angular/router';
 import { UpdateMobileNumberComponent } from './update-mobile-number/update-mobile-number.component';
 import { PopupWithBulletsComponent } from 'src/app/shared/components/popup-with-bullets/popup-with-bullets.component';
 import { allInfoCardsData } from 'src/app/core/mock-data/info-card-data.data';
+import { cloneDeep } from 'lodash';
 
 xdescribe('MyProfilePage', () => {
   let component: MyProfilePage;
@@ -145,12 +146,14 @@ xdescribe('MyProfilePage', () => {
 
   describe('setInfoCardsData(): ', () => {
     it('should show only email card for non USD orgs', () => {
-      component.setInfoCardsData('INR');
+      component.setInfoCardsData(eouRes3);
       expect(component.infoCardsData).toEqual([allInfoCardsData[1]]);
     });
 
     it('should show both email and mobile number cards for USD orgs', () => {
-      component.setInfoCardsData('USD');
+      const eou = cloneDeep(apiEouRes);
+      eou.ou.mobile_verified = true;
+      component.setInfoCardsData(eou);
       expect(component.infoCardsData).toEqual(allInfoCardsData);
     });
   });

--- a/src/app/fyle/my-profile/my-profile.page.ts
+++ b/src/app/fyle/my-profile/my-profile.page.ts
@@ -184,7 +184,7 @@ export class MyProfilePage {
     this.org$ = this.orgService.getCurrentOrg();
     const orgSettings$ = this.orgSettingsService.get();
 
-    this.currencyService.getHomeCurrency().subscribe((homeCurrency) => this.setInfoCardsData(homeCurrency));
+    this.eou$.subscribe((eou) => this.setInfoCardsData(eou));
 
     from(this.loaderService.showLoader())
       .pipe(
@@ -234,7 +234,7 @@ export class MyProfilePage {
     this.preferenceSettings = allPreferenceSettings.filter((setting) => setting.isAllowed);
   }
 
-  setInfoCardsData(homeCurrency: string) {
+  setInfoCardsData(eou: ExtendedOrgUser): void {
     const fyleMobileNumber = '(302) 440-2921';
     const fyleEmail = 'receipts@fylehq.com';
 
@@ -244,17 +244,18 @@ export class MyProfilePage {
         content: `Message your receipts to Fyle at ${fyleMobileNumber}.`,
         contentToCopy: fyleMobileNumber,
         toastMessageContent: 'Phone Number Copied Successfully',
-        isHidden: homeCurrency !== 'USD',
+        isShown: eou.org.currency === 'USD' && eou.ou.mobile_verified,
       },
       {
         title: 'Email Receipts',
         content: `Forward your receipts to Fyle at ${fyleEmail}.`,
         contentToCopy: fyleEmail,
         toastMessageContent: 'Email Copied Successfully',
+        isShown: true,
       },
     ];
 
-    this.infoCardsData = allInfoCardsData.filter((infoCardData) => !infoCardData.isHidden);
+    this.infoCardsData = allInfoCardsData.filter((infoCardData) => infoCardData.isShown);
   }
 
   showToastMessage(message: string, type: 'success' | 'failure') {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 693f28c</samp>

Updated the info card display logic and data model to use `isShown` instead of `isHidden` and to show relevant info cards based on the user's currency and mobile verification status. Added a new info card for Fyle mobile number.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 693f28c</samp>

> _Sing, O Muse, of the valiant coder who refined the `InfoCardData`_
> _And made its `isShown` property clear and fixed, removing `isHidden`_
> _So that the splendid `MyProfilePage` could display the cards with grace_
> _And show the user's currency and mobile, and Fyle's own number's trace_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 693f28c</samp>

*  Rename and invert `isHidden` property to `isShown` in info card data interface and objects ([link](https://github.com/fylein/fyle-mobile-app/pull/2188/files?diff=unified&w=0#diff-bfb705007a7b5727c8e5b58814ef10942dd8b352bef4f780137238496c7ebb84L9-R9), [link](https://github.com/fylein/fyle-mobile-app/pull/2188/files?diff=unified&w=0#diff-bfb705007a7b5727c8e5b58814ef10942dd8b352bef4f780137238496c7ebb84R16), [link](https://github.com/fylein/fyle-mobile-app/pull/2188/files?diff=unified&w=0#diff-93e8134784dc76e4e674be9610ceabc02be07f5c18cdd839ec18db34c3eb6ac9L6-R6), [link](https://github.com/fylein/fyle-mobile-app/pull/2188/files?diff=unified&w=0#diff-2c63a619cd79823c07aec7f42fb6ef1e07a5a3f9068ed72c121826ceed7996f5L247-R247))
*  Replace `homeCurrency` parameter with `eou$` observable in `MyProfilePage` class to get extended org user data ([link](https://github.com/fylein/fyle-mobile-app/pull/2188/files?diff=unified&w=0#diff-2c63a619cd79823c07aec7f42fb6ef1e07a5a3f9068ed72c121826ceed7996f5L187-R187), [link](https://github.com/fylein/fyle-mobile-app/pull/2188/files?diff=unified&w=0#diff-2c63a619cd79823c07aec7f42fb6ef1e07a5a3f9068ed72c121826ceed7996f5L237-R237))
*  Show Fyle mobile number info card only if org currency is USD and user's mobile number is verified ([link](https://github.com/fylein/fyle-mobile-app/pull/2188/files?diff=unified&w=0#diff-2c63a619cd79823c07aec7f42fb6ef1e07a5a3f9068ed72c121826ceed7996f5L247-R247))
*  Add `isShown` property to fourth info card data object and update `filter` method to use it ([link](https://github.com/fylein/fyle-mobile-app/pull/2188/files?diff=unified&w=0#diff-2c63a619cd79823c07aec7f42fb6ef1e07a5a3f9068ed72c121826ceed7996f5L254-R258))

## Clickup
https://app.clickup.com/t/85zth8yc8

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes