### PR TITLE
fix: Added updates for page depth in linting rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          fetch-depth: 2
+        with:
           # Make sure the actual branch is checked out when running on pull requests
           ref: ${{ github.head_ref }}
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1xYEchUyW3bM0hLrfgBHMxGi8y5Wl15s%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=reaytE4)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 920df0e</samp>

Set `fetch-depth` to 2 for `actions/checkout@v2` in `.github/workflows/lint.yml` to enable better linting of changed files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 920df0e</samp>

> _`fetch-depth` is two_
> _`super-linter` compares_
> _autumn leaves falling_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 920df0e</samp>

*  Set `fetch-depth` option to 2 for `actions/checkout@v2` step to enable comparison of commits by some linters ([link](https://github.com/fylein/fyle-mobile-app/pull/2205/files?diff=unified&w=0#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R18-R19))

## Clickup
https://app.clickup.com/t/85ztj2p3j