### PR TITLE
test: 80% coverage of add-edit-per-diem test page - Part 2

### DIFF
--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem-4.page.spec.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem-4.page.spec.ts
@@ -601,6 +601,96 @@ export function TestCases4(getTestBed) {
             done();
           });
       });
+
+      it('should return etxn object and save the edited expense if policyRules is empty array', (done) => {
+        policyService.getCriticalPolicyRules.and.returnValue([]);
+        policyService.getPolicyRules.and.returnValue([]);
+        component
+          .editExpense('SAVE_PER_DIEM')
+          .pipe(
+            finalize(() => {
+              expect(component.savePerDiemLoader).toBeFalse();
+              expect(component.saveAndNextPerDiemLoader).toBeFalse();
+              expect(component.saveAndPrevPerDiemLoader).toBeFalse();
+            })
+          )
+          .subscribe((res) => {
+            expect(component.savePerDiemLoader).toBeTrue();
+            expect(component.saveAndNextPerDiemLoader).toBeFalse();
+            expect(component.saveAndPrevPerDiemLoader).toBeFalse();
+            expect(component.generateEtxnFromFg).toHaveBeenCalledOnceWith(component.etxn$, customFields$);
+            expect(component.checkPolicyViolation).toHaveBeenCalledOnceWith({
+              tx: unflattenedTxnData.tx,
+              ou: unflattenedTxnData.ou,
+              dataUrls: [],
+            });
+            expect(policyService.getCriticalPolicyRules).toHaveBeenCalledTimes(1);
+            expect(policyService.getPolicyRules).toHaveBeenCalledTimes(1);
+            expect(component.editExpenseCriticalPolicyViolationHandler).not.toHaveBeenCalled();
+            expect(component.editExpensePolicyViolationHandler).not.toHaveBeenCalled();
+            expect(trackingService.editExpense).not.toHaveBeenCalled();
+            expect(trackingService.viewExpense).toHaveBeenCalledOnceWith({ Type: 'Per Diem' });
+            expect(transactionService.upsert).toHaveBeenCalledOnceWith(unflattenedTxnData.tx);
+            expect(transactionService.getETxnUnflattened).toHaveBeenCalledOnceWith(unflattenedTxnData.tx.id);
+            expect(reportService.addTransactions).toHaveBeenCalledOnceWith('rp5eUkeNm9wB', ['tx3qHxFNgRcZ']);
+            expect(reportService.removeTransaction).not.toHaveBeenCalled();
+            expect(trackingService.addToExistingReportAddEditExpense).toHaveBeenCalledTimes(1);
+            expect(trackingService.removeFromExistingReportEditExpense).not.toHaveBeenCalled();
+            expect(transactionService.review).toHaveBeenCalledOnceWith(unflattenedTxnData.tx.id);
+            expect(res).toEqual(unflattenedTxnData.tx);
+            done();
+          });
+      });
+
+      it('should throw error and save the expense if any call fails', (done) => {
+        const error = new Error('unhandledError');
+        policyService.getCriticalPolicyRules.and.throwError(error);
+        component
+          .editExpense('SAVE_PER_DIEM')
+          .pipe(
+            finalize(() => {
+              expect(component.savePerDiemLoader).toBeFalse();
+              expect(component.saveAndNextPerDiemLoader).toBeFalse();
+              expect(component.saveAndPrevPerDiemLoader).toBeFalse();
+            })
+          )
+          .subscribe({
+            next: (res) => {
+              expect(component.savePerDiemLoader).toBeTrue();
+              expect(component.saveAndNextPerDiemLoader).toBeFalse();
+              expect(component.saveAndPrevPerDiemLoader).toBeFalse();
+              expect(component.generateEtxnFromFg).toHaveBeenCalledOnceWith(component.etxn$, customFields$);
+              expect(component.checkPolicyViolation).toHaveBeenCalledOnceWith({
+                tx: unflattenedTxnData.tx,
+                ou: unflattenedTxnData.ou,
+                dataUrls: [],
+              });
+              expect(policyService.getCriticalPolicyRules).toHaveBeenCalledTimes(1);
+              expect(policyService.getPolicyRules).not.toHaveBeenCalled();
+              expect(component.editExpenseCriticalPolicyViolationHandler).toHaveBeenCalledOnceWith({
+                type: 'criticalPolicyViolations',
+                policyViolations: ['The expense will be flagged'],
+                etxn: { tx: unflattenedTxnData.tx, ou: unflattenedTxnData.ou, dataUrls: [] },
+              });
+              expect(component.editExpensePolicyViolationHandler).not.toHaveBeenCalled();
+              expect(trackingService.editExpense).not.toHaveBeenCalled();
+              expect(trackingService.viewExpense).toHaveBeenCalledOnceWith({ Type: 'Per Diem' });
+              expect(transactionService.upsert).toHaveBeenCalledOnceWith(unflattenedTxnData.tx);
+              expect(transactionService.getETxnUnflattened).toHaveBeenCalledOnceWith(unflattenedTxnData.tx.id);
+              expect(reportService.addTransactions).toHaveBeenCalledOnceWith('rp5eUkeNm9wB', ['tx3qHxFNgRcZ']);
+              expect(reportService.removeTransaction).not.toHaveBeenCalled();
+              expect(trackingService.addToExistingReportAddEditExpense).toHaveBeenCalledTimes(1);
+              expect(trackingService.removeFromExistingReportEditExpense).not.toHaveBeenCalled();
+              expect(transactionService.review).toHaveBeenCalledOnceWith(unflattenedTxnData.tx.id);
+              expect(res).toEqual(unflattenedTxnData.tx);
+            },
+            error: (err) => {
+              expect(err).toBeTruthy();
+              expect(err).toEqual(error);
+              done();
+            },
+          });
+      });
     });
   });
 }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d32853c</samp>

Added new test cases for `editExpense` method in `AddEditPerDiem4Page` component. The test cases verify the method's functionality and error handling when editing per diem expenses.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d32853c</samp>

> _`editExpense` changed_
> _Observables and errors_
> _Autumn tests falling_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d32853c</samp>

*  Add two test cases for `editExpense` method of `AddEditPerDiem4Page` component ([link](https://github.com/fylein/fyle-mobile-app/pull/2307/files?diff=unified&w=0#diff-9fc3d987464b78b0c9c205e0855313051027757354ed26bcb90efd102618948eR604-R693))

## Clickup
https://app.clickup.com/t/85ztk93ev

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes