### PR TITLE
fix: View Info icon is overlapping slightly

### DIFF
--- a/src/app/fyle/my-view-report/my-view-report.page.scss
+++ b/src/app/fyle/my-view-report/my-view-report.page.scss
@@ -190,6 +190,7 @@
     font-size: 12px;
     font-weight: 500;
     color: $light-grey;
+    align-items: center;
 
     &__icon {
       height: 18px;

--- a/src/app/fyle/view-team-report/view-team-report.page.scss
+++ b/src/app/fyle/view-team-report/view-team-report.page.scss
@@ -80,6 +80,7 @@ $sent-back-color: #da1e28;
     font-size: 12px;
     font-weight: 500;
     color: $light-grey;
+    align-items: center;
 
     &__icon {
       height: 18px;


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c7e90e3</samp>

This pull request adds a CSS property to the `.report-header` class in two files: `my-view-report.page.scss` and `view-team-report.page.scss`. This property aligns the report title and status vertically in the header of the report pages.

Before

<img src="https://github.com/fylein/fyle-mobile-app/assets/72932336/283f45c7-f9aa-4d4f-92ab-a23afe99b6f4" width="200" height="400"></img>

After

https://github.com/fylein/fyle-mobile-app/assets/72932336/95907523-39b3-496b-a0e5-17f325653e7f


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c7e90e3</samp>

> _`align-items`: center_
> _report headers look better_
> _a spring UI refresh_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c7e90e3</samp>

*  Vertically center the report title and the report status in the header of the report pages ([link](https://github.com/fylein/fyle-mobile-app/pull/2358/files?diff=unified&w=0#diff-34c5d15eae6aff1ed174da1e15fcffdbddb979effe01cd6bd0738319ae335ffaR193), [link](https://github.com/fylein/fyle-mobile-app/pull/2358/files?diff=unified&w=0#diff-7d3618be80adbf91252bbdd08dcecde680f7cc6a97a1b5227851b135910df2d4R83))

## Clickup
https://app.clickup.com/t/85ztxaumq

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes