### PR TITLE
fix: CC Dependent Fields on Initial Load

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1852,7 +1852,7 @@ export class AddEditExpensePage implements OnInit {
               duplicate_detection_reason: etxn.tx.user_reason_for_duplicate_expenses,
               billable: etxn.tx.billable,
               custom_inputs: customInputValues,
-              costCenter,
+
               hotel_is_breakfast_provided: etxn.tx.hotel_is_breakfast_provided,
             },
             {
@@ -1860,6 +1860,9 @@ export class AddEditExpensePage implements OnInit {
             }
           );
 
+          this.fg.patchValue({
+            costCenter,
+          });
           this.initialFetch = false;
 
           setTimeout(() => {
@@ -2642,9 +2645,7 @@ export class AddEditExpensePage implements OnInit {
 
   setupSelectedCostCenterObservable(): void {
     this.fg.controls.costCenter.valueChanges.pipe(takeUntil(this.onPageExit$)).subscribe((costCenter: CostCenter) => {
-      if (!this.initialFetch) {
-        this.selectedCostCenter$.next(costCenter);
-      }
+      this.selectedCostCenter$.next(costCenter);
     });
   }
 


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3eb0edf</samp>

Refactored cost center logic in `add-edit-expense.page.ts` to avoid passing redundant data and ensure form consistency.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3eb0edf</samp>

> _`costCenter` gone_
> _from `saveExpense` object_
> _spring cleaning the code_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3eb0edf</samp>

*  Remove `costCenter` property from the object passed to `saveExpense` method to avoid duplication and simplify logic ([link](https://github.com/fylein/fyle-mobile-app/pull/2318/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL1855-R1855))
*  Patch `fg` form group with `costCenter` value from `etxn` object to initialize the form and trigger `valueChanges` observable ([link](https://github.com/fylein/fyle-mobile-app/pull/2318/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bR1863-R1865))
*  Remove `if (!this.initialFetch)` condition from `valueChanges` subscription of `costCenter` control to simplify code and avoid potential bugs ([link](https://github.com/fylein/fyle-mobile-app/pull/2318/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL2645-R2648))

## Clickup
https://app.clickup.com/t/85ztcza5a

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes