### PR TITLE
fix: Transaction Text is offset

### DIFF
--- a/src/app/fyle/personal-cards/personal-cards.page.scss
+++ b/src/app/fyle/personal-cards/personal-cards.page.scss
@@ -254,7 +254,6 @@
       color: $blue-black;
       font-size: 3.2vw;
       font-weight: 500;
-      width: 150px;
       text-transform: none;
     }
 


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f62a1ba</samp>

Removed fixed width from personal card image in `personal-cards.page.scss` to make it responsive. This improved the UI of the personal cards page.

<img src="https://github.com/fylein/fyle-mobile-app/assets/72932336/94b95c33-54d5-4aed-90a0-d9a98cedcabf" width="200" height="400"></img>
<img src="https://github.com/fylein/fyle-mobile-app/assets/72932336/a5a224ab-ee80-4ae5-a0b6-dc19f7899c79" width="200" height="400"></img>

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f62a1ba</samp>

> _`width` property_
> _gone from personal card image_
> _spring of responsiveness_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f62a1ba</samp>

*  Removed the width property of the personal card image to make it responsive and fit the available space ([link](https://github.com/fylein/fyle-mobile-app/pull/2313/files?diff=unified&w=0#diff-d7d1cbc4f41ca8414e63721843777beabda33d2900b5a4cda1a6ea2f8f42bf83L257)). This improved the UI of the personal cards page in `src/app/fyle/personal-cards/personal-cards.page.scss`.

## Clickup
https://app.clickup.com/t/85ztvbbzk

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes