### PR TITLE
test: Android negative fix test

### DIFF
--- a/src/app/shared/components/fy-number/fy-number.component.spec.ts
+++ b/src/app/shared/components/fy-number/fy-number.component.spec.ts
@@ -120,6 +120,31 @@ describe('FyNumberComponent', () => {
       expect(component.handleChange).not.toHaveBeenCalled();
     });
 
+    it('should enable isAndroidNegativeExpensePluginEnabled plugin when checkIfAndroidNegativeExpensePluginIsEnabled returns true', () => {
+      spyOn(component, 'handleChange');
+
+      platform.is.withArgs('android').and.returnValue(true);
+      launchDarklyService.checkIfAndroidNegativeExpensePluginIsEnabled.and.returnValue(of(true));
+
+      component.ngOnInit();
+      fixture.detectChanges();
+      const inputElement = getAllElementsBySelector(fixture, '.fy-number--input');
+      expect(component.isAndroid).toBeTrue();
+      expect(component.isAndroidNegativeExpensePluginEnabled).toBeTrue();
+      expect(inputElement.length).toBe(1);
+      expect(component.handleChange).not.toHaveBeenCalled();
+    });
+
+    it('should set this.value to null and give invalid error when given a negative number if input is distance', () => {
+      spyOn(component, 'handleChange');
+      component.isDistance = true;
+
+      component.ngOnInit();
+      fixture.detectChanges();
+      component.fc.setValue(-1);
+      expect(component.value).toBeNull();
+    });
+
     it('should set this.value to a parsed float when given a string', () => {
       spyOn(component, 'onChangeCallback').and.callThrough();
       const mockCallback = jasmine.createSpy('mockCallback');

--- a/src/app/shared/components/fy-number/fy-number.component.ts
+++ b/src/app/shared/components/fy-number/fy-number.component.ts
@@ -43,7 +43,7 @@ export class FyNumberComponent implements ControlValueAccessor, OnInit, AfterVie
   // This variable tracks if comma was clicked by the user.
   commaClicked = false;
 
-  innerValue: string | number;
+  innerValue: number;
 
   isNegativeExpensePluginEnabled = false;
 
@@ -53,7 +53,7 @@ export class FyNumberComponent implements ControlValueAccessor, OnInit, AfterVie
 
   onTouchedCallback: () => void = noop;
 
-  onChangeCallback: (_: string | number) => void = noop;
+  onChangeCallback: (_: number) => void = noop;
 
   keysForNegativeExpense = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '.'];
 
@@ -62,14 +62,14 @@ export class FyNumberComponent implements ControlValueAccessor, OnInit, AfterVie
   constructor(
     private platform: Platform,
     private launchDarklyService: LaunchDarklyService,
-    private injector: Injector
+    private injector: Injector,
   ) {}
 
-  get value(): string | number {
+  get value(): number {
     return this.innerValue;
   }
 
-  set value(v: string | number) {
+  set value(v: number) {
     if (v !== this.innerValue) {
       this.innerValue = v;
       this.onChangeCallback(v);
@@ -84,7 +84,7 @@ export class FyNumberComponent implements ControlValueAccessor, OnInit, AfterVie
     }
   }
 
-  registerOnChange(fn: (_: string | number) => void): void {
+  registerOnChange(fn: (_: number) => void): void {
     this.onChangeCallback = fn;
   }
 
@@ -112,7 +112,7 @@ export class FyNumberComponent implements ControlValueAccessor, OnInit, AfterVie
     this.launchDarklyService
       .checkIfNegativeExpensePluginIsEnabled()
       .subscribe(
-        (isNegativeExpensePluginEnabled) => (this.isNegativeExpensePluginEnabled = isNegativeExpensePluginEnabled)
+        (isNegativeExpensePluginEnabled) => (this.isNegativeExpensePluginEnabled = isNegativeExpensePluginEnabled),
       );
 
     this.launchDarklyService


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7cdede4</samp>

This pull request improves the `FyNumberComponent` by changing its type to `number` and adding new test cases. It also fixes a minor code style issue in the `fy-number.component.ts` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7cdede4</samp>

> _Oh we're the coders of the `FyNumberComponent`_
> _And we test and refactor as we please_
> _We make the `value` a number and we check for negative input_
> _Heave away, heave away, heave away with ease_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7cdede4</samp>

*  Simplify the type of the `innerValue`, `value`, and `onChangeCallback` properties and functions of the `FyNumberComponent` class from `string | number` to `number` ([link](https://github.com/fylein/fyle-mobile-app/pull/2338/files?diff=unified&w=0#diff-7a124d2b1279f426c898572db3f1a184b53487f32282ba714b3a1e657d374fdaL46-R46), [link](https://github.com/fylein/fyle-mobile-app/pull/2338/files?diff=unified&w=0#diff-7a124d2b1279f426c898572db3f1a184b53487f32282ba714b3a1e657d374fdaL56-R56), [link](https://github.com/fylein/fyle-mobile-app/pull/2338/files?diff=unified&w=0#diff-7a124d2b1279f426c898572db3f1a184b53487f32282ba714b3a1e657d374fdaL65-R72), [link](https://github.com/fylein/fyle-mobile-app/pull/2338/files?diff=unified&w=0#diff-7a124d2b1279f426c898572db3f1a184b53487f32282ba714b3a1e657d374fdaL87-R87))
*  Add two test cases for the `FyNumberComponent` in the `fy-number.component.spec.ts` file to check the behavior of the component when the platform is android and the `isAndroidNegativeExpensePluginEnabled` flag is enabled, and when the input is a negative number and the `isDistance` flag is true ([link](https://github.com/fylein/fyle-mobile-app/pull/2338/files?diff=unified&w=0#diff-cf5db23fa10a92ef5a35f6b3e0e0d6661e52c2c61a5e333c0757401ac3694f51R123-R147))
*  Add a comma at the end of the line in the `ngOnInit` function of the `FyNumberComponent` class to follow the code style and formatting rules ([link](https://github.com/fylein/fyle-mobile-app/pull/2338/files?diff=unified&w=0#diff-7a124d2b1279f426c898572db3f1a184b53487f32282ba714b3a1e657d374fdaL115-R115))

## Clickup
https://app.clickup.com/t/85zteyum0

## Code Coverage
<img width="1123" alt="Screenshot 2023-08-31 at 3 14 30 PM" src="https://github.com/fylein/fyle-mobile-app/assets/127177049/cd6ad982-26a2-48dc-9c1d-43051466dd7d">


## UI Preview
Please add screenshots for UI changes