### PR TITLE
feat: Added directions API

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,7 +18,6 @@ import { TokenService } from './core/services/token.service';
 import { SecureStorageService } from './core/services/secure-storage.service';
 import { StorageService } from './core/services/storage.service';
 import { HAMMER_GESTURE_CONFIG, HammerGestureConfig } from '@angular/platform-browser';
-import { GoogleMapsModule } from '@angular/google-maps';
 import { PAGINATION_SIZE, DEVICE_PLATFORM } from './constants';
 import { Smartlook } from '@awesome-cordova-plugins/smartlook/ngx';
 import { Capacitor } from '@capacitor/core';
@@ -42,7 +41,6 @@ export const MIN_SCREEN_WIDTH = new InjectionToken<number>(
     AppRoutingModule,
     BrowserAnimationsModule,
     HttpClientModule,
-    GoogleMapsModule,
     SharedModule,
     HammerModule,
     HttpClientJsonpModule,

--- a/src/app/core/mock-data/directions-results.data.ts
+++ b/src/app/core/mock-data/directions-results.data.ts
@@ -1,18 +1,6 @@
-export const directionsResults1: google.maps.DirectionsResult = {
-  routes: [
-    {
-      bounds: null,
-      copyrights: 'Map data ©2023',
-      legs: [],
-      overview_polyline: 'oygtBwpx}La@LMHGPB`@AXNl@BXC\\Wd@k@Y[QEIKg@WwCKYt@Wr@Qb@Ip@]v@_@h@SIWOe@XONK@GE_@Uq@MOM@',
-      summary: 'Navare Park Rd',
-      warnings: [],
-      waypoint_order: [],
-      overview_path: [],
-    },
-  ],
-};
+export const directionsResponse1: string =
+  'oygtBwpx}La@LMHGPB`@AXNl@BXC\\Wd@k@Y[QEIKg@WwCKYt@Wr@Qb@Ip@]v@_@h@SIWOe@XONK@GE_@Uq@MOM@';
 
-export const directionsResults2: google.maps.DirectionsResult = {
-  routes: [],
+export const directionsResponse2 = {
+  message: 'No route found',
 };

--- a/src/app/core/services/gmaps.service.ts
+++ b/src/app/core/services/gmaps.service.ts
@@ -32,12 +32,9 @@ export class GmapsService {
     });
 
     // importLibrary will add the specified library to the global namespace window.google.maps
-    return forkJoin([
-      from(loader.importLibrary('core')),
-      from(loader.importLibrary('maps')),
-      from(loader.importLibrary('routes')),
-      from(loader.importLibrary('geocoding')),
-    ]).pipe(ignoreElements());
+    return forkJoin([from(loader.importLibrary('core')), from(loader.importLibrary('geocoding'))]).pipe(
+      ignoreElements()
+    );
   }
 
   // Used to generate static map image urls, for single location

--- a/src/app/core/services/gmaps.service.ts
+++ b/src/app/core/services/gmaps.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable, forkJoin, from, ignoreElements, map } from 'rxjs';
-import { MapDirectionsResponse, MapDirectionsService, MapGeocoder, MapGeocoderResponse } from '@angular/google-maps';
+import { Observable, forkJoin, from, ignoreElements } from 'rxjs';
+import { MapGeocoder, MapGeocoderResponse } from '@angular/google-maps';
 import { Cacheable } from 'ts-cacheable';
 import { MileageRoute } from 'src/app/shared/components/route-visualizer/mileage-route.interface';
 import { MileageMarkerParams } from '../models/mileage-marker-params.interface';
@@ -14,11 +14,7 @@ import { Loader } from '@googlemaps/js-api-loader';
 export class GmapsService {
   private staticMapsApi = 'https://maps.googleapis.com/maps/api/staticmap';
 
-  constructor(
-    private geocoder: MapGeocoder,
-    private mapDirectionsService: MapDirectionsService,
-    private staticMapPropertiesService: StaticMapPropertiesService
-  ) {}
+  constructor(private geocoder: MapGeocoder, private staticMapPropertiesService: StaticMapPropertiesService) {}
 
   @Cacheable()
   getGeocode(latitude: number, longitude: number): Observable<MapGeocoderResponse> {
@@ -28,23 +24,6 @@ export class GmapsService {
         lng: longitude,
       },
     });
-  }
-
-  @Cacheable()
-  getDirections(mileageRoute: MileageRoute): Observable<google.maps.DirectionsResult> {
-    const { origin, destination, waypoints } = mileageRoute;
-
-    // Convert waypoints to google maps waypoints
-    const directionsWaypoints: google.maps.DirectionsWaypoint[] = waypoints.map((waypoint) => ({ location: waypoint }));
-
-    const request: google.maps.DirectionsRequest = {
-      destination,
-      origin,
-      waypoints: directionsWaypoints,
-      travelMode: google.maps.TravelMode.DRIVING,
-    };
-
-    return this.mapDirectionsService.route(request).pipe(map((response: MapDirectionsResponse) => response.result));
   }
 
   loadLibrary(): Observable<boolean> {
@@ -85,7 +64,7 @@ export class GmapsService {
     staticMapImageUrl.searchParams.append('size', `${properties.width}x${properties.height}`);
     staticMapImageUrl.searchParams.append('scale', properties.resolutionScale.toString());
 
-    const encodedPolyline = mileageRoute.directions.overview_polyline;
+    const encodedPolyline = mileageRoute.directionsPolyline;
     staticMapImageUrl.searchParams.append('path', `color:${properties.routeColor}|enc:${encodedPolyline}`);
 
     const { originParams, destinationParams, waypointsParams } = this.generateMarkerParams(

--- a/src/app/core/services/location.service.ts
+++ b/src/app/core/services/location.service.ts
@@ -52,6 +52,29 @@ export class LocationService {
     this.ROOT_ENDPOINT = rootUrl;
   }
 
+  getDirections(
+    origin: google.maps.LatLngLiteral,
+    destination: google.maps.LatLngLiteral,
+    waypoints?: google.maps.LatLngLiteral[]
+  ): Observable<string> {
+    const config = {
+      params: {
+        origin_lat: origin.lat,
+        origin_long: origin.lng,
+        destination_lat: destination.lat,
+        destination_long: destination.lng,
+        waypoints: waypoints.reduce(
+          (acc, waypoint, i) =>
+            i === 0 ? `${waypoint.lat},${waypoint.lng}` : `${acc}|${waypoint.lat},${waypoint.lng}`,
+          ''
+        ),
+        mode: 'driving',
+      },
+    };
+
+    return this.get<string>('/directions', config);
+  }
+
   getAutocompletePredictions(
     text: string,
     userId: string,

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
@@ -79,15 +79,12 @@
           </ng-container>
 
           <ng-container *ngIf="isConnected$ | async">
-            <ng-container *ngIf="{ loadDynamicMap: loadDynamicMap$ | async } as data">
-              <div class="add-edit-mileage--map" *ngIf="data.loadDynamicMap !== null">
-                <app-route-visualizer
-                  [mileageLocations]="fg.controls.route.value?.mileageLocations || []"
-                  [loadDynamicMap]="data.loadDynamicMap"
-                  (mapClick)="onRouteVisualizerClick()"
-                ></app-route-visualizer>
-              </div>
-            </ng-container>
+            <div class="add-edit-mileage--map">
+              <app-route-visualizer
+                [mileageLocations]="fg.controls.route.value?.mileageLocations || []"
+                (mapClick)="onRouteVisualizerClick()"
+              ></app-route-visualizer>
+            </div>
           </ng-container>
 
           <form #formContainer [formGroup]="fg" class="add-edit-mileage--form">

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -72,7 +72,6 @@ import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-proper
 import { FyPolicyViolationComponent } from 'src/app/shared/components/fy-policy-violation/fy-policy-violation.component';
 import { AccountOption } from 'src/app/core/models/account-option.model';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
-import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 import { ExpenseType } from 'src/app/core/enums/expense-type.enum';
 import { PaymentModesService } from 'src/app/core/services/payment-modes.service';
 import { OrgSettingsService } from 'src/app/core/services/org-settings.service';
@@ -245,8 +244,6 @@ export class AddEditMileagePage implements OnInit {
 
   selectedCostCenter$: BehaviorSubject<CostCenter>;
 
-  loadDynamicMap$: Observable<boolean>;
-
   private _isExpandedView = false;
 
   constructor(
@@ -281,7 +278,6 @@ export class AddEditMileagePage implements OnInit {
     private modalProperties: ModalPropertiesService,
     private matSnackBar: MatSnackBar,
     private snackbarProperties: SnackbarPropertiesService,
-    private launchDarklyService: LaunchDarklyService,
     private paymentModesService: PaymentModesService,
     private currencyService: CurrencyService,
     private mileageRateService: MileageRatesService,
@@ -326,8 +322,6 @@ export class AddEditMileagePage implements OnInit {
   ngOnInit() {
     this.isRedirectedFromReport = this.activatedRoute.snapshot.params.remove_from_report ? true : false;
     this.canRemoveFromReport = this.activatedRoute.snapshot.params.remove_from_report === 'true';
-
-    this.loadDynamicMap$ = this.launchDarklyService.getVariation('show_dynamic_maps', false);
   }
 
   goToPrev() {

--- a/src/app/shared/components/route-visualizer/mileage-route.interface.ts
+++ b/src/app/shared/components/route-visualizer/mileage-route.interface.ts
@@ -2,5 +2,5 @@ export interface MileageRoute {
   origin: google.maps.LatLngLiteral;
   destination: google.maps.LatLngLiteral;
   waypoints: google.maps.LatLngLiteral[];
-  directions?: google.maps.DirectionsRoute;
+  directionsPolyline?: string;
 }

--- a/src/app/shared/components/route-visualizer/route-visualizer.component.html
+++ b/src/app/shared/components/route-visualizer/route-visualizer.component.html
@@ -1,39 +1,19 @@
-<ng-container *ngIf="loadDynamicMap; else staticMap">
-  <ng-container *ngIf="directions$ | async as directions">
-    <google-map (mapClick)="mapClicked($event)" [width]="mapWidth" [height]="mapHeight" [options]="dynamicMapOptions">
-      <map-directions-renderer [directions]="directions"></map-directions-renderer>
-    </google-map>
-  </ng-container>
-
-  <ng-container *ngIf="showCurrentLocation && currentLocation">
-    <google-map
-      (mapClick)="mapClicked($event)"
-      [width]="mapWidth"
-      [height]="mapHeight"
-      [center]="currentLocation"
-      [options]="dynamicMapOptions"
-    ></google-map>
-  </ng-container>
+<ng-container *ngIf="directionsMapUrl$ | async as directionsMapUrl">
+  <img
+    (click)="mapClicked($event)"
+    (error)="handleMapLoadError($event)"
+    [src]="directionsMapUrl"
+    [style.width]="mapWidth + 'px'"
+    [style.height]="mapHeight + 'px'"
+  />
 </ng-container>
 
-<ng-template #staticMap>
-  <ng-container *ngIf="directionsMapUrl$ | async as directionsMapUrl">
-    <img
-      (click)="mapClicked($event)"
-      (error)="handleMapLoadError($event)"
-      [src]="directionsMapUrl"
-      [style.width]="mapWidth + 'px'"
-      [style.height]="mapHeight + 'px'"
-    />
-  </ng-container>
-
-  <ng-container *ngIf="showCurrentLocation && currentLocation">
-    <img
-      (click)="mapClicked($event)"
-      (error)="handleMapLoadError($event)"
-      [src]="currentLocationMapUrl"
-      [style.width]="mapWidth + 'px'"
-      [style.height]="mapHeight + 'px'"
-    />
-  </ng-container>
-</ng-template>
+<ng-container *ngIf="showCurrentLocation && currentLocation">
+  <img
+    (click)="mapClicked($event)"
+    (error)="handleMapLoadError($event)"
+    [src]="currentLocationMapUrl"
+    [style.width]="mapWidth + 'px'"
+    [style.height]="mapHeight + 'px'"
+  />
+</ng-container>

--- a/src/app/shared/components/route-visualizer/route-visualizer.component.ts
+++ b/src/app/shared/components/route-visualizer/route-visualizer.component.ts
@@ -17,10 +17,6 @@ export class RouteVisualizerComponent implements OnChanges, OnInit {
 
   @Output() mapClick = new EventEmitter<void>();
 
-  dynamicMapOptions: google.maps.MapOptions = {
-    disableDefaultUI: true,
-  };
-
   showCurrentLocation = false;
 
   mapWidth: number;

--- a/src/app/shared/components/route-visualizer/route-visualizer.component.ts
+++ b/src/app/shared/components/route-visualizer/route-visualizer.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
-import { Observable, map, filter } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 import { GmapsService } from 'src/app/core/services/gmaps.service';
 import { LocationService } from 'src/app/core/services/location.service';
@@ -15,8 +15,6 @@ import { StaticMapPropertiesService } from 'src/app/core/services/static-map-pro
 export class RouteVisualizerComponent implements OnChanges, OnInit {
   @Input() mileageLocations: MileageLocation[];
 
-  @Input() loadDynamicMap: boolean;
-
   @Output() mapClick = new EventEmitter<void>();
 
   dynamicMapOptions: google.maps.MapOptions = {
@@ -29,7 +27,7 @@ export class RouteVisualizerComponent implements OnChanges, OnInit {
 
   mapHeight: number;
 
-  directions$: Observable<google.maps.DirectionsResult>;
+  directionsPolyline$: Observable<string>;
 
   directionsMapUrl$: Observable<string>;
 
@@ -54,7 +52,7 @@ export class RouteVisualizerComponent implements OnChanges, OnInit {
       const mileageRoute = this.locationService.getMileageRoute(this.mileageLocations);
       this.renderMap(mileageRoute);
     } else {
-      this.directions$ = null;
+      this.directionsPolyline$ = null;
       this.directionsMapUrl$ = null;
 
       if (validLocations.length === 0) {
@@ -88,22 +86,23 @@ export class RouteVisualizerComponent implements OnChanges, OnInit {
   handleMapLoadError(event) {
     this.showCurrentLocation = false;
 
-    this.directions$ = null;
+    this.directionsPolyline$ = null;
     this.directionsMapUrl$ = null;
   }
 
   private renderMap(mileageRoute: MileageRoute) {
-    this.directions$ = this.gmapsService.getDirections(mileageRoute);
+    this.directionsPolyline$ = this.locationService.getDirections(
+      mileageRoute.origin,
+      mileageRoute.destination,
+      mileageRoute.waypoints
+    );
 
-    if (!this.loadDynamicMap) {
-      this.directionsMapUrl$ = this.directions$.pipe(
-        filter((directionsResults) => directionsResults.routes.length > 0),
-        map((directionsResults) => ({
-          ...mileageRoute,
-          directions: directionsResults.routes[0],
-        })),
-        map((mileageRoute) => this.gmapsService.generateDirectionsMapUrl(mileageRoute))
-      );
-    }
+    this.directionsMapUrl$ = this.directionsPolyline$.pipe(
+      map((directionsPolyline) => ({
+        ...mileageRoute,
+        directionsPolyline,
+      })),
+      map((mileageRoute) => this.gmapsService.generateDirectionsMapUrl(mileageRoute))
+    );
   }
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -88,7 +88,6 @@ import { RouteSelectorModalComponent } from './components/route-selector/route-s
 import { RouteVisualizerComponent } from './components/route-visualizer/route-visualizer.component';
 import { ReceiptPreviewThumbnailComponent } from './components/receipt-preview-thumbnail/receipt-preview-thumbnail.component';
 import { FyViewReportInfoComponent } from './components/fy-view-report-info/fy-view-report-info.component';
-import { GoogleMapsModule } from '@angular/google-maps';
 import { BankAccountCardsComponent } from './components/bank-account-cards/bank-account-cards.component';
 import { BankAccountCardComponent } from './components/bank-account-cards/bank-account-card/bank-account-card.component';
 import { DeleteButtonComponent } from './components/bank-account-cards/bank-account-card/delete-button/delete-button-component';
@@ -275,7 +274,6 @@ import { PopupWithBulletsComponent } from './components/popup-with-bullets/popup
     MatRadioModule,
     MatDatepickerModule,
     MatChipsModule,
-    GoogleMapsModule,
     MatChipsModule,
     SwiperModule,
     MatSnackBarModule,


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1JjuhykoX4EiWUz2cD2urRpbPrObokmVE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=QuxKZtu)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab80078</samp>

Refactored the app to use the new directions api from the location service instead of the google maps directions service. Removed the unused dependencies and code related to the google maps directions renderer and the launch darkly service. Updated the route visualizer component and the add-edit-mileage page to use the static map image url and the encoded polyline string from the new api. Modified the mock data and the test cases to match the new api format.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ab80078</samp>

> _We're sailing away from Google Maps, me hearties_
> _We've got a new directions api to try_
> _So heave away and pull the `polyline` string_
> _And watch the static map image in your eye_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab80078</samp>

*  Replace google maps directions service with new directions api ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-a0c4b2435d7844c17cac92480ba1fa5c2a85160c3c7699128809c2bd43cb6d1bL1-R5), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-0cebb24de75c112faebaef5e5125b9c8a3893dd5b900e1249723ce2dbcdfa350L2-R3), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-0cebb24de75c112faebaef5e5125b9c8a3893dd5b900e1249723ce2dbcdfa350L17-R17), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-0cebb24de75c112faebaef5e5125b9c8a3893dd5b900e1249723ce2dbcdfa350L33-L49), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-0cebb24de75c112faebaef5e5125b9c8a3893dd5b900e1249723ce2dbcdfa350L88-R67), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-a9f7eb56754004566eb5b64da853044e880131a666d300dfc68ff6594310ea1eR55-R77), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-04416b8114238b14b62e71d7041f88959b1251aac31f03a257cdbd29ce60a50bL5-R5), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L4-R4), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L16-R16), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L59-R64), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L141-R144), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L193-R196), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L199-R212), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L223-R231), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-b40c7d882dae9c3cff13038276ec92375b905681316be9c21e6a7ddb44df455aL2-R2), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-b40c7d882dae9c3cff13038276ec92375b905681316be9c21e6a7ddb44df455aL91-R106))
  * Remove unused imports and dependencies related to google maps directions service from `gmaps.service.ts` and `route-visualizer.component.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-0cebb24de75c112faebaef5e5125b9c8a3893dd5b900e1249723ce2dbcdfa350L2-R3), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-0cebb24de75c112faebaef5e5125b9c8a3893dd5b900e1249723ce2dbcdfa350L17-R17), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-b40c7d882dae9c3cff13038276ec92375b905681316be9c21e6a7ddb44df455aL2-R2))
  * Remove `getDirections` method from `gmaps.service.ts` as it is no longer needed to call google maps directions service ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-0cebb24de75c112faebaef5e5125b9c8a3893dd5b900e1249723ce2dbcdfa350L33-L49))
  * Add `getDirections` method to `location.service.ts` that calls the new directions api with origin, destination, and waypoints parameters and returns an observable of the encoded polyline string or an error object ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-a9f7eb56754004566eb5b64da853044e880131a666d300dfc68ff6594310ea1eR55-R77))
  * Update `generateDirectionsMapUrl` method in `gmaps.service.ts` to use the `directionsPolyline` property of the mileage route instead of the `overview_polyline` property of the directions object, as the new directions api returns a string for the encoded polyline instead of a google maps object ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-0cebb24de75c112faebaef5e5125b9c8a3893dd5b900e1249723ce2dbcdfa350L88-R67))
  * Update `mileage-route.interface.ts` to use the `directionsPolyline` property instead of the `directions` property, as the new directions api returns a string for the encoded polyline instead of a google maps object ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-04416b8114238b14b62e71d7041f88959b1251aac31f03a257cdbd29ce60a50bL5-R5))
  * Update mock data for directions results in `directions-results.data.ts` and `route-visualizer.component.spec.ts` to use a string for the encoded polyline instead of a google maps object, and to use an object with a message for the error case instead of an empty array of routes ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-a0c4b2435d7844c17cac92480ba1fa5c2a85160c3c7699128809c2bd43cb6d1bL1-R5), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L16-R16))
  * Update `route-visualizer.component.ts` to use the `location.service.ts` instead of the `gmaps.service.ts` to get the directions polyline, and to use the `directionsPolyline` and `directionsMapUrl` properties instead of the `directions` and `directionsMapUrl` properties, as the new directions api returns a string for the encoded polyline instead of a google maps object ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-b40c7d882dae9c3cff13038276ec92375b905681316be9c21e6a7ddb44df455aL32-R30), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-b40c7d882dae9c3cff13038276ec92375b905681316be9c21e6a7ddb44df455aL57-R55), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-b40c7d882dae9c3cff13038276ec92375b905681316be9c21e6a7ddb44df455aL91-R106))
  * Update `route-visualizer.component.spec.ts` to import the `throwError` operator and to use the `location.service.ts` spy instead of the `gmaps.service.ts` spy to mock the call to the new directions api, and to use the `directionsPolyline` property instead of the `directions` property, as the new directions api returns a string for the encoded polyline instead of a google maps object ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L4-R4), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L59-R64), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L141-R144), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L164-R167), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L177-R180), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L193-R196), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L199-R212), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L217-R224), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L223-R231), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L252-R246))
* Remove feature flag for showing dynamic maps ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-91d90eb686ef4e78cc171f9f1472a515637b0871709d9a7e77bc70176891d507L82-R87), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL75), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL248-L249), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL284), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL329-L330), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-22253a466d399b3361348f95a73ebbdf73ab985b75a582cf4cb65db0e45422f3L1-R19), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-b40c7d882dae9c3cff13038276ec92375b905681316be9c21e6a7ddb44df455aL18-L19))
  * Remove `loadDynamicMap` input from `route-visualizer.component.ts` and `route-visualizer.component.html`, as it is no longer needed to conditionally render the google map component based on the feature flag for showing dynamic maps ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-22253a466d399b3361348f95a73ebbdf73ab985b75a582cf4cb65db0e45422f3L1-R19), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-b40c7d882dae9c3cff13038276ec92375b905681316be9c21e6a7ddb44df455aL18-L19))
  * Remove `loadDynamicMap` property from `add-edit-mileage.page.ts` and `add-edit-mileage.page.html`, as it is no longer needed to pass the feature flag value to the `route-visualizer.component.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL248-L249), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL329-L330), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-91d90eb686ef4e78cc171f9f1472a515637b0871709d9a7e77bc70176891d507L82-R87))
  * Remove import and dependency injection of the launch darkly service from `add-edit-mileage.page.ts`, as it is no longer needed to check the feature flag for showing dynamic maps ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL75), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL284))
  * Remove condition for loading a dynamic map from `renderMap` method in `route-visualizer.component.ts` and `route-visualizer.component.spec.ts`, as the app will no longer use the google maps directions renderer to show the dynamic map, but instead use the static map image url generated by the `gmaps.service.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-b40c7d882dae9c3cff13038276ec92375b905681316be9c21e6a7ddb44df455aL91-R106), [link](https://github.com/fylein/fyle-mobile-app/pull/2199/files?diff=unified&w=0#diff-cd34879418743e5fa8e811c07bfd9f9b07db088d96127ce28c0d0ed9b7544760L223-R231))

## Clickup
https://app.clickup.com/t/85ztcg9k6

## Code Coverage
Please add code coverage here

## UI Preview
<img width="719" alt="image" src="https://github.com/fylein/fyle-mobile-app/assets/65808188/9149ef40-7c92-4921-93d3-8ab1d0deb982">
