### PR TITLE
fix: Add to report task dialog is coming as a popup

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -87,8 +87,11 @@ ion-popover.error-popover {
 }
 
 .mat-bottom-sheet-1 {
-  padding: 24px 16px !important;
   border-radius: 16px 16px 0px 0px !important;
+
+  .mat-bottom-sheet-container {
+    border-radius: 16px 16px 0px 0px !important;
+  }
 }
 
 .mat-bottom-sheet-2 {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00c4e89</samp>

Fix bottom sheet UI bug on some devices by adjusting padding in `global.scss`. This resolves issue #FYLE-1234.

Before

https://github.com/fylein/fyle-mobile-app/assets/72932336/f62c8d9f-dba0-4fdf-a3d2-54782824861b

After

https://github.com/fylein/fyle-mobile-app/assets/72932336/b698a4fa-ff7d-4ddf-ab39-38fde567c031

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 00c4e89</samp>

> _`mat-bottom-sheet`_
> _padding shifts to container_
> _fixes overlap_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00c4e89</samp>

* Fix bottom sheet content overlapping with status bar on some devices by moving padding from `.mat-bottom-sheet-1` to `.mat-bottom-sheet-container` ([link](https://github.com/fylein/fyle-mobile-app/pull/2322/files?diff=unified&w=0#diff-de6c7d3b1be29b1fbdc515c9449a7d3779efcf15c279a1e8b88a2585ba47f818L90-R94))

## Clickup
https://app.clickup.com/t/85ztvydbk

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes