### PR TITLE
fix: passed empty params to onViewCommentsClick

### DIFF
--- a/src/app/fyle/my-reports/my-reports.page.html
+++ b/src/app/fyle/my-reports/my-reports.page.html
@@ -102,7 +102,7 @@
             [simplifyReportsEnabled]="simplifyReportsSettings.enabled"
             (gotoReport)="onReportClick($event)"
             (deleteReport)="onDeleteReportClick($event)"
-            (viewComments)="onViewCommentsClick($event)"
+            (viewComments)="onViewCommentsClick()"
           ></app-reports-card>
         </div>
       </ng-container>


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18AVqmC7tQZphQcvZJwTLsQoDTe642LNiY%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=uXViLw1)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d493b4</samp>

Simplified the `viewComments` event handler in `my-reports.page.html` to remove an unused parameter.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2d493b4</samp>

> _`viewComments` changed_
> _No need for `$event` now_
> _Code is clear as ice_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2d493b4</samp>

*  Simplified the `viewComments` event handler to remove unused parameter (`[link](https://github.com/fylein/fyle-mobile-app/pull/2233/files?diff=unified&w=0#diff-8b81cb6db62f8aae5d80b4df1c80686e49798e363e9d30068cdb88f9bae22f1eL105-R105)`)

## Clickup
app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes