### PR TITLE
fix: Search text is misaligned

### DIFF
--- a/src/assets/styles/_fy_select.scss
+++ b/src/assets/styles/_fy_select.scss
@@ -62,7 +62,6 @@ $sub-title: #ababab;
   padding: 0 12px;
   font-size: 14px;
   line-height: 18px;
-  margin-top: -4px;
 }
 
 %fy-select-header {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7fb2433</samp>

Fix label alignment in fy-select component. Remove negative margin-top from `.fy-select__label` in `src/assets/styles/_fy_select.scss`.

before

<img src="https://github.com/fylein/fyle-mobile-app/assets/72932336/706916fe-98e1-4fc0-a900-e45e13856e2a" width="200" height="400"></img>

after

<img src="https://github.com/fylein/fyle-mobile-app/assets/72932336/cee72812-13e1-4cc3-b2e0-1ec8341b5ae7" width="200" height="400"></img>

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7fb2433</samp>

> _`fy-select` label_
> _aligns with input field now_
> _no more overlap - spring_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7fb2433</samp>

* Remove negative margin-top from fy-select label to fix alignment issue ([link](https://github.com/fylein/fyle-mobile-app/pull/2319/files?diff=unified&w=0#diff-482f64621779d5b22afc391b0cf914255a7f3ed8526e71830c6a34c4a243bec7L65))

## Clickup
https://app.clickup.com/t/85ztvyd7j

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes