### PR TITLE
fix: Fixed category custom fields not loading up on incomplete expenses

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense-3.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-3.spec.ts
@@ -1129,7 +1129,7 @@ export function TestCases3(getTestBed) {
         });
       });
 
-      it('should return null in case the expense does not have an expense and auto-fill category is not found', (done) => {
+      it('should return null in case the expense does not have a category and auto-fill category is not found', (done) => {
         orgUserSettingsService.get.and.returnValue(of(orgUserSettingsData));
         orgSettingsService.get.and.returnValue(of(orgSettingsData));
         component.recentlyUsedValues$ = of(recentlyUsedRes);

--- a/src/app/fyle/add-edit-expense/add-edit-expense-3.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-3.spec.ts
@@ -1062,7 +1062,7 @@ export function TestCases3(getTestBed) {
         });
       });
 
-      it('should get autofill category for draft expense', (done) => {
+      it('should get autofill category for draft expense when category is unspecified', (done) => {
         orgUserSettingsService.get.and.returnValue(of(orgUserSettingsData));
         orgSettingsService.get.and.returnValue(of(orgSettingsData));
         component.recentlyUsedValues$ = of(recentlyUsedRes);

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1964,9 +1964,8 @@ export class AddEditExpensePage implements OnInit {
           recentCategories: OrgCategoryListItem[];
           etxn: UnflattenedTransaction;
         }) => {
-          const isExpenseDraft = etxn.tx.state === 'DRAFT';
           const isExpenseCategoryUnspecified = etxn.tx?.fyle_category?.toLowerCase() === 'unspecified';
-          if (this.initialFetch && etxn.tx.org_category_id && !isExpenseDraft && !isExpenseCategoryUnspecified) {
+          if (this.initialFetch && etxn.tx.org_category_id && !isExpenseCategoryUnspecified) {
             return this.categoriesService.getCategoryById(etxn.tx.org_category_id).pipe(
               map((selectedCategory) => ({
                 orgUserSettings,


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1YetHJmChrNHIDLTsS6lTl3wouGMri9k%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=oBlvhQQ)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a1d954b</samp>

Fixed a bug where draft expenses with a category did not show the category icon and name. Removed `isExpenseDraft` condition from `add-edit-expense.page.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a1d954b</samp>

> _`isExpenseDraft` gone_
> _Category details fetched_
> _Expense card shows spring_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a1d954b</samp>

*  Removed `isExpenseDraft` condition from `if` statement to fetch category details for all expenses ([link](https://github.com/fylein/fyle-mobile-app/pull/2353/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL1967-R1968))

## Clickup
https://app.clickup.com/t/85ztt5xxv