### PR TITLE
test: 78% coverage of split-expense

### DIFF
--- a/src/app/core/mock-data/split-expense-form.data.ts
+++ b/src/app/core/mock-data/split-expense-form.data.ts
@@ -1,0 +1,49 @@
+import { FormControl, FormGroup } from '@angular/forms';
+
+export const splitExpenseFormData1 = new FormGroup({
+  amount: new FormControl(120),
+  currency: new FormControl('INR'),
+  percentage: new FormControl(60),
+  txn_dt: new FormControl('2023-01-11'),
+  category: new FormControl(''),
+});
+
+export const splitExpenseFormData2 = new FormGroup({
+  amount: new FormControl(),
+  currency: new FormControl('INR'),
+  percentage: new FormControl(60),
+  txn_dt: new FormControl('2023-01-11'),
+  category: new FormControl(''),
+});
+
+export const splitExpenseFormData3 = new FormGroup({
+  amount: new FormControl(120),
+  currency: new FormControl('INR'),
+  percentage: new FormControl(),
+  txn_dt: new FormControl('2023-01-11'),
+  category: new FormControl(''),
+});
+
+export const splitExpenseFormData4 = new FormGroup({
+  amount: new FormControl(800),
+  currency: new FormControl('INR'),
+  percentage: new FormControl(40),
+  txn_dt: new FormControl('2023-01-11'),
+  category: new FormControl(''),
+});
+
+export const splitExpenseFormData5 = new FormGroup({
+  amount: new FormControl(800),
+  currency: new FormControl('INR'),
+  percentage: new FormControl(90),
+  txn_dt: new FormControl('2023-01-11'),
+  category: new FormControl(''),
+});
+
+export const splitExpenseFormData6 = new FormGroup({
+  amount: new FormControl(80),
+  currency: new FormControl('INR'),
+  percentage: new FormControl(96),
+  txn_dt: new FormControl('2023-01-11'),
+  category: new FormControl(''),
+});

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -117,6 +117,14 @@ import { unflattenedAccount2Data, unflattenedAccount3Data } from 'src/app/core/t
 import { categorieListRes } from 'src/app/core/mock-data/org-category-list-item.data';
 import * as dayjs from 'dayjs';
 import { expenseList2 } from 'src/app/core/mock-data/expense.data';
+import { cloneDeep } from 'lodash';
+import {
+  splitExpenseFormData1,
+  splitExpenseFormData2,
+  splitExpenseFormData3,
+  splitExpenseFormData5,
+  splitExpenseFormData6,
+} from 'src/app/core/mock-data/split-expense-form.data';
 
 describe('SplitExpensePage', () => {
   let component: SplitExpensePage;
@@ -337,6 +345,94 @@ describe('SplitExpensePage', () => {
       expect(splitExpenseForm1.controls.amount.value).toEqual(1920);
       expect(splitExpenseForm1.controls.percentage.value).toEqual(96);
       expect(otherSplitExpenseForm.controls.percentage.value).toEqual(4);
+      expect(component.getTotalSplitAmount).toHaveBeenCalledTimes(1);
+    }));
+
+    it('should return void immediately if amount is null', () => {
+      spyOn(component, 'getTotalSplitAmount');
+      const splitExpenseForm1 = cloneDeep(splitExpenseFormData1);
+
+      Object.defineProperty(splitExpenseForm1.controls.amount, '_pendingChange', { value: true });
+
+      component.onChangeAmount(splitExpenseForm1, 0);
+
+      expect(splitExpenseForm1.controls.amount.value).toEqual(120);
+      expect(splitExpenseForm1.controls.percentage.value).toEqual(60);
+      expect(component.getTotalSplitAmount).not.toHaveBeenCalled();
+    });
+
+    it('should return void immediately if splitExpenseForm.amount is not a number', () => {
+      spyOn(component, 'getTotalSplitAmount');
+      component.amount = 2000;
+      const splitExpenseForm1 = cloneDeep(splitExpenseFormData2);
+
+      Object.defineProperty(splitExpenseForm1.controls.amount, '_pendingChange', { value: true });
+
+      component.onChangeAmount(splitExpenseForm1, 0);
+
+      expect(splitExpenseForm1.controls.amount.value).toEqual(null);
+      expect(splitExpenseForm1.controls.percentage.value).toEqual(60);
+      expect(component.getTotalSplitAmount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onChangePercentage():', () => {
+    it('should return void immediately if amount is null', () => {
+      spyOn(component, 'getTotalSplitAmount');
+      const splitExpenseForm1 = cloneDeep(splitExpenseFormData1);
+
+      Object.defineProperty(splitExpenseForm1.controls.percentage, '_pendingChange', { value: true });
+
+      component.onChangePercentage(splitExpenseForm1, 0);
+
+      expect(splitExpenseForm1.controls.amount.value).toEqual(120);
+      expect(splitExpenseForm1.controls.percentage.value).toEqual(60);
+      expect(component.getTotalSplitAmount).not.toHaveBeenCalled();
+    });
+
+    it('should return void immediately if splitExpenseForm.percentage is not a number', () => {
+      spyOn(component, 'getTotalSplitAmount');
+      component.amount = 2000;
+      const splitExpenseForm1 = cloneDeep(splitExpenseFormData3);
+
+      Object.defineProperty(splitExpenseForm1.controls.percentage, '_pendingChange', { value: true });
+
+      component.onChangePercentage(splitExpenseForm1, 0);
+
+      expect(splitExpenseForm1.controls.amount.value).toEqual(120);
+      expect(splitExpenseForm1.controls.percentage.value).toEqual(null);
+      expect(component.getTotalSplitAmount).not.toHaveBeenCalled();
+    });
+
+    it('should get the new amount and percentage value after percentage is changed for first split', fakeAsync(() => {
+      spyOn(component, 'getTotalSplitAmount');
+      component.amount = 2000;
+      const splitExpenseForm1 = cloneDeep(splitExpenseFormData1);
+      const otherSplitExpenseForm = cloneDeep(splitExpenseFormData5);
+      Object.defineProperty(splitExpenseForm1.controls.percentage, '_pendingChange', { value: true });
+      component.splitExpensesFormArray = new FormArray([splitExpenseForm1, otherSplitExpenseForm]);
+
+      component.onChangePercentage(splitExpenseForm1, 0);
+
+      expect(otherSplitExpenseForm.controls.percentage.value).toEqual(40);
+      expect(otherSplitExpenseForm.controls.amount.value).toEqual(800);
+      expect(splitExpenseForm1.controls.percentage.value).toEqual(60);
+      expect(component.getTotalSplitAmount).toHaveBeenCalledTimes(1);
+    }));
+
+    it('should get the new amount and percentage value after percentage is changed for second split', fakeAsync(() => {
+      spyOn(component, 'getTotalSplitAmount');
+      component.amount = 2000;
+      const splitExpenseForm1 = cloneDeep(splitExpenseFormData1);
+      const otherSplitExpenseForm = cloneDeep(splitExpenseFormData6);
+      Object.defineProperty(otherSplitExpenseForm.controls.percentage, '_pendingChange', { value: true });
+      component.splitExpensesFormArray = new FormArray([splitExpenseForm1, otherSplitExpenseForm]);
+
+      component.onChangePercentage(otherSplitExpenseForm, 1);
+
+      expect(splitExpenseForm1.controls.percentage.value).toEqual(4);
+      expect(splitExpenseForm1.controls.amount.value).toEqual(80);
+      expect(otherSplitExpenseForm.controls.percentage.value).toEqual(96);
       expect(component.getTotalSplitAmount).toHaveBeenCalledTimes(1);
     }));
   });

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -370,7 +370,7 @@ describe('SplitExpensePage', () => {
 
       component.onChangeAmount(splitExpenseForm1, 0);
 
-      expect(splitExpenseForm1.controls.amount.value).toEqual(null);
+      expect(splitExpenseForm1.controls.amount.value).toBeNull();
       expect(splitExpenseForm1.controls.percentage.value).toEqual(60);
       expect(component.getTotalSplitAmount).not.toHaveBeenCalled();
     });
@@ -400,7 +400,7 @@ describe('SplitExpensePage', () => {
       component.onChangePercentage(splitExpenseForm1, 0);
 
       expect(splitExpenseForm1.controls.amount.value).toEqual(120);
-      expect(splitExpenseForm1.controls.percentage.value).toEqual(null);
+      expect(splitExpenseForm1.controls.percentage.value).toBeNull();
       expect(component.getTotalSplitAmount).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19BWB0pC0QnV4DbU4IcdzQFUjgruPNufns%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=0PjYGEm)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a9888f</samp>

This pull request adds test cases and mock data for the split expense page component in the app. The test cases verify the logic of the `onChangeAmount` and `onChangePercentage` methods using the mock data. The mock data simulates different split expense scenarios with various form values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7a9888f</samp>

> _We mock the data for the split expense_
> _We test the methods with different inputs_
> _We face the doom of the currency change_
> _We resist the errors with our outputs_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7a9888f</samp>

*  Add mock data for split expense form groups ([link](https://github.com/fylein/fyle-mobile-app/pull/2235/files?diff=unified&w=0#diff-34a64d3b11f026ed5059cb78801436ea312cfab12781dbd085479cae1817ad48R1-R49))
*  Import mock data for testing split expense page component ([link](https://github.com/fylein/fyle-mobile-app/pull/2235/files?diff=unified&w=0#diff-391b3c1134d2ffdd6f0128e3e95116db167b57a91a80674dbb0abfe568407ec5R120-R127))
*  Test `onChangeAmount` and `onChangePercentage` methods for different scenarios and expected outcomes ([link](https://github.com/fylein/fyle-mobile-app/pull/2235/files?diff=unified&w=0#diff-391b3c1134d2ffdd6f0128e3e95116db167b57a91a80674dbb0abfe568407ec5L342-R439))

## Clickup
https://app.clickup.com/t/85ztjmt7v

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes