### PR TITLE
test: 100% coverage of merge-expense page

### DIFF
--- a/src/app/core/mock-data/combined-options.data.ts
+++ b/src/app/core/mock-data/combined-options.data.ts
@@ -5,8 +5,14 @@ import {
   optionsData12,
   optionsData13,
   optionsData14,
+  optionsData15,
+  optionsData16,
+  optionsData17,
   optionsData18,
+  optionsData19,
   optionsData2,
+  optionsData20,
+  optionsData21,
   optionsData3,
   optionsData31,
   optionsData6,
@@ -33,4 +39,17 @@ export const combinedOptionsData2: CombinedOptions = {
   userlist: optionsData3,
   test: optionsData6,
   category2: optionsData31,
+};
+
+export const combinedOptionsData3: CombinedOptions = {
+  location1OptionsData: optionsData15,
+  location2OptionsData: optionsData15,
+  onwardDateOptionsData: optionsData16,
+  returnDateOptionsData: optionsData16,
+  flightJourneyTravelClassOptionsData: optionsData17,
+  flightReturnTravelClassOptionsData: optionsData17,
+  trainTravelClassOptionsData: optionsData18,
+  busTravelClassOptionsData: optionsData19,
+  distanceOptionsData: optionsData20,
+  distanceUnitOptionsData: optionsData21,
 };

--- a/src/app/fyle/merge-expense/merge-expense-3.page.spec.ts
+++ b/src/app/fyle/merge-expense/merge-expense-3.page.spec.ts
@@ -337,13 +337,9 @@ export function TestCases3(getTestBed) {
         mergeExpensesService.isReportedPresent.and.returnValue([expenseList2[0]]);
       });
 
-      it('should call mergeExpensesService.isReportedPresent() once with expenses', () => {
-        component.setIsReported(expensesInfo);
-        expect(mergeExpensesService.isReportedPresent).toHaveBeenCalledOnceWith(expenseList2);
-      });
-
       it('should set isReportedExpensePresent to true if isReported length is greater than zero', () => {
         component.setIsReported(expensesInfo);
+        expect(mergeExpensesService.isReportedPresent).toHaveBeenCalledOnceWith(expenseList2);
         expect(component.isReportedExpensePresent).toEqual(true);
       });
 

--- a/src/app/fyle/merge-expense/merge-expense-3.page.spec.ts
+++ b/src/app/fyle/merge-expense/merge-expense-3.page.spec.ts
@@ -337,7 +337,7 @@ export function TestCases3(getTestBed) {
         mergeExpensesService.isReportedPresent.and.returnValue([expenseList2[0]]);
       });
 
-      it('should set isReportedExpensePresent to true if isReported length is greater than zero', () => {
+      it('should call mergeExpensesService.isReportedPresent() once and set isReportedExpensePresent to true if isReported length is greater than zero', () => {
         component.setIsReported(expensesInfo);
         expect(mergeExpensesService.isReportedPresent).toHaveBeenCalledOnceWith(expenseList2);
         expect(component.isReportedExpensePresent).toEqual(true);

--- a/src/app/fyle/merge-expense/merge-expense.page.ts
+++ b/src/app/fyle/merge-expense/merge-expense.page.ts
@@ -717,11 +717,11 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
     }
   }
 
-  onGenericFieldsTouched(touchedGenericFields) {
+  onGenericFieldsTouched(touchedGenericFields: string[]) {
     this.touchedGenericFields = touchedGenericFields;
   }
 
-  onCategoryDependentFieldsTouched(touchedGenericFields) {
+  onCategoryDependentFieldsTouched(touchedGenericFields: string[]) {
     this.touchedCategoryDepedentFields = touchedGenericFields;
   }
 
@@ -798,8 +798,8 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
             distance_unit: this.mergeExpensesService.getFieldValueOnChange(
               distanceUnitOptionsData,
               this.touchedGenericFields?.includes('distance_unit'),
-              this.expenses[selectedIndex]?.tx_flight_journey_travel_class,
-              this.genericFieldsForm.value?.tx_distance_unit
+              this.expenses[selectedIndex]?.tx_distance_unit,
+              this.genericFieldsForm.value?.distance_unit
             ),
           },
         });


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68b1b18</samp>

This pull request enhances the merge expense feature by updating the mock data, adding unit tests, and fixing a typo. It improves the functionality, testing, and quality of the `merge-expense-3.page` component and its related files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 68b1b18</samp>

> _We merge the expenses of doom_
> _With mock data and tests we consume_
> _We fix the typo in the `merge-expense-3.page`_
> _We enhance the type annotation to rage_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68b1b18</samp>

*  Add more options data for category dependent fields and a new combined options data object for the third expense in the mock data file ([link](https://github.com/fylein/fyle-mobile-app/pull/2196/files?diff=unified&w=0#diff-8382698806436668f5db9b70ccdb0034e5b8e9a55c6acf5bc215bd308540074fL8-R15), [link](https://github.com/fylein/fyle-mobile-app/pull/2196/files?diff=unified&w=0#diff-8382698806436668f5db9b70ccdb0034e5b8e9a55c6acf5bc215bd308540074fR43-R55))
* Import mock data for apiExpenseRes, combinedOptionsData3, expenseInfoWithoutDefaultExpense and expensesInfo in the merge-expense-3.page.spec.ts file ([link](https://github.com/fylein/fyle-mobile-app/pull/2196/files?diff=unified&w=0#diff-a7ed545db35aa672503bbcc4009804e9fc36c5213f1041c026c657a65eaf023bL16-R16), [link](https://github.com/fylein/fyle-mobile-app/pull/2196/files?diff=unified&w=0#diff-a7ed545db35aa672503bbcc4009804e9fc36c5213f1041c026c657a65eaf023bL39-R43), [link](https://github.com/fylein/fyle-mobile-app/pull/2196/files?diff=unified&w=0#diff-a7ed545db35aa672503bbcc4009804e9fc36c5213f1041c026c657a65eaf023bR75))
* Add unit tests for `setAdvanceOrApprovedAndAbove`, `setIsReported`, `setInitialExpenseToKeepDetails`, `onGenericFieldsTouched`, `onCategoryDependentFieldsTouched` and `patchCategoryDependentFields` methods in the `merge-expense-3.page` component ([link](https://github.com/fylein/fyle-mobile-app/pull/2196/files?diff=unified&w=0#diff-a7ed545db35aa672503bbcc4009804e9fc36c5213f1041c026c657a65eaf023bR302-R624))
* Add type annotation of string[] to the `touchedGenericFields` parameter in the `onGenericFieldsTouched` and `onCategoryDependentFieldsTouched` methods in the `merge-expense-3.page` component ([link](https://github.com/fylein/fyle-mobile-app/pull/2196/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L720-R724))
* Fix typo in the property names of `tx_distance_unit` and `distance_unit` in the `getFieldValueOnChange` method call in the `patchCategoryDependentFields` method in the `merge-expense-3.page` component ([link](https://github.com/fylein/fyle-mobile-app/pull/2196/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L801-R802))

## Clickup
https://app.clickup.com/t/85zt9c36m

## Code Coverage
![Screenshot 2023-07-18 at 2 42 08 PM](https://github.com/fylein/fyle-mobile-app/assets/127177049/d0e8a233-8d86-4d1f-86d2-d80da81e6759)

## UI Preview
Please add screenshots for UI changes