### PR TITLE
fix: Cost Centers Dependent Fields Not Visible

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -460,10 +460,6 @@ export class AddEditExpensePage implements OnInit {
     private platformHandlerService: PlatformHandlerService
   ) {}
 
-  get selectedCostCenter(): Observable<CostCenter | null> {
-    return this.selectedCostCenter$.asObservable();
-  }
-
   get isExpandedView(): boolean {
     return this._isExpandedView;
   }

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -460,6 +460,10 @@ export class AddEditExpensePage implements OnInit {
     private platformHandlerService: PlatformHandlerService
   ) {}
 
+  get selectedCostCenter(): Observable<CostCenter | null> {
+    return this.selectedCostCenter$.asObservable();
+  }
+
   get isExpandedView(): boolean {
     return this._isExpandedView;
   }
@@ -2641,9 +2645,11 @@ export class AddEditExpensePage implements OnInit {
   }
 
   setupSelectedCostCenterObservable(): void {
-    this.fg.controls.costCenter.valueChanges
-      .pipe(takeUntil(this.onPageExit$))
-      .subscribe((costCenter: CostCenter) => this.selectedCostCenter$.next(costCenter));
+    this.fg.controls.costCenter.valueChanges.pipe(takeUntil(this.onPageExit$)).subscribe((costCenter: CostCenter) => {
+      if (!this.initialFetch) {
+        this.selectedCostCenter$.next(costCenter);
+      }
+    });
   }
 
   getCCCpaymentMode(): void {

--- a/src/app/shared/components/dependent-fields/dependent-field/dependent-field-modal/dependent-field-modal.component.ts
+++ b/src/app/shared/components/dependent-fields/dependent-field/dependent-field-modal/dependent-field-modal.component.ts
@@ -40,7 +40,7 @@ export class DependentFieldModalComponent implements AfterViewInit {
 
   getDependentFieldOptions(searchQuery: string): Observable<DependentFieldOption[]> {
     this.isLoading = true;
-
+    this.cdr.detectChanges();
     return this.dependentFieldsService
       .getOptionsForDependentField({
         fieldId: this.fieldId,
@@ -57,7 +57,10 @@ export class DependentFieldModalComponent implements AfterViewInit {
           }))
         ),
         map((dependentFieldOptions) => this.getFinalDependentFieldValues(dependentFieldOptions, this.currentSelection)),
-        finalize(() => (this.isLoading = false))
+        finalize(() => {
+          this.isLoading = false;
+          this.cdr.detectChanges();
+        })
       );
   }
 


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b2cd235</samp>

This pull request enhances the cost center selection and dependent field options features in the expense form. It improves the cost center getter method in `add-edit-expense.page.ts` and adds loading spinner logic to `dependent-field-modal.component.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b2cd235</samp>

> _To edit an expense with a flair_
> _We need the cost center to be there_
> _So we use a getter_
> _To make it better_
> _And sync the `selectedCostCenter$` pair_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b2cd235</samp>

*  Add a getter method for the selected cost center value in the expense form ([link](https://github.com/fylein/fyle-mobile-app/pull/2300/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bR463-R466))
*  Prevent overriding the existing cost center value when loading the expense data ([link](https://github.com/fylein/fyle-mobile-app/pull/2300/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL2644-R2652))
*  Trigger change detection manually when fetching options for a dependent field ([link](https://github.com/fylein/fyle-mobile-app/pull/2300/files?diff=unified&w=0#diff-a6d66bb1a4c856fa4872abfa250d33d47e6c65cb819c7aaf4907777ad5da3ca2L43-R43), [link](https://github.com/fylein/fyle-mobile-app/pull/2300/files?diff=unified&w=0#diff-a6d66bb1a4c856fa4872abfa250d33d47e6c65cb819c7aaf4907777ad5da3ca2L60-R63))

## Clickup
https://app.clickup.com/t/85ztcza5a

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes