### PR TITLE
fix: The cross button should be right aligned inside the input box

### DIFF
--- a/src/app/auth/switch-org/switch-org.page.scss
+++ b/src/app/auth/switch-org/switch-org.page.scss
@@ -101,6 +101,10 @@
     padding-top: 8px;
 
     mat-form-field {
+      ::ng-deep .d-flex {
+        flex: 1;
+      }
+
       ::ng-deep .mat-form-field-outline {
         color: $black-light !important;
       }
@@ -118,7 +122,6 @@
       }
 
       &__clear-icon {
-        margin: -10px;
         font-size: 18px;
         background-color: transparent;
         color: $black;


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b81a2b</samp>

Improved the UI of the switch organization page by fixing the layout of the organization cards. Modified the CSS rules in `switch-org.page.scss`.

Before

<img src="https://github.com/fylein/fyle-mobile-app/assets/72932336/74b50453-3e91-4403-b714-f0b439870ac3" width="200" height="400"></img>

After

<img src="https://github.com/fylein/fyle-mobile-app/assets/72932336/8375b459-b84b-42cd-bdc7-3b4dd510a0a0" width="200" height="400"></img>

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0b81a2b</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The page where users switch their orgs with ease and grace_
> _Adjusting `d-flex` and `org-card` with CSS sublime_
> _To make them fill the space like stars in heaven's face_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b81a2b</samp>

*  Align organization cards in switch organization page by making them fill the available space ([link](https://github.com/fylein/fyle-mobile-app/pull/2321/files?diff=unified&w=0#diff-590e04bd60fee9d8a5693586619ea7f733c004deb60fe4fbbddccc1a2595cb61R104-R107)) and removing negative margin ([link](https://github.com/fylein/fyle-mobile-app/pull/2321/files?diff=unified&w=0#diff-590e04bd60fee9d8a5693586619ea7f733c004deb60fe4fbbddccc1a2595cb61L121)) in `switch-org.page.scss`

## Clickup
https://app.clickup.com/t/85ztvyd9n

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes