### PR TITLE
test: Code Coverage: Add Edit Mileage #3 Part 2

### DIFF
--- a/src/app/core/mock-data/org-category.data.ts
+++ b/src/app/core/mock-data/org-category.data.ts
@@ -1038,3 +1038,42 @@ export const mileageCategories: OrgCategory[] = [
     updated_at: new Date('2023-01-09T16:54:09.929Z'),
   },
 ];
+
+export const mileageCategories2: OrgCategory[] = [
+  {
+    code: '93',
+    created_at: new Date('2021-05-18T11:40:38.576Z'),
+    displayName: 'mileage',
+    enabled: true,
+    fyle_category: 'Food',
+    id: 141295,
+    name: 'mileage',
+    org_id: 'orrjqbDbeP9p',
+    sub_category: 'Business',
+    updated_at: new Date('2022-07-01T05:51:31.800Z'),
+  },
+  {
+    code: '98',
+    created_at: new Date('2021-05-18T11:40:38.576Z'),
+    displayName: 'Pager',
+    enabled: true,
+    fyle_category: 'Mileage',
+    id: 141300,
+    name: 'Pager',
+    org_id: 'orrjqbDbeP9p',
+    sub_category: 'Pager',
+    updated_at: new Date('2022-05-05T17:47:06.951Z'),
+  },
+  {
+    code: '42',
+    created_at: new Date('2023-01-09T16:54:09.929Z'),
+    displayName: 'Marketing outreach',
+    enabled: true,
+    fyle_category: null,
+    id: 226659,
+    name: 'Marketing outreach',
+    org_id: 'orrjqbDbeP9p',
+    sub_category: 'Marketing outreach',
+    updated_at: new Date('2023-01-09T16:54:09.929Z'),
+  },
+];

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.setup.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.setup.spec.ts
@@ -57,6 +57,7 @@ import { MileageService } from 'src/app/core/services/mileage.service';
 import { MileageRatesService } from 'src/app/core/services/mileage-rates.service';
 import { LocationService } from 'src/app/core/services/location.service';
 import { FyLocationComponent } from 'src/app/shared/components/fy-location/fy-location.component';
+import { TestCases2 } from '../add-edit-mileage/add-edit-mileage-2.spec';
 
 export function setFormValid(component) {
   Object.defineProperty(component.fg, 'valid', {
@@ -434,4 +435,5 @@ describe('AddEditMileagePage', () => {
   };
 
   TestCases1(getTestBed);
+  TestCases2(getTestBed);
 });


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a44c92</samp>

This pull request enhances the testing of the `AddEditMileagePage` component by adding more imports, mock data, and test cases. It also introduces a new mock data file `org-category.data.ts` with mileage categories for testing.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a44c92</samp>

> _To test `AddEditMileagePage` better_
> _They added more imports and setters_
> _They used `mileageCategories2`_
> _And a function they knew_
> _To make the code coverage much fitter_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a44c92</samp>

*  Add new mock data array of mileage categories for testing purposes ([link](https://github.com/fylein/fyle-mobile-app/pull/2270/files?diff=unified&w=0#diff-8914bfb32bd70efe52e673bc9938855b2c84a494d9464f82c50fe2c8bfbdca45R1041-R1079))
*  Import additional modules and mock data for testing the `add-edit-mileage-2.spec.ts` file ([link](https://github.com/fylein/fyle-mobile-app/pull/2270/files?diff=unified&w=0#diff-035f26539504516a07a4540ded16b687e8c0447825f17da32e9cfc9c47c9e3f5L2-R3))
*  Add more imports and declarations for testing the `add-edit-mileage-2.spec.ts` file ([link](https://github.com/fylein/fyle-mobile-app/pull/2270/files?diff=unified&w=0#diff-035f26539504516a07a4540ded16b687e8c0447825f17da32e9cfc9c47c9e3f5L45-R52))
*  Add more test cases for the `AddEditMileagePage` component, covering different methods and scenarios ([link](https://github.com/fylein/fyle-mobile-app/pull/2270/files?diff=unified&w=0#diff-035f26539504516a07a4540ded16b687e8c0447825f17da32e9cfc9c47c9e3f5R191-R332))
*  Import the `TestCases2` function from the `add-edit-mileage-2.spec.ts` file to the `add-edit-mileage.page.setup.spec.ts` file ([link](https://github.com/fylein/fyle-mobile-app/pull/2270/files?diff=unified&w=0#diff-df40b6e711e89d5e80e6f3867394ee96bbff1eeae11eef42db09ce0b3f1821fbR60))
*  Invoke the `TestCases2` function at the end of the `add-edit-mileage.page.setup.spec.ts` file, to run the test cases after the `setup` function ([link](https://github.com/fylein/fyle-mobile-app/pull/2270/files?diff=unified&w=0#diff-df40b6e711e89d5e80e6f3867394ee96bbff1eeae11eef42db09ce0b3f1821fbR438))

## Clickup
https://app.clickup.com/t/85ztjmtf6

## Code Coverage
`28.7% Statements 242/843`
`20.96% Branches 144/687`
`25.51% Functions 75/294`
`29.14% Lines 234/803`

## UI Preview
Please add screenshots for UI changes