### PR TITLE
test: Code Coverage: Add Edit Mileage #1 

### DIFF
--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
@@ -283,7 +283,7 @@ export function TestCases1(getTestBed) {
           ...properties,
         });
         expect(modalProperties.getModalDefaultProperties).toHaveBeenCalledTimes(1);
-        expect(trackingService.viewComment).toHaveBeenCalledOnceWith();
+        expect(trackingService.viewComment).toHaveBeenCalledTimes(1);
       }));
     });
   });

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
@@ -1,10 +1,13 @@
 import { TitleCasePipe } from '@angular/common';
-import { ComponentFixture } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
 import { FormArray, FormBuilder, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ActionSheetController, ModalController, NavController, Platform, PopoverController } from '@ionic/angular';
+import { of } from 'rxjs';
+import { individualExpPolicyStateData2 } from 'src/app/core/mock-data/individual-expense-policy-state.data';
+import { unflattenedTxnData } from 'src/app/core/mock-data/unflattened-txn.data';
 import { AccountsService } from 'src/app/core/services/accounts.service';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { CategoriesService } from 'src/app/core/services/categories.service';
@@ -18,6 +21,9 @@ import { FileService } from 'src/app/core/services/file.service';
 import { HandleDuplicatesService } from 'src/app/core/services/handle-duplicates.service';
 import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 import { LoaderService } from 'src/app/core/services/loader.service';
+import { LocationService } from 'src/app/core/services/location.service';
+import { MileageRatesService } from 'src/app/core/services/mileage-rates.service';
+import { MileageService } from 'src/app/core/services/mileage.service';
 import { ModalPropertiesService } from 'src/app/core/services/modal-properties.service';
 import { NetworkService } from 'src/app/core/services/network.service';
 import { OrgSettingsService } from 'src/app/core/services/org-settings.service';
@@ -39,9 +45,8 @@ import { TrackingService } from 'src/app/core/services/tracking.service';
 import { TransactionService } from 'src/app/core/services/transaction.service';
 import { TransactionsOutboxService } from 'src/app/core/services/transactions-outbox.service';
 import { AddEditMileagePage } from './add-edit-mileage.page';
-import { MileageService } from 'src/app/core/services/mileage.service';
-import { MileageRatesService } from 'src/app/core/services/mileage-rates.service';
-import { LocationService } from 'src/app/core/services/location.service';
+import { properties } from 'src/app/core/mock-data/modal-properties.data';
+import { ViewCommentComponent } from 'src/app/shared/components/comments-history/view-comment/view-comment.component';
 
 export function TestCases1(getTestBed) {
   return describe('AddEditMileage-1', () => {
@@ -176,6 +181,110 @@ export function TestCases1(getTestBed) {
 
     it('should create', () => {
       expect(component).toBeTruthy();
+    });
+
+    it('goToPrev(): should go to the previous txn', () => {
+      spyOn(component, 'goToTransaction');
+      activatedRoute.snapshot.params.activeIndex = 1;
+      component.reviewList = ['txSEM4DtjyKR', 'txNyI8ot5CuJ'];
+      transactionService.getETxnUnflattened.and.returnValue(of(unflattenedTxnData));
+      fixture.detectChanges();
+
+      component.goToPrev();
+      expect(transactionService.getETxnUnflattened).toHaveBeenCalledOnceWith('txSEM4DtjyKR');
+      expect(component.goToTransaction).toHaveBeenCalledOnceWith(unflattenedTxnData, component.reviewList, 0);
+    });
+
+    it('goToNext(): should got to the next txn', () => {
+      const etxn = { ...unflattenedTxnData, tx: { ...unflattenedTxnData.tx, id: 'txNyI8ot5CuJ' } };
+      spyOn(component, 'goToTransaction');
+      activatedRoute.snapshot.params.activeIndex = 0;
+      component.reviewList = ['txSEM4DtjyKR', 'txNyI8ot5CuJ'];
+      transactionService.getETxnUnflattened.and.returnValue(of(etxn));
+      fixture.detectChanges();
+
+      component.goToNext();
+      expect(transactionService.getETxnUnflattened).toHaveBeenCalledOnceWith('txNyI8ot5CuJ');
+      expect(component.goToTransaction).toHaveBeenCalledOnceWith(etxn, component.reviewList, 1);
+    });
+
+    it('getPolicyDetails(): should get policy details', () => {
+      policyService.getSpenderExpensePolicyViolations.and.returnValue(of(individualExpPolicyStateData2));
+
+      component.getPolicyDetails();
+
+      expect(component.policyDetails).toEqual(individualExpPolicyStateData2);
+      expect(policyService.getSpenderExpensePolicyViolations).toHaveBeenCalledOnceWith(
+        activatedRoute.snapshot.params.id
+      );
+    });
+
+    it('showFields(): should show expanded view', () => {
+      component.showFields();
+
+      expect(trackingService.showMoreClicked).toHaveBeenCalledOnceWith({
+        source: 'Add Mileage page',
+      });
+      expect(component.isExpandedView).toBeTrue();
+    });
+
+    it('hideFields(): should disable expanded view', () => {
+      component.hideFields();
+
+      expect(trackingService.hideMoreClicked).toHaveBeenCalledOnceWith({
+        source: 'Add Mileage page',
+      });
+      expect(component.isExpandedView).toBeFalse();
+    });
+
+    describe('openCommentsModal():', () => {
+      it('should add comment to the expense and track the event', fakeAsync(() => {
+        modalProperties.getModalDefaultProperties.and.returnValue(properties);
+        component.etxn$ = of(unflattenedTxnData);
+        fixture.detectChanges();
+
+        const modalSpy = jasmine.createSpyObj('modal', ['present', 'onDidDismiss']);
+        modalSpy.onDidDismiss.and.resolveTo({ data: { updated: 'comment' } });
+        modalController.create.and.resolveTo(modalSpy);
+
+        component.openCommentsModal();
+        tick(500);
+
+        expect(modalController.create).toHaveBeenCalledOnceWith({
+          component: ViewCommentComponent,
+          componentProps: {
+            objectType: 'transactions',
+            objectId: unflattenedTxnData.tx.id,
+          },
+          ...properties,
+        });
+        expect(modalProperties.getModalDefaultProperties).toHaveBeenCalledTimes(1);
+        expect(trackingService.addComment).toHaveBeenCalledOnceWith();
+      }));
+
+      it('should view comment in the expense and track the event', fakeAsync(() => {
+        modalProperties.getModalDefaultProperties.and.returnValue(properties);
+        component.etxn$ = of(unflattenedTxnData);
+        fixture.detectChanges();
+
+        const modalSpy = jasmine.createSpyObj('modal', ['present', 'onDidDismiss']);
+        modalSpy.onDidDismiss.and.resolveTo({ data: null });
+        modalController.create.and.resolveTo(modalSpy);
+
+        component.openCommentsModal();
+        tick(500);
+
+        expect(modalController.create).toHaveBeenCalledOnceWith({
+          component: ViewCommentComponent,
+          componentProps: {
+            objectType: 'transactions',
+            objectId: unflattenedTxnData.tx.id,
+          },
+          ...properties,
+        });
+        expect(modalProperties.getModalDefaultProperties).toHaveBeenCalledTimes(1);
+        expect(trackingService.viewComment).toHaveBeenCalledOnceWith();
+      }));
     });
   });
 }

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
@@ -259,7 +259,7 @@ export function TestCases1(getTestBed) {
           ...properties,
         });
         expect(modalProperties.getModalDefaultProperties).toHaveBeenCalledTimes(1);
-        expect(trackingService.addComment).toHaveBeenCalledOnceWith();
+        expect(trackingService.addComment).toHaveBeenCalledTimes(1);
       }));
 
       it('should view comment in the expense and track the event', fakeAsync(() => {

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.setup.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.setup.spec.ts
@@ -64,7 +64,7 @@ export function setFormValid(component) {
   });
 }
 
-describe('AddEditExpensePage', () => {
+describe('AddEditMileagePage', () => {
   const getTestBed = () => {
     const accountsServiceSpy = jasmine.createSpyObj('AccountsService', [
       'getEMyAccounts',


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67f9aa5</samp>

Added and updated unit tests for the `AddEditMileageComponent` in the fyle-mobile-app. Fixed a naming inconsistency in the test file and describe block for the component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 67f9aa5</samp>

> _We're testing the `AddEditMileagePage` today_
> _With `fakeAsync`, `tick` and `of` we'll play_
> _We'll mock the data and the modal too_
> _And cover all the methods that we need to do_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67f9aa5</samp>

* Import `fakeAsync`, `tick`, `of`, mock data files, `LocationService`, `MileageRatesService` and `MileageService` to enable testing of asynchronous operations, observables and mileage related functionality in `add-edit-mileage-1.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2262/files?diff=unified&w=0#diff-5ea8feba7a8355dcc3a878d59e6ac3c56d89e15472f7ddfe5d9c63c38a90c961L2-R2), [link](https://github.com/fylein/fyle-mobile-app/pull/2262/files?diff=unified&w=0#diff-5ea8feba7a8355dcc3a878d59e6ac3c56d89e15472f7ddfe5d9c63c38a90c961R8-R10), [link](https://github.com/fylein/fyle-mobile-app/pull/2262/files?diff=unified&w=0#diff-5ea8feba7a8355dcc3a878d59e6ac3c56d89e15472f7ddfe5d9c63c38a90c961R24-R26))
* Remove duplicate imports and import `properties` mock data file and `ViewCommentComponent` to provide modal properties and comment viewing functionality in `add-edit-mileage-1.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2262/files?diff=unified&w=0#diff-5ea8feba7a8355dcc3a878d59e6ac3c56d89e15472f7ddfe5d9c63c38a90c961L42-R49))
* Add test cases for `goToPrev`, `goToNext`, `getPolicyDetails`, `showFields`, `hideFields` and `openCommentsModal` methods of `AddEditMileagePage` component using spies, mocks and observables in `add-edit-mileage-1.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2262/files?diff=unified&w=0#diff-5ea8feba7a8355dcc3a878d59e6ac3c56d89e15472f7ddfe5d9c63c38a90c961R185-R288))
* Rename file and describe block from `AddEditExpensePage` to `AddEditMileagePage` to reflect correct component name in `add-edit-mileage.page.setup.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2262/files?diff=unified&w=0#diff-df40b6e711e89d5e80e6f3867394ee96bbff1eeae11eef42db09ce0b3f1821fbL67-R67))

## Clickup
https://app.clickup.com/t/85ztjmtex

## Code Coverage
`10.02% Statements 86/858`
`1.44% Branches 10/690`
`4.77% Functions 14/293`
`10.39% Lines 85/818`

## UI Preview
Please add screenshots for UI changes