### PR TITLE
test: Code Coverage: Add Edit Mileage #5 Part 2

### DIFF
--- a/src/app/core/mock-data/default-txn-field-values.data.ts
+++ b/src/app/core/mock-data/default-txn-field-values.data.ts
@@ -28,3 +28,9 @@ export const defaultTxnFieldValuesData2: Partial<DefaultTxnFieldValues> = {
   num_days: 32,
   billable: true,
 };
+
+export const defaultTxnFieldValuesData4: Partial<DefaultTxnFieldValues> = {
+  purpose: 'test_term',
+  cost_center_id: 15818,
+  billable: true,
+};

--- a/src/app/core/mock-data/org-category-list-item.data.ts
+++ b/src/app/core/mock-data/org-category-list-item.data.ts
@@ -67,3 +67,66 @@ export const recentUsedCategoriesRes: OrgCategoryListItem[] = [
     },
   },
 ];
+
+export const orgCategoryListItemData1 = [
+  {
+    label: 'Business',
+    value: {
+      code: '93',
+      created_at: new Date('2021-05-18T11:40:38.576Z'),
+      displayName: 'Business',
+      enabled: true,
+      fyle_category: null,
+      id: 141295,
+      name: 'Business',
+      org_id: 'orrjqbDbeP9p',
+      sub_category: 'Business',
+      updated_at: new Date('2022-07-01T05:51:31.800Z'),
+    },
+  },
+  {
+    label: 'Marketing outreach',
+    value: {
+      code: '42',
+      created_at: new Date('2023-01-09T16:54:09.929Z'),
+      displayName: 'Marketing outreach',
+      enabled: true,
+      fyle_category: null,
+      id: 226659,
+      name: 'Marketing outreach',
+      org_id: 'orrjqbDbeP9p',
+      sub_category: 'Marketing outreach',
+      updated_at: new Date('2023-01-09T16:54:09.929Z'),
+    },
+  },
+  {
+    label: 'Pager',
+    value: {
+      code: '98',
+      created_at: new Date('2021-05-18T11:40:38.576Z'),
+      displayName: 'Pager',
+      enabled: true,
+      fyle_category: null,
+      id: 141300,
+      name: 'Pager',
+      org_id: 'orrjqbDbeP9p',
+      sub_category: 'Pager',
+      updated_at: new Date('2022-05-05T17:47:06.951Z'),
+    },
+  },
+  {
+    label: 'samp category',
+    value: {
+      code: '43',
+      created_at: new Date('2023-01-09T16:54:09.929Z'),
+      displayName: 'samp category',
+      enabled: true,
+      fyle_category: null,
+      id: 226646,
+      name: 'samp category',
+      org_id: 'orrjqbDbeP9p',
+      sub_category: 'samp category',
+      updated_at: new Date('2023-01-09T16:54:09.929Z'),
+    },
+  },
+];

--- a/src/app/core/mock-data/track-expense-properties.data.ts
+++ b/src/app/core/mock-data/track-expense-properties.data.ts
@@ -1,4 +1,8 @@
-import { expectedUnflattendedTxnData4, trackAddExpenseWoCurrency } from './unflattened-txn.data';
+import {
+  expectedUnflattendedTxnData4,
+  trackAddExpenseWoCurrency,
+  unflattenedTxnWithTrackData,
+} from './unflattened-txn.data';
 
 export const createExpenseProperties = {
   Type: 'Receipt',
@@ -24,4 +28,16 @@ export const createExpenseProperties2 = {
   Used_Autofilled_CostCenter: true,
   Used_Autofilled_Currency: true,
   Instafyle: false,
+};
+
+export const editExpenseProperties1 = {
+  Type: 'Mileage',
+  Amount: unflattenedTxnWithTrackData.tx.amount,
+  Currency: unflattenedTxnWithTrackData.tx.currency,
+  Category: unflattenedTxnWithTrackData.tx.org_category,
+  Time_Spent: '300 secs',
+  Used_Autofilled_Project: true,
+  Used_Autofilled_CostCenter: true,
+  Used_Autofilled_VehicleType: true,
+  Used_Autofilled_StartLocation: true,
 };

--- a/src/app/core/mock-data/unflattened-txn.data.ts
+++ b/src/app/core/mock-data/unflattened-txn.data.ts
@@ -2842,3 +2842,18 @@ export const unflattendedTxnWithPolicyAmount: UnflattenedTransaction = {
     policy_amount: 100,
   },
 };
+
+export const unflattenedTxnWithTrackData: UnflattenedTransaction = {
+  ...unflattenedTxnData,
+  tx: {
+    ...unflattenedTxnData.tx,
+    project_id: 257528,
+    cost_center_id: 2411,
+    mileage_vehicle_type: 'car',
+    locations: [
+      {
+        display: 'Kolkata',
+      },
+    ],
+  },
+};

--- a/src/app/core/models/platform/platform-policy-expense.model.ts
+++ b/src/app/core/models/platform/platform-policy-expense.model.ts
@@ -19,7 +19,7 @@ export interface PlatformPolicyExpense {
   is_reimbursable?: boolean;
   distance?: number;
   distance_unit?: string;
-  locations?: Destination[];
+  locations?: Destination[] | string[];
   custom_fields?: TxnCustomProperties[];
   started_at?: Date;
   ended_at?: Date;

--- a/src/app/core/models/public-policy-expense.model.ts
+++ b/src/app/core/models/public-policy-expense.model.ts
@@ -38,7 +38,7 @@ export interface PublicPolicyExpense {
   is_matching_ccc_expense: boolean;
   mileage_rate_id: number;
   invoice_number: number;
-  locations?: Destination[];
+  locations?: Destination[] | string[];
   mandatory_fields_present: boolean;
   manual_flag: boolean;
   mileage_calculated_amount: number;

--- a/src/app/core/models/v1/transaction.model.ts
+++ b/src/app/core/models/v1/transaction.model.ts
@@ -39,7 +39,7 @@ export interface Transaction {
   hotel_is_breakfast_provided?: boolean;
   id?: string;
   invoice_number?: number;
-  locations?: Destination[];
+  locations?: Destination[] | string[] | { display: string }[];
   mandatory_fields_present?: boolean;
   manual_flag?: boolean;
   mileage_calculated_amount?: number;

--- a/src/app/core/services/policy.service.ts
+++ b/src/app/core/services/policy.service.ts
@@ -21,7 +21,7 @@ export class PolicyService {
   ) {}
 
   transformTo(transaction: PublicPolicyExpense | Partial<Transaction>): PlatformPolicyExpense {
-    const locs = transaction.locations as string[];
+    const txnLocations = transaction.locations as string[];
     const platformPolicyExpense: PlatformPolicyExpense = {
       id: transaction.id,
       spent_at: transaction.txn_dt,
@@ -40,7 +40,7 @@ export class PolicyService {
       is_reimbursable: transaction.skip_reimbursement === null ? null : !transaction.skip_reimbursement,
       distance: transaction.distance,
       distance_unit: transaction.distance_unit,
-      locations: locs?.filter((location) => !!location),
+      locations: txnLocations?.filter((location) => !!location),
       custom_fields: transaction.custom_properties,
       started_at: transaction.from_dt,
       ended_at: transaction.to_dt,

--- a/src/app/core/services/policy.service.ts
+++ b/src/app/core/services/policy.service.ts
@@ -21,6 +21,7 @@ export class PolicyService {
   ) {}
 
   transformTo(transaction: PublicPolicyExpense | Partial<Transaction>): PlatformPolicyExpense {
+    const locs = transaction.locations as string[];
     const platformPolicyExpense: PlatformPolicyExpense = {
       id: transaction.id,
       spent_at: transaction.txn_dt,
@@ -39,7 +40,7 @@ export class PolicyService {
       is_reimbursable: transaction.skip_reimbursement === null ? null : !transaction.skip_reimbursement,
       distance: transaction.distance,
       distance_unit: transaction.distance_unit,
-      locations: transaction.locations?.filter((location) => !!location),
+      locations: locs?.filter((location) => !!location),
       custom_fields: transaction.custom_properties,
       started_at: transaction.from_dt,
       ended_at: transaction.to_dt,

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-3.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-3.spec.ts
@@ -67,6 +67,7 @@ import {
   defaultTxnFieldValuesData4,
 } from 'src/app/core/mock-data/default-txn-field-values.data';
 import { costCentersData } from 'src/app/core/mock-data/cost-centers.data';
+import { editExpenseProperties1 } from 'src/app/core/mock-data/track-expense-properties.data';
 
 export function TestCases3(getTestBed) {
   return describe('AddEditMileage-3', () => {
@@ -509,17 +510,7 @@ export function TestCases3(getTestBed) {
       fixture.detectChanges();
 
       component.trackEditExpense(unflattenedTxnWithTrackData);
-      expect(trackingService.editExpense).toHaveBeenCalledOnceWith({
-        Type: 'Mileage',
-        Amount: unflattenedTxnWithTrackData.tx.amount,
-        Currency: unflattenedTxnWithTrackData.tx.currency,
-        Category: unflattenedTxnWithTrackData.tx.org_category,
-        Time_Spent: '300 secs',
-        Used_Autofilled_Project: true,
-        Used_Autofilled_CostCenter: true,
-        Used_Autofilled_VehicleType: true,
-        Used_Autofilled_StartLocation: true,
-      });
+      expect(trackingService.editExpense).toHaveBeenCalledOnceWith(editExpenseProperties1);
     });
   });
 }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b8d576</samp>

This pull request adds a new feature to create or edit mileage transactions in the `add-edit-mileage.page.ts` file. It also fixes a bug in the policy service that caused validation errors with locations data, and updates the interfaces and mock data for transactions and policy expenses to handle different formats of locations data. It also adds and imports a new test file for the add-edit-mileage page.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0b8d576</samp>

> _We are the masters of mileage, we control the data flow_
> _We mock the transactions, we test the scenarios_
> _We change the interfaces, we handle the locations_
> _We fix the policy bugs, we create the `reportValue`_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b8d576</samp>

*  Add a new optional property `type` to the add-edit-mileage page class and constructor to store and receive the type of the transaction ([link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eR2421), [link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eR2438))
*  Add optional chaining operators to the `reportValue` object and its properties to handle null or undefined cases ([link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL2544-R2549))
*  Modify the interfaces for platform policy expense, public policy expense and transaction to allow the `locations` property to be either an array of destination objects, an array of strings, or an array of objects with a display property ([link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-d4b66927d68d2bc65589170acb4d89b7b3c233cbc69f6a01bce7dfbb2e72b0ddL22-R22), [link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-a0bc59def1dacbb0e0b8682fb52ecc114af35777a19b35355bf95d27f18a4958L41-R41), [link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-db96e89a4671a6577872d9c95a3722abc4d79e6b3f8443ec4f74cedb81915dbaL42-R42))
*  Cast the transaction `locations` property to an array of strings in the policy service and pass it to the policy engine for validation ([link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-d422f4879ab43f145be15ff4d400cfdf80d1c25a79012dc1c4073947149d913fR24), [link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-d422f4879ab43f145be15ff4d400cfdf80d1c25a79012dc1c4073947149d913fL42-R43))
*  Add new mock data objects and arrays for default transaction field values, organization category list items and unflattened transactions with different scenarios ([link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-88d03c9481ee9f872719d0aa13033ce30c0e50a9d5de1403d54b362a3f5282cbR31-R36), [link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-3f08ed1afe1b627dd8d79ee0eb6e1b895d7e1505e3670f46c43b97c46e016c9eR70-R132), [link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-21ae928ce640ad62cfada5fee7bf0bbc490300ab04a25f8309a9878e21b2f1cfR2837-R2859))
*  Add a new test file `add-edit-mileage.page.scenarios.spec.ts` that contains test cases for the add-edit-mileage page with different scenarios and import and invoke it in the add-edit-mileage page setup spec file ([link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-df40b6e711e89d5e80e6f3867394ee96bbff1eeae11eef42db09ce0b3f1821fbR61), [link](https://github.com/fylein/fyle-mobile-app/pull/2309/files?diff=unified&w=0#diff-df40b6e711e89d5e80e6f3867394ee96bbff1eeae11eef42db09ce0b3f1821fbR441))

## Clickup
https://app.clickup.com/t/85ztjmtfc

## Code Coverage
`50.11% Statements 423/844`
`44.84% Branches 322/718`
`45.91% Functions 135/294`
`50.87% Lines 409/804`

## UI Preview
Please add screenshots for UI changes