### PR TITLE
fix: Crop Receipt is not working - image dosnt load after cropping

### DIFF
--- a/src/app/shared/components/capture-receipt/crop-receipt/crop-receipt.component.html
+++ b/src/app/shared/components/capture-receipt/crop-receipt/crop-receipt.component.html
@@ -15,6 +15,7 @@
   <div class="crop-receipt__content">
     <image-cropper
       #imageCropper
+      output="base64"
       [imageBase64]="base64ImageWithSource.base64Image"
       [maintainAspectRatio]="false"
       (imageLoaded)="imageLoaded()"


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 330f296</samp>

Added `output` attribute to `image-cropper` component to enable receipt processing. This change allows the cropped receipt image to be sent as a base64 string to the backend API.

https://github.com/fylein/fyle-mobile-app/assets/72932336/1f8ab735-0686-43e1-8d38-90fc33d9a89f

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 330f296</samp>

> _`image-cropper` crops_
> _output as base64 string_
> _autumn receipts fly_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 330f296</samp>

*  Add `output` attribute to `image-cropper` component to get cropped image as base64 string ([link](https://github.com/fylein/fyle-mobile-app/pull/2311/files?diff=unified&w=0#diff-c4a06543167587b95f65ac3f5e5264ef43019579e15a8d21316df100351f8078R18))

## Clickup
https://app.clickup.com/t/85ztvbc3b

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes