### PR TITLE
test: 73% coverage of add-edit-per-diem page

### DIFF
--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem-4.page.spec.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem-4.page.spec.ts
@@ -1,0 +1,263 @@
+import { ComponentFixture, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { AddEditPerDiemPage } from './add-edit-per-diem.page';
+import { AccountsService } from 'src/app/core/services/accounts.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { AuthService } from 'src/app/core/services/auth.service';
+import { CategoriesService } from 'src/app/core/services/categories.service';
+import { CurrencyService } from 'src/app/core/services/currency.service';
+import { CustomFieldsService } from 'src/app/core/services/custom-fields.service';
+import { CustomInputsService } from 'src/app/core/services/custom-inputs.service';
+import { DateService } from 'src/app/core/services/date.service';
+import { ExpenseFieldsService } from 'src/app/core/services/expense-fields.service';
+import { LoaderService } from 'src/app/core/services/loader.service';
+import { ModalPropertiesService } from 'src/app/core/services/modal-properties.service';
+import { NetworkService } from 'src/app/core/services/network.service';
+import { OrgSettingsService } from 'src/app/core/services/org-settings.service';
+import { OrgUserSettingsService } from 'src/app/core/services/org-user-settings.service';
+import { PaymentModesService } from 'src/app/core/services/payment-modes.service';
+import { PolicyService } from 'src/app/core/services/policy.service';
+import { ProjectsService } from 'src/app/core/services/projects.service';
+import { RecentlyUsedItemsService } from 'src/app/core/services/recently-used-items.service';
+import { ReportService } from 'src/app/core/services/report.service';
+import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
+import { StatusService } from 'src/app/core/services/status.service';
+import { StorageService } from 'src/app/core/services/storage.service';
+import { TokenService } from 'src/app/core/services/token.service';
+import { TrackingService } from 'src/app/core/services/tracking.service';
+import { TransactionService } from 'src/app/core/services/transaction.service';
+import { TransactionsOutboxService } from 'src/app/core/services/transactions-outbox.service';
+
+import { FormArray, FormBuilder, Validators } from '@angular/forms';
+import { ModalController, NavController, Platform, PopoverController } from '@ionic/angular';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { PerDiemService } from 'src/app/core/services/per-diem.service';
+import { of } from 'rxjs';
+import { estatusData1 } from 'src/app/core/test-data/status.service.spec.data';
+import { unflattenedTxnData, unflattenedTxnData2 } from 'src/app/core/mock-data/unflattened-txn.data';
+import { criticalPolicyViolation1 } from 'src/app/core/mock-data/crtical-policy-violations.data';
+import { policyViolation1 } from 'src/app/core/mock-data/policy-violation.data';
+import { unflattenedExpData } from 'src/app/core/mock-data/unflattened-expense.data';
+
+export function TestCases4(getTestBed) {
+  return fdescribe('add-edit-per-diem test cases set 4', () => {
+    let component: AddEditPerDiemPage;
+    let fixture: ComponentFixture<AddEditPerDiemPage>;
+    let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+    let accountsService: jasmine.SpyObj<AccountsService>;
+    let authService: jasmine.SpyObj<AuthService>;
+    let formBuilder: FormBuilder;
+    let categoriesService: jasmine.SpyObj<CategoriesService>;
+    let dateService: jasmine.SpyObj<DateService>;
+    let projectsService: jasmine.SpyObj<ProjectsService>;
+    let reportService: jasmine.SpyObj<ReportService>;
+    let customInputsService: jasmine.SpyObj<CustomInputsService>;
+    let customFieldsService: jasmine.SpyObj<CustomFieldsService>;
+    let transactionService: jasmine.SpyObj<TransactionService>;
+    let policyService: jasmine.SpyObj<PolicyService>;
+    let transactionOutboxService: jasmine.SpyObj<TransactionsOutboxService>;
+    let router: jasmine.SpyObj<Router>;
+    let loaderService: jasmine.SpyObj<LoaderService>;
+    let modalController: jasmine.SpyObj<ModalController>;
+    let statusService: jasmine.SpyObj<StatusService>;
+    let popoverController: jasmine.SpyObj<PopoverController>;
+    let currencyService: jasmine.SpyObj<CurrencyService>;
+    let networkService: jasmine.SpyObj<NetworkService>;
+    let navController: jasmine.SpyObj<NavController>;
+    let trackingService: jasmine.SpyObj<TrackingService>;
+    let recentlyUsedItemsService: jasmine.SpyObj<RecentlyUsedItemsService>;
+    let tokenService: jasmine.SpyObj<TokenService>;
+    let expenseFieldsService: jasmine.SpyObj<ExpenseFieldsService>;
+    let modalProperties: jasmine.SpyObj<ModalPropertiesService>;
+    let orgSettingsService: jasmine.SpyObj<OrgSettingsService>;
+    let matSnackBar: jasmine.SpyObj<MatSnackBar>;
+    let snackbarProperties: jasmine.SpyObj<SnackbarPropertiesService>;
+    let platform: Platform;
+    let paymentModesService: jasmine.SpyObj<PaymentModesService>;
+    let orgUserSettingsService: jasmine.SpyObj<OrgUserSettingsService>;
+    let storageService: jasmine.SpyObj<StorageService>;
+    let perDiemService: jasmine.SpyObj<PerDiemService>;
+
+    beforeEach(waitForAsync(() => {
+      const TestBed = getTestBed();
+      fixture = TestBed.createComponent(AddEditPerDiemPage);
+      component = fixture.componentInstance;
+
+      activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
+      accountsService = TestBed.inject(AccountsService) as jasmine.SpyObj<AccountsService>;
+      authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+      formBuilder = TestBed.inject(FormBuilder);
+      categoriesService = TestBed.inject(CategoriesService) as jasmine.SpyObj<CategoriesService>;
+      dateService = TestBed.inject(DateService) as jasmine.SpyObj<DateService>;
+      projectsService = TestBed.inject(ProjectsService) as jasmine.SpyObj<ProjectsService>;
+      reportService = TestBed.inject(ReportService) as jasmine.SpyObj<ReportService>;
+      customInputsService = TestBed.inject(CustomInputsService) as jasmine.SpyObj<CustomInputsService>;
+      customFieldsService = TestBed.inject(CustomFieldsService) as jasmine.SpyObj<CustomFieldsService>;
+      transactionService = TestBed.inject(TransactionService) as jasmine.SpyObj<TransactionService>;
+      policyService = TestBed.inject(PolicyService) as jasmine.SpyObj<PolicyService>;
+      transactionOutboxService = TestBed.inject(TransactionsOutboxService) as jasmine.SpyObj<TransactionsOutboxService>;
+      router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+      loaderService = TestBed.inject(LoaderService) as jasmine.SpyObj<LoaderService>;
+      modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
+      statusService = TestBed.inject(StatusService) as jasmine.SpyObj<StatusService>;
+      popoverController = TestBed.inject(PopoverController) as jasmine.SpyObj<PopoverController>;
+      currencyService = TestBed.inject(CurrencyService) as jasmine.SpyObj<CurrencyService>;
+      networkService = TestBed.inject(NetworkService) as jasmine.SpyObj<NetworkService>;
+      navController = TestBed.inject(NavController) as jasmine.SpyObj<NavController>;
+      trackingService = TestBed.inject(TrackingService) as jasmine.SpyObj<TrackingService>;
+      recentlyUsedItemsService = TestBed.inject(RecentlyUsedItemsService) as jasmine.SpyObj<RecentlyUsedItemsService>;
+      tokenService = TestBed.inject(TokenService) as jasmine.SpyObj<TokenService>;
+      expenseFieldsService = TestBed.inject(ExpenseFieldsService) as jasmine.SpyObj<ExpenseFieldsService>;
+      modalProperties = TestBed.inject(ModalPropertiesService) as jasmine.SpyObj<ModalPropertiesService>;
+      orgSettingsService = TestBed.inject(OrgSettingsService) as jasmine.SpyObj<OrgSettingsService>;
+      matSnackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
+      snackbarProperties = TestBed.inject(SnackbarPropertiesService) as jasmine.SpyObj<SnackbarPropertiesService>;
+      platform = TestBed.inject(Platform);
+      paymentModesService = TestBed.inject(PaymentModesService) as jasmine.SpyObj<PaymentModesService>;
+      orgUserSettingsService = TestBed.inject(OrgUserSettingsService) as jasmine.SpyObj<OrgUserSettingsService>;
+      storageService = TestBed.inject(StorageService) as jasmine.SpyObj<StorageService>;
+      perDiemService = TestBed.inject(PerDiemService) as jasmine.SpyObj<PerDiemService>;
+      component.fg = formBuilder.group({
+        currencyObj: [
+          {
+            value: null,
+            disabled: true,
+          },
+        ],
+        paymentMode: [, Validators.required],
+        project: [],
+        sub_category: [],
+        per_diem_rate: [, Validators.required],
+        purpose: [],
+        num_days: [, Validators.compose([Validators.required, Validators.min(0)])],
+        report: [],
+        from_dt: [],
+        to_dt: [, component.customDateValidator.bind(component)],
+        custom_inputs: new FormArray([]),
+        duplicate_detection_reason: [],
+        billable: [],
+        costCenter: [],
+        project_dependent_fields: formBuilder.array([]),
+        cost_center_dependent_fields: formBuilder.array([]),
+      });
+    }));
+
+    it('trackPolicyCorrections(): should track policy corrections', () => {
+      component.isCriticalPolicyViolated$ = of(true);
+      component.comments$ = of(estatusData1);
+      component.fg.markAsDirty();
+
+      fixture.detectChanges();
+
+      component.trackPolicyCorrections();
+      expect(trackingService.policyCorrection).toHaveBeenCalledWith({ Violation: 'Critical', Mode: 'Edit Expense' });
+      expect(trackingService.policyCorrection).toHaveBeenCalledWith({ Violation: 'Regular', Mode: 'Edit Expense' });
+    });
+
+    describe('editExpenseCriticalPolicyViolationErrorHandler():', () => {
+      it('should return txn with permission to continue with critical violations from user', (done) => {
+        loaderService.showLoader.and.resolveTo();
+        component.etxn$ = of(unflattenedTxnData2);
+        spyOn(component, 'continueWithCriticalPolicyViolation').and.resolveTo(true);
+
+        component
+          .editExpenseCriticalPolicyViolationHandler({
+            policyViolations: criticalPolicyViolation1,
+            etxn: unflattenedTxnData,
+          })
+          .subscribe((res) => {
+            expect(loaderService.showLoader).toHaveBeenCalledTimes(1);
+            expect(component.continueWithCriticalPolicyViolation).toHaveBeenCalledOnceWith(criticalPolicyViolation1);
+            expect(res).toEqual({ etxn: unflattenedTxnData });
+            done();
+          });
+      });
+
+      it('should throw error if policy violation check errors fails', (done) => {
+        loaderService.showLoader.and.resolveTo();
+        component.etxn$ = of(unflattenedTxnData2);
+        spyOn(component, 'continueWithCriticalPolicyViolation').and.resolveTo(false);
+
+        component
+          .editExpenseCriticalPolicyViolationHandler({
+            policyViolations: criticalPolicyViolation1,
+            etxn: unflattenedTxnData,
+          })
+          .subscribe({
+            next: () => {},
+            error: (error) => {
+              expect(error).toBeTruthy();
+              expect(error).toEqual('unhandledError');
+              done();
+            },
+          });
+      });
+    });
+
+    describe('editExpensePolicyViolationErrorHandler():', () => {
+      it('should return txn if user wants to continue with violations', (done) => {
+        loaderService.showLoader.and.resolveTo();
+        component.etxn$ = of(unflattenedTxnData2);
+        spyOn(component, 'continueWithPolicyViolations').and.resolveTo({ comment: 'comment' });
+
+        component
+          .editExpensePolicyViolationHandler({
+            policyViolations: criticalPolicyViolation1,
+            policyAction: policyViolation1.data.final_desired_state,
+            etxn: unflattenedTxnData,
+          })
+          .subscribe((res) => {
+            expect(loaderService.showLoader).toHaveBeenCalledTimes(1);
+            expect(component.continueWithPolicyViolations).toHaveBeenCalledOnceWith(
+              criticalPolicyViolation1,
+              policyViolation1.data.final_desired_state
+            );
+            expect(res).toEqual({ etxn: unflattenedTxnData, comment: 'comment' });
+            done();
+          });
+      });
+
+      it('should add default policy violation comment if user wants to continue with violations without providing a comment', (done) => {
+        loaderService.showLoader.and.resolveTo();
+        component.etxn$ = of(unflattenedTxnData2);
+        spyOn(component, 'continueWithPolicyViolations').and.resolveTo({ comment: '' });
+        spyOn(component, 'generateEtxnFromFg').and.returnValue(of(unflattenedExpData));
+
+        component
+          .editExpensePolicyViolationHandler({
+            policyViolations: criticalPolicyViolation1,
+            policyAction: policyViolation1.data.final_desired_state,
+            etxn: unflattenedTxnData,
+          })
+          .subscribe((res) => {
+            expect(loaderService.showLoader).toHaveBeenCalledTimes(1);
+            expect(component.continueWithPolicyViolations).toHaveBeenCalledOnceWith(
+              criticalPolicyViolation1,
+              policyViolation1.data.final_desired_state
+            );
+            expect(res).toEqual({ etxn: unflattenedTxnData, comment: 'No policy violation explaination provided' });
+            done();
+          });
+      });
+
+      it('should throw an error if policy check fails', (done) => {
+        loaderService.showLoader.and.resolveTo();
+        component.etxn$ = of(unflattenedTxnData2);
+        spyOn(component, 'continueWithPolicyViolations').and.resolveTo(null);
+
+        component
+          .editExpensePolicyViolationHandler({
+            policyViolations: criticalPolicyViolation1,
+            policyAction: policyViolation1.data.final_desired_state,
+          })
+          .subscribe({
+            next: () => {},
+            error: (error) => {
+              expect(error).toBeTruthy();
+              expect(error).toEqual('unhandledError');
+              done();
+            },
+          });
+      });
+    });
+  });
+}

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem-4.page.spec.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem-4.page.spec.ts
@@ -39,7 +39,7 @@ import { policyViolation1 } from 'src/app/core/mock-data/policy-violation.data';
 import { unflattenedExpData } from 'src/app/core/mock-data/unflattened-expense.data';
 
 export function TestCases4(getTestBed) {
-  return fdescribe('add-edit-per-diem test cases set 4', () => {
+  return describe('add-edit-per-diem test cases set 4', () => {
     let component: AddEditPerDiemPage;
     let fixture: ComponentFixture<AddEditPerDiemPage>;
     let activatedRoute: jasmine.SpyObj<ActivatedRoute>;

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.setup.spec.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.setup.spec.ts
@@ -39,7 +39,7 @@ import { TestCases2 } from './add-edit-per-diem-2.page.spec';
 import { TestCases3 } from './add-edit-per-diem-3.page.spec';
 import { TestCases4 } from './add-edit-per-diem-4.page.spec';
 
-fdescribe('AddEditPerDiemPage', () => {
+describe('AddEditPerDiemPage', () => {
   const getTestBed = () => {
     const accountsServiceSpy = jasmine.createSpyObj('AccountsService', [
       'getEMyAccounts',

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.setup.spec.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.setup.spec.ts
@@ -37,8 +37,9 @@ import { TokenService } from 'src/app/core/services/token.service';
 import { DateService } from 'src/app/core/services/date.service';
 import { TestCases2 } from './add-edit-per-diem-2.page.spec';
 import { TestCases3 } from './add-edit-per-diem-3.page.spec';
+import { TestCases4 } from './add-edit-per-diem-4.page.spec';
 
-describe('AddEditPerDiemPage', () => {
+fdescribe('AddEditPerDiemPage', () => {
   const getTestBed = () => {
     const accountsServiceSpy = jasmine.createSpyObj('AccountsService', [
       'getEMyAccounts',
@@ -92,6 +93,7 @@ describe('AddEditPerDiemPage', () => {
       'addPageViewWithParams',
       'viewExpense',
       'createExpense',
+      'policyCorrection',
     ]);
     const recentlyUsedItemsServiceSpy = jasmine.createSpyObj('RecentlyUsedItemsService', [
       'getRecentlyUsed',
@@ -278,4 +280,5 @@ describe('AddEditPerDiemPage', () => {
   TestCases1(getTestBed);
   TestCases2(getTestBed);
   TestCases3(getTestBed);
+  TestCases4(getTestBed);
 });


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a94265</samp>

This pull request adds tests and fixes a bug for the `add-edit-per-diem` page, which allows users to create and edit expenses of type Per Diem. The bug fix ensures that the tracking service is only triggered when the expense data is changed.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6a94265</samp>

> _`add-edit-per-diem`_
> _Fixing bugs, adding tests_
> _Autumn of improvement_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a94265</samp>

*  Fix bug in equality check for expense data in add-edit-per-diem page ([link](https://github.com/fylein/fyle-mobile-app/pull/2305/files?diff=unified&w=0#diff-b6e1f6e315ef2edc53799d40c1304deff11e97673e1003986d199937196dda0dL2012-R2012))
*  Add mock data object for editing an expense of type Per Diem in `track-expense-properties.data.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2305/files?diff=unified&w=0#diff-a653b6db5346a045928b09e35163a104cfc48adf0e15d168e5d223c4557899e7R39-R43))
*  Import TestCases4 module from `add-edit-per-diem.page.setup.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2305/files?diff=unified&w=0#diff-113c190c8d5e8c3f8c98cf1e699be2562159cd2ba8d04e2e19a31ef5b74d35c2R40))
*  Add and run test cases for editing an expense of type Per Diem in `add-edit-per-diem.page.setup.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2305/files?diff=unified&w=0#diff-113c190c8d5e8c3f8c98cf1e699be2562159cd2ba8d04e2e19a31ef5b74d35c2R96-R99),[link](https://github.com/fylein/fyle-mobile-app/pull/2305/files?diff=unified&w=0#diff-113c190c8d5e8c3f8c98cf1e699be2562159cd2ba8d04e2e19a31ef5b74d35c2R286))

## Clickup
https://app.clickup.com/t/85ztk93ev

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes