### PR TITLE
test: Code Coverage: Add Edit Mileage #2 Part 3

### DIFF
--- a/src/app/core/mock-data/org-category.data.ts
+++ b/src/app/core/mock-data/org-category.data.ts
@@ -1038,3 +1038,42 @@ export const mileageCategories: OrgCategory[] = [
     updated_at: new Date('2023-01-09T16:54:09.929Z'),
   },
 ];
+
+export const mileageCategories2: OrgCategory[] = [
+  {
+    code: '93',
+    created_at: new Date('2021-05-18T11:40:38.576Z'),
+    displayName: 'mileage',
+    enabled: true,
+    fyle_category: 'Food',
+    id: 141295,
+    name: 'mileage',
+    org_id: 'orrjqbDbeP9p',
+    sub_category: 'Business',
+    updated_at: new Date('2022-07-01T05:51:31.800Z'),
+  },
+  {
+    code: '98',
+    created_at: new Date('2021-05-18T11:40:38.576Z'),
+    displayName: 'Pager',
+    enabled: true,
+    fyle_category: 'Mileage',
+    id: 141300,
+    name: 'Pager',
+    org_id: 'orrjqbDbeP9p',
+    sub_category: 'Pager',
+    updated_at: new Date('2022-05-05T17:47:06.951Z'),
+  },
+  {
+    code: '42',
+    created_at: new Date('2023-01-09T16:54:09.929Z'),
+    displayName: 'Marketing outreach',
+    enabled: true,
+    fyle_category: null,
+    id: 226659,
+    name: 'Marketing outreach',
+    org_id: 'orrjqbDbeP9p',
+    sub_category: 'Marketing outreach',
+    updated_at: new Date('2023-01-09T16:54:09.929Z'),
+  },
+];

--- a/src/app/core/services/status.service.ts
+++ b/src/app/core/services/status.service.ts
@@ -17,13 +17,18 @@ export class StatusService {
       map((estatuses: ExtendedStatus[]) =>
         estatuses?.map((estatus) => {
           estatus.st_created_at = new Date(estatus.st_created_at);
-          return estatus as ExtendedStatus;
+          return estatus;
         })
       )
     );
   }
 
-  post(objectType: string, objectId: string, status: { comment: string | ExtendedStatus }, notify: boolean = false) {
+  post(
+    objectType: string,
+    objectId: string,
+    status: { comment: string | ExtendedStatus },
+    notify: boolean = false
+  ): Observable<TransactionStatus> {
     return this.apiService.post<TransactionStatus>('/' + objectType + '/' + objectId + '/statuses', {
       status,
       notify,

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
@@ -451,7 +451,7 @@ export function TestCases1(getTestBed) {
 
         component.saveExpenseAndGotoNext();
 
-        expect(component.showFormValidationErrors).toHaveBeenCalledOnceWith();
+        expect(component.showFormValidationErrors).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -823,7 +823,7 @@ export function TestCases1(getTestBed) {
 
         component.saveExpenseAndGotoPrev();
         expect(component.addExpense).toHaveBeenCalledOnceWith('SAVE_AND_PREV_MILEAGE');
-        expect(component.close).toHaveBeenCalledOnceWith();
+        expect(component.close).toHaveBeenCalledTimes(1);
       });
 
       it('should add a new expense and go to the previous expense if not the first one in list', () => {
@@ -838,7 +838,7 @@ export function TestCases1(getTestBed) {
 
         component.saveExpenseAndGotoPrev();
         expect(component.addExpense).toHaveBeenCalledOnceWith('SAVE_AND_PREV_MILEAGE');
-        expect(component.goToPrev).toHaveBeenCalledOnceWith();
+        expect(component.goToPrev).toHaveBeenCalledTimes(1);
       });
 
       it('should save an edited expense and close the form', () => {
@@ -853,7 +853,7 @@ export function TestCases1(getTestBed) {
 
         component.saveExpenseAndGotoPrev();
         expect(component.editExpense).toHaveBeenCalledOnceWith('SAVE_AND_PREV_MILEAGE');
-        expect(component.close).toHaveBeenCalledOnceWith();
+        expect(component.close).toHaveBeenCalledTimes(1);
       });
 
       it('should save an edited expense and go to the previous expense', () => {
@@ -868,7 +868,7 @@ export function TestCases1(getTestBed) {
 
         component.saveExpenseAndGotoPrev();
         expect(component.editExpense).toHaveBeenCalledOnceWith('SAVE_AND_PREV_MILEAGE');
-        expect(component.goToPrev).toHaveBeenCalledOnceWith();
+        expect(component.goToPrev).toHaveBeenCalledTimes(1);
       });
 
       it('should show validation errors if the form is not valid', () => {
@@ -876,7 +876,7 @@ export function TestCases1(getTestBed) {
 
         component.saveExpenseAndGotoPrev();
 
-        expect(component.showFormValidationErrors).toHaveBeenCalledOnceWith();
+        expect(component.showFormValidationErrors).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
@@ -1,6 +1,6 @@
 import { TitleCasePipe } from '@angular/common';
 import { ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
-import { FormArray, FormBuilder, Validators } from '@angular/forms';
+import { FormArray, FormBuilder, FormControl, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -10,11 +10,7 @@ import { criticalPolicyViolation2 } from 'src/app/core/mock-data/crtical-policy-
 import { policyExpense2 } from 'src/app/core/mock-data/expense.data';
 import { individualExpPolicyStateData2 } from 'src/app/core/mock-data/individual-expense-policy-state.data';
 import { properties } from 'src/app/core/mock-data/modal-properties.data';
-import {
-  mileageCategories,
-  orgCategoryData,
-  transformedOrgCategoryById,
-} from 'src/app/core/mock-data/org-category.data';
+import { mileageCategories, transformedOrgCategoryById } from 'src/app/core/mock-data/org-category.data';
 import { outboxQueueData1 } from 'src/app/core/mock-data/outbox-queue.data';
 import { splitPolicyExp4 } from 'src/app/core/mock-data/policy-violation.data';
 import { txnData2 } from 'src/app/core/mock-data/transaction.data';
@@ -55,16 +51,22 @@ import { TokenService } from 'src/app/core/services/token.service';
 import { TrackingService } from 'src/app/core/services/tracking.service';
 import { TransactionService } from 'src/app/core/services/transaction.service';
 import { TransactionsOutboxService } from 'src/app/core/services/transactions-outbox.service';
+import { estatusData1 } from 'src/app/core/test-data/status.service.spec.data';
 import { ViewCommentComponent } from 'src/app/shared/components/comments-history/view-comment/view-comment.component';
+import { FyCriticalPolicyViolationComponent } from 'src/app/shared/components/fy-critical-policy-violation/fy-critical-policy-violation.component';
 import { FyPolicyViolationComponent } from 'src/app/shared/components/fy-policy-violation/fy-policy-violation.component';
 import { AddEditMileagePage } from './add-edit-mileage.page';
-import { FyCriticalPolicyViolationComponent } from 'src/app/shared/components/fy-critical-policy-violation/fy-critical-policy-violation.component';
-import { estatusData1 } from 'src/app/core/test-data/status.service.spec.data';
-import { expensePolicyData } from 'src/app/core/mock-data/expense-policy.data';
-import { fileObject4 } from 'src/app/core/mock-data/file-object.data';
-import { platformPolicyExpenseData1 } from 'src/app/core/mock-data/platform-policy-expense.data';
-import { publicPolicyExpenseData1 } from 'src/app/core/mock-data/public-policy-expense.data';
-import { unfilteredMileageRatesData } from 'src/app/core/mock-data/mileage-rate.data';
+import {
+  multiplePaymentModesData,
+  multiplePaymentModesWithoutAdvData,
+  orgSettingsData,
+} from 'src/app/core/test-data/accounts.service.spec.data';
+import { txnCustomPropertiesData } from 'src/app/core/mock-data/txn-custom-properties.data';
+import { orgUserSettingsData } from 'src/app/core/mock-data/org-user-settings.data';
+import { accountOptionData1 } from 'src/app/core/mock-data/account-option.data';
+import { ExpenseType } from 'src/app/core/enums/expense-type.enum';
+import { PopupAlertComponent } from 'src/app/shared/components/popup-alert/popup-alert.component';
+import { locationData1, locationData2, locationData3 } from 'src/app/core/mock-data/location.data';
 
 export function TestCases1(getTestBed) {
   return describe('AddEditMileage-1', () => {
@@ -877,6 +879,175 @@ export function TestCases1(getTestBed) {
         component.saveExpenseAndGotoPrev();
 
         expect(component.showFormValidationErrors).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('customDateValidator():', () => {
+      it('should return null when the date is within the valid range', () => {
+        const control = new FormControl('2023-06-15');
+        const result = component.customDateValidator(control);
+        expect(result).toBeNull();
+      });
+
+      it('should return an error object when the date is after the upper bound of the valid range', () => {
+        const tomorrow = new Date();
+        tomorrow.setDate(tomorrow.getDate() + 2);
+        const control = new FormControl(tomorrow.toDateString());
+        const result = component.customDateValidator(control);
+        expect(result).toEqual({ invalidDateSelection: true });
+      });
+    });
+
+    it('getEditExpense(): should return an unflattened expense to edit', (done) => {
+      transactionService.getETxnUnflattened.and.returnValue(of(unflattenedTxnData));
+      activatedRoute.snapshot.params.id = unflattenedTxnData.tx.id;
+      component.getEditExpense().subscribe((res) => {
+        expect(res).toEqual(unflattenedTxnData);
+        done();
+      });
+    });
+
+    describe('checkAvailableAdvance():', () => {
+      it('should setup balance available flag', fakeAsync(() => {
+        accountsService.getEMyAccounts.and.returnValue(of(multiplePaymentModesData));
+        component.checkAvailableAdvance();
+        tick(500);
+
+        component.isBalanceAvailableInAnyAdvanceAccount$.subscribe((res) => {
+          expect(res).toBeTrue();
+          expect(accountsService.getEMyAccounts).toHaveBeenCalledOnceWith();
+        });
+        component.fg.controls.paymentMode.setValue(multiplePaymentModesWithoutAdvData[0]);
+        fixture.detectChanges();
+
+        tick(500);
+      }));
+
+      it('should return false in advance balance if payment mode is not personal', fakeAsync(() => {
+        accountsService.getEMyAccounts.and.returnValue(of(multiplePaymentModesData));
+        component.checkAvailableAdvance();
+        tick(500);
+
+        component.isBalanceAvailableInAnyAdvanceAccount$.subscribe((res) => {
+          expect(res).toBeFalse();
+          expect(accountsService.getEMyAccounts).not.toHaveBeenCalledOnceWith();
+        });
+        component.fg.controls.paymentMode.setValue(multiplePaymentModesWithoutAdvData[1]);
+        fixture.detectChanges();
+
+        tick(500);
+      }));
+
+      it('should return false when account type changes to null', fakeAsync(() => {
+        accountsService.getEMyAccounts.and.returnValue(of(null));
+        component.checkAvailableAdvance();
+        tick(500);
+
+        component.isBalanceAvailableInAnyAdvanceAccount$.subscribe((res) => {
+          expect(res).toBeFalse();
+          expect(accountsService.getEMyAccounts).not.toHaveBeenCalledOnceWith();
+        });
+        component.fg.controls.paymentMode.setValue(null);
+        fixture.detectChanges();
+
+        tick(500);
+      }));
+    });
+
+    it('getPaymentModes(): should get payment modes', (done) => {
+      accountsService.getEMyAccounts.and.returnValue(of(multiplePaymentModesData));
+      orgSettingsService.get.and.returnValue(of(orgSettingsData));
+      orgUserSettingsService.getAllowedPaymentModes.and.returnValue(
+        of(orgUserSettingsData.payment_mode_settings.allowed_payment_modes)
+      );
+      paymentModesService.checkIfPaymentModeConfigurationsIsEnabled.and.returnValue(of(true));
+      accountsService.getPaymentModes.and.returnValue(accountOptionData1);
+      component.etxn$ = of(unflattenedTxnData);
+      fixture.detectChanges();
+
+      const config = {
+        etxn: unflattenedTxnData,
+        orgSettings: orgSettingsData,
+        expenseType: ExpenseType.MILEAGE,
+        isPaymentModeConfigurationsEnabled: true,
+      };
+
+      component.getPaymentModes().subscribe((res) => {
+        expect(res).toEqual(accountOptionData1);
+        expect(accountsService.getEMyAccounts).toHaveBeenCalledTimes(1);
+        expect(orgSettingsService.get).toHaveBeenCalledTimes(1);
+        expect(orgUserSettingsService.getAllowedPaymentModes).toHaveBeenCalledTimes(1);
+        expect(paymentModesService.checkIfPaymentModeConfigurationsIsEnabled).toHaveBeenCalledTimes(1);
+        expect(accountsService.getPaymentModes).toHaveBeenCalledOnceWith(
+          multiplePaymentModesData,
+          orgUserSettingsData.payment_mode_settings.allowed_payment_modes,
+          config
+        );
+        done();
+      });
+    });
+
+    describe('close():', () => {
+      it('should navigate back to the previous page if redirected from report', () => {
+        component.isRedirectedFromReport = true;
+        fixture.detectChanges();
+
+        component.close();
+
+        expect(navController.back).toHaveBeenCalledTimes(1);
+      });
+
+      it('should navigate to my expense page if the user was not redirected from report', () => {
+        component.isRedirectedFromReport = false;
+        fixture.detectChanges();
+
+        component.close();
+
+        expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_expenses']);
+      });
+    });
+
+    describe('getEditCalculatedDistance():', () => {
+      it('should get distance in edit mode for a single trip', (done) => {
+        mileageService.getDistance.and.returnValue(of(5));
+        component.etxn$ = of(unflattenedTxnData);
+        spyOn(component, 'getFormValues').and.returnValue({
+          route: null,
+        });
+        fixture.detectChanges();
+
+        component
+          .getEditCalculatedDistance({
+            value: { mileageLocations: [locationData1, locationData2] },
+          })
+          .subscribe((res) => {
+            expect(res).toEqual('0.01');
+            expect(mileageService.getDistance).toHaveBeenCalledOnceWith([locationData1, locationData2]);
+            done();
+          });
+      });
+
+      it('should get distance in edit mode for a round trip', (done) => {
+        mileageService.getDistance.and.returnValue(of(10));
+        component.etxn$ = of(unflattenedTxnData);
+        spyOn(component, 'getFormValues').and.returnValue({
+          route: {
+            roundTrip: true,
+            mileageLocations: [],
+            distance: 0,
+          },
+        });
+        fixture.detectChanges();
+
+        component
+          .getEditCalculatedDistance({
+            value: { mileageLocations: [locationData1, locationData3] },
+          })
+          .subscribe((res) => {
+            expect(res).toEqual('0.02');
+            expect(mileageService.getDistance).toHaveBeenCalledOnceWith([locationData1, locationData3]);
+            done();
+          });
       });
     });
   });

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
@@ -826,7 +826,7 @@ export function TestCases1(getTestBed) {
         expect(component.close).toHaveBeenCalledTimes(1);
       });
 
-      it('should add a new expense and go to the previous expense if not the first one in list', () => {
+      it('should add a new expense and go to the previous expense in the report', () => {
         spyOn(component, 'addExpense').and.returnValue(of(outboxQueueData1[0]));
         spyOn(component, 'goToPrev');
         component.activeIndex = 1;

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-1.spec.ts
@@ -10,7 +10,11 @@ import { criticalPolicyViolation2 } from 'src/app/core/mock-data/crtical-policy-
 import { policyExpense2 } from 'src/app/core/mock-data/expense.data';
 import { individualExpPolicyStateData2 } from 'src/app/core/mock-data/individual-expense-policy-state.data';
 import { properties } from 'src/app/core/mock-data/modal-properties.data';
-import { mileageCategories, transformedOrgCategoryById } from 'src/app/core/mock-data/org-category.data';
+import {
+  mileageCategories,
+  orgCategoryData,
+  transformedOrgCategoryById,
+} from 'src/app/core/mock-data/org-category.data';
 import { outboxQueueData1 } from 'src/app/core/mock-data/outbox-queue.data';
 import { splitPolicyExp4 } from 'src/app/core/mock-data/policy-violation.data';
 import { txnData2 } from 'src/app/core/mock-data/transaction.data';
@@ -56,6 +60,11 @@ import { FyPolicyViolationComponent } from 'src/app/shared/components/fy-policy-
 import { AddEditMileagePage } from './add-edit-mileage.page';
 import { FyCriticalPolicyViolationComponent } from 'src/app/shared/components/fy-critical-policy-violation/fy-critical-policy-violation.component';
 import { estatusData1 } from 'src/app/core/test-data/status.service.spec.data';
+import { expensePolicyData } from 'src/app/core/mock-data/expense-policy.data';
+import { fileObject4 } from 'src/app/core/mock-data/file-object.data';
+import { platformPolicyExpenseData1 } from 'src/app/core/mock-data/platform-policy-expense.data';
+import { publicPolicyExpenseData1 } from 'src/app/core/mock-data/public-policy-expense.data';
+import { unfilteredMileageRatesData } from 'src/app/core/mock-data/mileage-rate.data';
 
 export function TestCases1(getTestBed) {
   return describe('AddEditMileage-1', () => {
@@ -436,6 +445,14 @@ export function TestCases1(getTestBed) {
         expect(component.editExpense).toHaveBeenCalledOnceWith('SAVE_AND_NEXT_MILEAGE');
         expect(component.goToNext).toHaveBeenCalledTimes(1);
       });
+
+      it('should show validation errors if the form is not valid', () => {
+        spyOn(component, 'showFormValidationErrors');
+
+        component.saveExpenseAndGotoNext();
+
+        expect(component.showFormValidationErrors).toHaveBeenCalledOnceWith();
+      });
     });
 
     it('getTimeSpentOnPage(): should get time spent on page', () => {
@@ -791,6 +808,76 @@ export function TestCases1(getTestBed) {
       component.trackPolicyCorrections();
       expect(trackingService.policyCorrection).toHaveBeenCalledWith({ Violation: 'Critical', Mode: 'Edit Expense' });
       expect(trackingService.policyCorrection).toHaveBeenCalledWith({ Violation: 'Regular', Mode: 'Edit Expense' });
+    });
+
+    describe('saveExpenseAndGotoPrev():', () => {
+      it('should add a new expense and close the form', () => {
+        spyOn(component, 'addExpense').and.returnValue(of(outboxQueueData1[0]));
+        spyOn(component, 'close');
+        component.activeIndex = 0;
+        component.mode = 'add';
+        Object.defineProperty(component.fg, 'valid', {
+          get: () => true,
+        });
+        fixture.detectChanges();
+
+        component.saveExpenseAndGotoPrev();
+        expect(component.addExpense).toHaveBeenCalledOnceWith('SAVE_AND_PREV_MILEAGE');
+        expect(component.close).toHaveBeenCalledOnceWith();
+      });
+
+      it('should add a new expense and go to the previous expense if not the first one in list', () => {
+        spyOn(component, 'addExpense').and.returnValue(of(outboxQueueData1[0]));
+        spyOn(component, 'goToPrev');
+        component.activeIndex = 1;
+        component.mode = 'add';
+        Object.defineProperty(component.fg, 'valid', {
+          get: () => true,
+        });
+        fixture.detectChanges();
+
+        component.saveExpenseAndGotoPrev();
+        expect(component.addExpense).toHaveBeenCalledOnceWith('SAVE_AND_PREV_MILEAGE');
+        expect(component.goToPrev).toHaveBeenCalledOnceWith();
+      });
+
+      it('should save an edited expense and close the form', () => {
+        spyOn(component, 'editExpense').and.returnValue(of(txnData2));
+        spyOn(component, 'close');
+        component.activeIndex = 0;
+        component.mode = 'edit';
+        Object.defineProperty(component.fg, 'valid', {
+          get: () => true,
+        });
+        fixture.detectChanges();
+
+        component.saveExpenseAndGotoPrev();
+        expect(component.editExpense).toHaveBeenCalledOnceWith('SAVE_AND_PREV_MILEAGE');
+        expect(component.close).toHaveBeenCalledOnceWith();
+      });
+
+      it('should save an edited expense and go to the previous expense', () => {
+        spyOn(component, 'editExpense').and.returnValue(of(txnData2));
+        spyOn(component, 'goToPrev');
+        component.activeIndex = 1;
+        component.mode = 'edit';
+        Object.defineProperty(component.fg, 'valid', {
+          get: () => true,
+        });
+        fixture.detectChanges();
+
+        component.saveExpenseAndGotoPrev();
+        expect(component.editExpense).toHaveBeenCalledOnceWith('SAVE_AND_PREV_MILEAGE');
+        expect(component.goToPrev).toHaveBeenCalledOnceWith();
+      });
+
+      it('should show validation errors if the form is not valid', () => {
+        spyOn(component, 'showFormValidationErrors');
+
+        component.saveExpenseAndGotoPrev();
+
+        expect(component.showFormValidationErrors).toHaveBeenCalledOnceWith();
+      });
     });
   });
 }

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-2.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-2.spec.ts
@@ -1,0 +1,334 @@
+import { TitleCasePipe } from '@angular/common';
+import { ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
+import { AbstractControl, FormArray, FormBuilder, Validators } from '@angular/forms';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { DomSanitizer } from '@angular/platform-browser';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ModalController, PopoverController, NavController, ActionSheetController, Platform } from '@ionic/angular';
+import { AccountsService } from 'src/app/core/services/accounts.service';
+import { AuthService } from 'src/app/core/services/auth.service';
+import { CategoriesService } from 'src/app/core/services/categories.service';
+import { CorporateCreditCardExpenseService } from 'src/app/core/services/corporate-credit-card-expense.service';
+import { CurrencyService } from 'src/app/core/services/currency.service';
+import { CustomFieldsService } from 'src/app/core/services/custom-fields.service';
+import { CustomInputsService } from 'src/app/core/services/custom-inputs.service';
+import { DateService } from 'src/app/core/services/date.service';
+import { ExpenseFieldsService } from 'src/app/core/services/expense-fields.service';
+import { FileService } from 'src/app/core/services/file.service';
+import { HandleDuplicatesService } from 'src/app/core/services/handle-duplicates.service';
+import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
+import { LoaderService } from 'src/app/core/services/loader.service';
+import { LocationService } from 'src/app/core/services/location.service';
+import { MileageRatesService } from 'src/app/core/services/mileage-rates.service';
+import { MileageService } from 'src/app/core/services/mileage.service';
+import { ModalPropertiesService } from 'src/app/core/services/modal-properties.service';
+import { NetworkService } from 'src/app/core/services/network.service';
+import { OrgSettingsService } from 'src/app/core/services/org-settings.service';
+import { OrgUserSettingsService } from 'src/app/core/services/org-user-settings.service';
+import { PaymentModesService } from 'src/app/core/services/payment-modes.service';
+import { PersonalCardsService } from 'src/app/core/services/personal-cards.service';
+import { PolicyService } from 'src/app/core/services/policy.service';
+import { PopupService } from 'src/app/core/services/popup.service';
+import { ProjectsService } from 'src/app/core/services/projects.service';
+import { RecentLocalStorageItemsService } from 'src/app/core/services/recent-local-storage-items.service';
+import { RecentlyUsedItemsService } from 'src/app/core/services/recently-used-items.service';
+import { ReportService } from 'src/app/core/services/report.service';
+import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
+import { StatusService } from 'src/app/core/services/status.service';
+import { StorageService } from 'src/app/core/services/storage.service';
+import { TaxGroupService } from 'src/app/core/services/tax-group.service';
+import { TokenService } from 'src/app/core/services/token.service';
+import { TrackingService } from 'src/app/core/services/tracking.service';
+import { TransactionService } from 'src/app/core/services/transaction.service';
+import { TransactionsOutboxService } from 'src/app/core/services/transactions-outbox.service';
+import { AddEditMileagePage } from './add-edit-mileage.page';
+import { Subscription, Subject, BehaviorSubject, of } from 'rxjs';
+import { EventEmitter } from '@angular/core';
+import { locationData1, locationData2 } from 'src/app/core/mock-data/location.data';
+import { unflattenedTxnData } from 'src/app/core/mock-data/unflattened-txn.data';
+import { mileageCategories2 } from 'src/app/core/mock-data/org-category.data';
+import { unfilteredMileageRatesData } from 'src/app/core/mock-data/mileage-rate.data';
+import { setFormValid } from './add-edit-mileage.page.setup.spec';
+import { outboxQueueData1 } from 'src/app/core/mock-data/outbox-queue.data';
+
+export function TestCases2(getTestBed) {
+  return describe('AddEditMileage-2', () => {
+    let component: AddEditMileagePage;
+    let fixture: ComponentFixture<AddEditMileagePage>;
+    let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+    let accountsService: jasmine.SpyObj<AccountsService>;
+    let authService: jasmine.SpyObj<AuthService>;
+    let formBuilder: FormBuilder;
+    let categoriesService: jasmine.SpyObj<CategoriesService>;
+    let dateService: jasmine.SpyObj<DateService>;
+    let projectsService: jasmine.SpyObj<ProjectsService>;
+    let reportService: jasmine.SpyObj<ReportService>;
+    let customInputsService: jasmine.SpyObj<CustomInputsService>;
+    let customFieldsService: jasmine.SpyObj<CustomFieldsService>;
+    let transactionService: jasmine.SpyObj<TransactionService>;
+    let policyService: jasmine.SpyObj<PolicyService>;
+    let transactionOutboxService: jasmine.SpyObj<TransactionsOutboxService>;
+    let router: jasmine.SpyObj<Router>;
+    let loaderService: jasmine.SpyObj<LoaderService>;
+    let modalController: jasmine.SpyObj<ModalController>;
+    let statusService: jasmine.SpyObj<StatusService>;
+    let fileService: jasmine.SpyObj<FileService>;
+    let popoverController: jasmine.SpyObj<PopoverController>;
+    let currencyService: jasmine.SpyObj<CurrencyService>;
+    let networkService: jasmine.SpyObj<NetworkService>;
+    let popupService: jasmine.SpyObj<PopupService>;
+    let navController: jasmine.SpyObj<NavController>;
+    let corporateCreditCardExpenseService: jasmine.SpyObj<CorporateCreditCardExpenseService>;
+    let trackingService: jasmine.SpyObj<TrackingService>;
+    let recentLocalStorageItemsService: jasmine.SpyObj<RecentLocalStorageItemsService>;
+    let recentlyUsedItemsService: jasmine.SpyObj<RecentlyUsedItemsService>;
+    let tokenService: jasmine.SpyObj<TokenService>;
+    let expenseFieldsService: jasmine.SpyObj<ExpenseFieldsService>;
+    let modalProperties: jasmine.SpyObj<ModalPropertiesService>;
+    let actionSheetController: jasmine.SpyObj<ActionSheetController>;
+    let orgSettingsService: jasmine.SpyObj<OrgSettingsService>;
+    let sanitizer: jasmine.SpyObj<DomSanitizer>;
+    let personalCardsService: jasmine.SpyObj<PersonalCardsService>;
+    let matSnackBar: jasmine.SpyObj<MatSnackBar>;
+    let snackbarProperties: jasmine.SpyObj<SnackbarPropertiesService>;
+    let platform: Platform;
+    let titleCasePipe: jasmine.SpyObj<TitleCasePipe>;
+    let handleDuplicates: jasmine.SpyObj<HandleDuplicatesService>;
+    let paymentModesService: jasmine.SpyObj<PaymentModesService>;
+    let taxGroupService: jasmine.SpyObj<TaxGroupService>;
+    let orgUserSettingsService: jasmine.SpyObj<OrgUserSettingsService>;
+    let storageService: jasmine.SpyObj<StorageService>;
+    let launchDarklyService: jasmine.SpyObj<LaunchDarklyService>;
+    let mileageService: jasmine.SpyObj<MileageService>;
+    let mileageRatesService: jasmine.SpyObj<MileageRatesService>;
+    let locationService: jasmine.SpyObj<LocationService>;
+
+    beforeEach(() => {
+      const TestBed = getTestBed();
+      TestBed.compileComponents();
+
+      fixture = TestBed.createComponent(AddEditMileagePage);
+      component = fixture.componentInstance;
+
+      activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
+      accountsService = TestBed.inject(AccountsService) as jasmine.SpyObj<AccountsService>;
+      authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+      formBuilder = TestBed.inject(FormBuilder);
+      categoriesService = TestBed.inject(CategoriesService) as jasmine.SpyObj<CategoriesService>;
+      dateService = TestBed.inject(DateService) as jasmine.SpyObj<DateService>;
+      reportService = TestBed.inject(ReportService) as jasmine.SpyObj<ReportService>;
+      projectsService = TestBed.inject(ProjectsService) as jasmine.SpyObj<ProjectsService>;
+      customInputsService = TestBed.inject(CustomInputsService) as jasmine.SpyObj<CustomInputsService>;
+      customFieldsService = TestBed.inject(CustomFieldsService) as jasmine.SpyObj<CustomFieldsService>;
+      transactionService = TestBed.inject(TransactionService) as jasmine.SpyObj<TransactionService>;
+      policyService = TestBed.inject(PolicyService) as jasmine.SpyObj<PolicyService>;
+      transactionOutboxService = TestBed.inject(TransactionsOutboxService) as jasmine.SpyObj<TransactionsOutboxService>;
+      router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+      loaderService = TestBed.inject(LoaderService) as jasmine.SpyObj<LoaderService>;
+      modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
+      statusService = TestBed.inject(StatusService) as jasmine.SpyObj<StatusService>;
+      fileService = TestBed.inject(FileService) as jasmine.SpyObj<FileService>;
+      popoverController = TestBed.inject(PopoverController) as jasmine.SpyObj<PopoverController>;
+      currencyService = TestBed.inject(CurrencyService) as jasmine.SpyObj<CurrencyService>;
+      networkService = TestBed.inject(NetworkService) as jasmine.SpyObj<NetworkService>;
+      popupService = TestBed.inject(PopupService) as jasmine.SpyObj<PopupService>;
+      navController = TestBed.inject(NavController) as jasmine.SpyObj<NavController>;
+      corporateCreditCardExpenseService = TestBed.inject(
+        CorporateCreditCardExpenseService
+      ) as jasmine.SpyObj<CorporateCreditCardExpenseService>;
+      trackingService = TestBed.inject(TrackingService) as jasmine.SpyObj<TrackingService>;
+      recentLocalStorageItemsService = TestBed.inject(
+        RecentLocalStorageItemsService
+      ) as jasmine.SpyObj<RecentLocalStorageItemsService>;
+      recentlyUsedItemsService = TestBed.inject(RecentlyUsedItemsService) as jasmine.SpyObj<RecentlyUsedItemsService>;
+      tokenService = TestBed.inject(TokenService) as jasmine.SpyObj<TokenService>;
+      expenseFieldsService = TestBed.inject(ExpenseFieldsService) as jasmine.SpyObj<ExpenseFieldsService>;
+      modalProperties = TestBed.inject(ModalPropertiesService) as jasmine.SpyObj<ModalPropertiesService>;
+      actionSheetController = TestBed.inject(ActionSheetController) as jasmine.SpyObj<ActionSheetController>;
+      orgSettingsService = TestBed.inject(OrgSettingsService) as jasmine.SpyObj<OrgSettingsService>;
+      sanitizer = TestBed.inject(DomSanitizer) as jasmine.SpyObj<DomSanitizer>;
+      personalCardsService = TestBed.inject(PersonalCardsService) as jasmine.SpyObj<PersonalCardsService>;
+      matSnackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
+      snackbarProperties = TestBed.inject(SnackbarPropertiesService) as jasmine.SpyObj<SnackbarPropertiesService>;
+      platform = TestBed.inject(Platform);
+      titleCasePipe = TestBed.inject(TitleCasePipe) as jasmine.SpyObj<TitleCasePipe>;
+      handleDuplicates = TestBed.inject(HandleDuplicatesService) as jasmine.SpyObj<HandleDuplicatesService>;
+      paymentModesService = TestBed.inject(PaymentModesService) as jasmine.SpyObj<PaymentModesService>;
+      taxGroupService = TestBed.inject(TaxGroupService) as jasmine.SpyObj<TaxGroupService>;
+      orgUserSettingsService = TestBed.inject(OrgUserSettingsService) as jasmine.SpyObj<OrgUserSettingsService>;
+      storageService = TestBed.inject(StorageService) as jasmine.SpyObj<StorageService>;
+      launchDarklyService = TestBed.inject(LaunchDarklyService) as jasmine.SpyObj<LaunchDarklyService>;
+      mileageService = TestBed.inject(MileageService) as jasmine.SpyObj<MileageService>;
+      mileageRatesService = TestBed.inject(MileageRatesService) as jasmine.SpyObj<MileageRatesService>;
+      locationService = TestBed.inject(LocationService) as jasmine.SpyObj<LocationService>;
+
+      component.fg = formBuilder.group({
+        mileage_rate_name: [],
+        dateOfSpend: [, component.customDateValidator],
+        route: [],
+        paymentMode: [, Validators.required],
+        purpose: [],
+        project: [],
+        billable: [],
+        sub_category: [, Validators.required],
+        custom_inputs: new FormArray([]),
+        costCenter: [],
+        report: [],
+        duplicate_detection_reason: [],
+        project_dependent_fields: formBuilder.array([]),
+        cost_center_dependent_fields: formBuilder.array([]),
+      });
+
+      component.hardwareBackButtonAction = new Subscription();
+      component.onPageExit$ = new Subject();
+      component.selectedProject$ = new BehaviorSubject(null);
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('setupNetworkWatcher(): should setup a network watcher', (done) => {
+      networkService.connectivityWatcher.and.returnValue(new EventEmitter<boolean>());
+      networkService.isOnline.and.returnValue(of(true));
+      fixture.detectChanges();
+
+      component.setupNetworkWatcher();
+
+      component.connectionStatus$.subscribe((res) => {
+        expect(res).toEqual({
+          connected: true,
+        });
+      });
+      expect(networkService.connectivityWatcher).toHaveBeenCalledTimes(1);
+      expect(networkService.isOnline).toHaveBeenCalledTimes(1);
+      done();
+    });
+
+    it('getMileageCategories(): should get all mileage categories', (done) => {
+      categoriesService.getAll.and.returnValue(of(mileageCategories2));
+
+      component.getMileageCategories().subscribe((res) => {
+        expect(res).toEqual({
+          defaultMileageCategory: mileageCategories2[0],
+          mileageCategories: [mileageCategories2[1]],
+        });
+        expect(categoriesService.getAll).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+
+    it('getSubCategories(): should get sub categories', (done) => {
+      categoriesService.getAll.and.returnValue(of(mileageCategories2));
+
+      component.getSubCategories().subscribe((res) => {
+        expect(res).toEqual([mileageCategories2[0]]);
+        expect(categoriesService.getAll).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+
+    it('getRateByVehicleType(): should get rate by vehicle type', () => {
+      const result = component.getRateByVehicleType(unfilteredMileageRatesData, 'bicycle');
+
+      expect(result).toEqual(10);
+    });
+
+    it('getMileageByVehicleType(): should get mileage by vehicle type', () => {
+      const result = component.getMileageByVehicleType(unfilteredMileageRatesData, 'bicycle');
+
+      expect(result).toEqual(unfilteredMileageRatesData[0]);
+    });
+
+    describe('saveAndNewExpense():', () => {
+      it('should add an expense in add mode if the payment mode is valid', () => {
+        spyOn(component, 'checkIfInvalidPaymentMode').and.returnValue(of(false));
+        setFormValid(component);
+        component.mode = 'add';
+        spyOn(component, 'addExpense').and.returnValue(of(true));
+        spyOn(component, 'reloadCurrentRoute');
+        fixture.detectChanges();
+
+        component.saveAndNewExpense();
+
+        expect(component.checkIfInvalidPaymentMode).toHaveBeenCalledTimes(1);
+        expect(component.addExpense).toHaveBeenCalledTimes(1);
+        expect(component.reloadCurrentRoute).toHaveBeenCalledTimes(1);
+        expect(trackingService.clickSaveAddNew).toHaveBeenCalledTimes(1);
+      });
+
+      it('should edit an expense in edit mode if the payment mode is valid', () => {
+        spyOn(component, 'checkIfInvalidPaymentMode').and.returnValue(of(false));
+        setFormValid(component);
+        component.mode = 'edit';
+        spyOn(component, 'editExpense').and.returnValue(of(null));
+        spyOn(component, 'close');
+        fixture.detectChanges();
+
+        component.saveAndNewExpense();
+
+        expect(component.checkIfInvalidPaymentMode).toHaveBeenCalledTimes(1);
+        expect(component.editExpense).toHaveBeenCalledTimes(1);
+        expect(component.close).toHaveBeenCalledTimes(1);
+      });
+
+      it('should show an error if payment mode is invalid', fakeAsync(() => {
+        spyOn(component, 'showFormValidationErrors');
+        spyOn(component, 'checkIfInvalidPaymentMode').and.returnValue(of(true));
+        fixture.detectChanges();
+
+        component.saveAndNewExpense();
+        tick(4000);
+
+        expect(component.checkIfInvalidPaymentMode).toHaveBeenCalledTimes(1);
+        expect(component.showFormValidationErrors).toHaveBeenCalledTimes(1);
+      }));
+    });
+
+    describe('saveExpense():', () => {
+      it('should add an expense in add mode if the payment mode is valid', () => {
+        spyOn(component, 'checkIfInvalidPaymentMode').and.returnValue(of(false));
+        setFormValid(component);
+        component.mode = 'add';
+        spyOn(component, 'addExpense').and.returnValue(of(true));
+
+        spyOn(component, 'close');
+        fixture.detectChanges();
+
+        component.saveExpense();
+
+        expect(component.checkIfInvalidPaymentMode).toHaveBeenCalledTimes(1);
+        expect(component.addExpense).toHaveBeenCalledTimes(1);
+        expect(component.close).toHaveBeenCalledTimes(1);
+      });
+
+      it('should edit an expense in edit mode if the payment mode is valid', () => {
+        spyOn(component, 'checkIfInvalidPaymentMode').and.returnValue(of(false));
+        setFormValid(component);
+        component.mode = 'edit';
+        spyOn(component, 'editExpense').and.returnValue(of(null));
+        spyOn(component, 'close');
+        fixture.detectChanges();
+
+        component.saveExpense();
+
+        expect(component.checkIfInvalidPaymentMode).toHaveBeenCalledTimes(1);
+        expect(component.editExpense).toHaveBeenCalledTimes(1);
+        expect(component.close).toHaveBeenCalledTimes(1);
+      });
+
+      it('should show an error if payment mode is invalid', fakeAsync(() => {
+        spyOn(component, 'showFormValidationErrors');
+        spyOn(component, 'checkIfInvalidPaymentMode').and.returnValue(of(true));
+        fixture.detectChanges();
+
+        component.saveExpense();
+        tick(4000);
+
+        expect(component.checkIfInvalidPaymentMode).toHaveBeenCalledTimes(1);
+        expect(component.showFormValidationErrors).toHaveBeenCalledTimes(1);
+      }));
+    });
+  });
+}

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.setup.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.setup.spec.ts
@@ -57,6 +57,7 @@ import { MileageService } from 'src/app/core/services/mileage.service';
 import { MileageRatesService } from 'src/app/core/services/mileage-rates.service';
 import { LocationService } from 'src/app/core/services/location.service';
 import { FyLocationComponent } from 'src/app/shared/components/fy-location/fy-location.component';
+import { TestCases2 } from '../add-edit-mileage/add-edit-mileage-2.spec';
 
 export function setFormValid(component) {
   Object.defineProperty(component.fg, 'valid', {
@@ -434,4 +435,5 @@ describe('AddEditMileagePage', () => {
   };
 
   TestCases1(getTestBed);
+  TestCases2(getTestBed);
 });

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -1803,6 +1803,19 @@ export class AddEditMileagePage implements OnInit {
     });
   }
 
+  showFormValidationErrors(): void {
+    this.fg.markAllAsTouched();
+    const formContainer = this.formContainer.nativeElement as HTMLElement;
+    if (formContainer) {
+      const invalidElement = formContainer.querySelector('.ng-invalid');
+      if (invalidElement) {
+        invalidElement.scrollIntoView({
+          behavior: 'smooth',
+        });
+      }
+    }
+  }
+
   saveExpense(): void {
     const that = this;
 
@@ -1818,16 +1831,7 @@ export class AddEditMileagePage implements OnInit {
             that.editExpense('SAVE_MILEAGE').subscribe(() => this.close());
           }
         } else {
-          that.fg.markAllAsTouched();
-          const formContainer = that.formContainer.nativeElement as HTMLElement;
-          if (formContainer) {
-            const invalidElement = formContainer.querySelector('.ng-invalid');
-            if (invalidElement) {
-              invalidElement.scrollIntoView({
-                behavior: 'smooth',
-              });
-            }
-          }
+          this.showFormValidationErrors();
           if (invalidPaymentMode) {
             that.invalidPaymentMode = true;
             setTimeout(() => {
@@ -1863,16 +1867,7 @@ export class AddEditMileagePage implements OnInit {
             });
           }
         } else {
-          that.fg.markAllAsTouched();
-          const formContainer = that.formContainer.nativeElement as HTMLElement;
-          if (formContainer) {
-            const invalidElement = formContainer.querySelector('.ng-invalid');
-            if (invalidElement) {
-              invalidElement.scrollIntoView({
-                behavior: 'smooth',
-              });
-            }
-          }
+          this.showFormValidationErrors();
           if (invalidPaymentMode) {
             that.invalidPaymentMode = true;
             setTimeout(() => {
@@ -1905,16 +1900,7 @@ export class AddEditMileagePage implements OnInit {
         });
       }
     } else {
-      that.fg.markAllAsTouched();
-      const formContainer = that.formContainer.nativeElement as HTMLElement;
-      if (formContainer) {
-        const invalidElement = formContainer.querySelector('.ng-invalid');
-        if (invalidElement) {
-          invalidElement.scrollIntoView({
-            behavior: 'smooth',
-          });
-        }
-      }
+      this.showFormValidationErrors();
     }
   }
 
@@ -1940,16 +1926,7 @@ export class AddEditMileagePage implements OnInit {
         });
       }
     } else {
-      that.fg.markAllAsTouched();
-      const formContainer = that.formContainer.nativeElement as HTMLElement;
-      if (formContainer) {
-        const invalidElement = formContainer.querySelector('.ng-invalid');
-        if (invalidElement) {
-          invalidElement.scrollIntoView({
-            behavior: 'smooth',
-          });
-        }
-      }
+      this.showFormValidationErrors();
     }
   }
 

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -355,7 +355,7 @@ export class AddEditMileagePage implements OnInit {
     }
   }
 
-  getFormValues(): FormValue {
+  getFormValues(): Partial<FormValue> {
     return this.fg.value as FormValue;
   }
 
@@ -939,17 +939,6 @@ export class AddEditMileagePage implements OnInit {
         ? null
         : {
             invalidDateSelection: true,
-          };
-    }
-  }
-
-  customDistanceValidator(control: AbstractControl): null | { invalidDistance: boolean } {
-    const passedInDistance = control.value && +control.value;
-    if (passedInDistance !== null) {
-      return passedInDistance > 0
-        ? null
-        : {
-            invalidDistance: true,
           };
     }
   }
@@ -2190,7 +2179,7 @@ export class AddEditMileagePage implements OnInit {
         )
       ),
       map((finalDistance) => {
-        if (this.getFormValues().route.roundTrip) {
+        if (this.getFormValues()?.route?.roundTrip) {
           return (finalDistance * 2).toFixed(2);
         } else {
           return finalDistance.toFixed(2);

--- a/src/app/fyle/my-profile/employee-details-card/employee-details-card.component.ts
+++ b/src/app/fyle/my-profile/employee-details-card/employee-details-card.component.ts
@@ -13,13 +13,14 @@ export class EmployeeDetailsCardComponent {
 
   @Output() verifyMobileNumber = new EventEmitter();
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   constructor() {}
 
-  onUpdateMobileNumber(eou: ExtendedOrgUser) {
+  onUpdateMobileNumber(eou: ExtendedOrgUser): void {
     this.updateMobileNumber.emit(eou);
   }
 
-  onVerifyMobileNumber(eou: ExtendedOrgUser) {
+  onVerifyMobileNumber(eou: ExtendedOrgUser): void {
     this.verifyMobileNumber.emit(eou);
   }
 }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d69035</samp>

Improved unit tests and form validation for the add-edit-mileage component. Added import statements and test cases to `add-edit-mileage-1.spec.ts`. Added a new method `showFormValidationErrors()` to `add-edit-mileage.page.ts` and replaced repeated code with calls to it.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2d69035</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The add-edit-mileage component with tests sublime_
> _And who devised a method, `showFormValidationErrors`, to display_
> _The faults of the user's input in a clear and consistent way_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2d69035</samp>

*  Refactor the logic of marking the form as touched and scrolling to the invalid element into a new method `showFormValidationErrors()` in the class `AddEditMileagePage` ([link](https://github.com/fylein/fyle-mobile-app/pull/2267/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eR1806-R1818))
* Replace the duplicated calls to `markAsTouched()` and `scrollToFirstInvalidElement()` with the call to `showFormValidationErrors()` in the methods `saveExpenseAndGotoNext()` and `saveExpenseAndGotoPrev()` in the class `AddEditMileagePage` ([link](https://github.com/fylein/fyle-mobile-app/pull/2267/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL1821-R1834), [link](https://github.com/fylein/fyle-mobile-app/pull/2267/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL1866-R1870), [link](https://github.com/fylein/fyle-mobile-app/pull/2267/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL1908-R1903), [link](https://github.com/fylein/fyle-mobile-app/pull/2267/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL1943-R1929))
* Add test cases for the `saveExpenseAndGotoNext()` and `saveExpenseAndGotoPrev()` methods in the test file `add-edit-mileage-1.spec.ts` to check the form validation and the navigation logic ([link](https://github.com/fylein/fyle-mobile-app/pull/2267/files?diff=unified&w=0#diff-5ea8feba7a8355dcc3a878d59e6ac3c56d89e15472f7ddfe5d9c63c38a90c961R448-R455), [link](https://github.com/fylein/fyle-mobile-app/pull/2267/files?diff=unified&w=0#diff-5ea8feba7a8355dcc3a878d59e6ac3c56d89e15472f7ddfe5d9c63c38a90c961R812-R881))
* Add import statements for the mock data for testing the mileage categories, expense policies, file attachments, platform policies, public policies, and mileage rates in the test file `add-edit-mileage-1.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2267/files?diff=unified&w=0#diff-5ea8feba7a8355dcc3a878d59e6ac3c56d89e15472f7ddfe5d9c63c38a90c961L13-R17), [link](https://github.com/fylein/fyle-mobile-app/pull/2267/files?diff=unified&w=0#diff-5ea8feba7a8355dcc3a878d59e6ac3c56d89e15472f7ddfe5d9c63c38a90c961R63-R67))

## Clickup
https://app.clickup.com/t/85ztjmtf0

## Code Coverage
`20.21% Statements 171/846`
`10.67% Branches 73/684`
`13.55% Functions 40/295`
`20.96% Lines 169/806`

## UI Preview
Please add screenshots for UI changes