### PR TITLE
Added fix for the category dependant fields not coming

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -412,6 +412,8 @@ export class AddEditExpensePage implements OnInit {
 
   _isExpandedView = false;
 
+  extractedCategoryIsNotValid: boolean;
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private accountsService: AccountsService,
@@ -1961,9 +1963,8 @@ export class AddEditExpensePage implements OnInit {
           recentCategories: OrgCategoryListItem[];
           etxn: UnflattenedTransaction;
         }) => {
-          const isExpenseDraft = etxn.tx.state === 'DRAFT';
           const isExpenseCategoryUnspecified = etxn.tx?.fyle_category?.toLowerCase() === 'unspecified';
-          if (this.initialFetch && etxn.tx.org_category_id && !isExpenseDraft && !isExpenseCategoryUnspecified) {
+          if (this.initialFetch && etxn.tx.org_category_id && !isExpenseCategoryUnspecified) {
             return this.categoriesService.getCategoryById(etxn.tx.org_category_id).pipe(
               map((selectedCategory) => ({
                 orgUserSettings,
@@ -2009,7 +2010,7 @@ export class AddEditExpensePage implements OnInit {
             }
           } else if (
             etxn.tx.state === 'DRAFT' &&
-            !isCategoryExtracted &&
+            (!isCategoryExtracted || this.extractedCategoryIsNotValid) &&
             (!etxn.tx.org_category_id || etxn.tx.fyle_category?.toLowerCase() === 'unspecified')
           ) {
             return this.getAutofillCategory({
@@ -2532,6 +2533,7 @@ export class AddEditExpensePage implements OnInit {
             const categoryName = etxn.tx.extracted_data.category || 'unspecified';
             return this.categoriesService.getCategoryByName(categoryName).pipe(
               map((selectedCategory) => {
+                this.extractedCategoryIsNotValid = true;
                 etxn.tx.org_category_id = selectedCategory && selectedCategory.id;
                 return etxn;
               })
@@ -4244,6 +4246,8 @@ export class AddEditExpensePage implements OnInit {
           this.fg.patchValue({
             category: category && category.value,
           });
+        } else {
+          this.extractedCategoryIsNotValid = false;
         }
       });
   }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd85c87</samp>

Improved category validation and fetching for expenses based on receipt images. Fixed a bug in `add-edit-expense.page.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cd85c87</samp>

> _`extractedCategory`_
> _validates receipt image_
> _a bug is fixed now_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cd85c87</samp>

*  Add a new property `extractedCategoryIsNotValid` to track the validity of the category extracted from the receipt image ([link](https://github.com/fylein/fyle-mobile-app/pull/2272/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bR415-R416))
*  Simplify the condition for fetching the category by id by removing the check for the expense state ([link](https://github.com/fylein/fyle-mobile-app/pull/2272/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL1964-R1967))
*  Modify the condition for setting the default category by adding the check for the `extractedCategoryIsNotValid` property ([link](https://github.com/fylein/fyle-mobile-app/pull/2272/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL2012-R2013))
*  Set the `extractedCategoryIsNotValid` property to true if the extracted category is not found in the list of categories ([link](https://github.com/fylein/fyle-mobile-app/pull/2272/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bR2536))
*  Set the `extractedCategoryIsNotValid` property to false if the extracted category is found in the list of categories ([link](https://github.com/fylein/fyle-mobile-app/pull/2272/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bR4249-R4250))

## Clickup
Please add link here

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes