### PR TITLE
test: ionViewWillEnter Part 2 coverage

### DIFF
--- a/src/app/fyle/view-per-diem/view-per-diem.page.spec.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.spec.ts
@@ -480,7 +480,7 @@ describe('ViewPerDiemPage', () => {
       component.policyViolations$.subscribe((policyViolations) => {
         expect(policyService.getApproverExpensePolicyViolations).not.toHaveBeenCalled();
         expect(policyService.getSpenderExpensePolicyViolations).not.toHaveBeenCalled();
-        expect(policyViolations).toEqual(null);
+        expect(policyViolations).toBeNull();
         done();
       });
     });
@@ -504,7 +504,7 @@ describe('ViewPerDiemPage', () => {
 
       component.isCriticalPolicyViolated$.subscribe((isCriticalPolicyViolated) => {
         expect(component.isNumber).toHaveBeenCalledOnceWith(0);
-        expect(isCriticalPolicyViolated).toEqual(true);
+        expect(isCriticalPolicyViolated).toBeTrue();
         done();
       });
     });
@@ -518,7 +518,7 @@ describe('ViewPerDiemPage', () => {
 
       component.isCriticalPolicyViolated$.subscribe((isCriticalPolicyViolated) => {
         expect(component.isNumber).toHaveBeenCalledOnceWith(null);
-        expect(isCriticalPolicyViolated).toEqual(false);
+        expect(isCriticalPolicyViolated).toBeFalse();
         done();
       });
     });
@@ -532,7 +532,7 @@ describe('ViewPerDiemPage', () => {
 
       component.isAmountCapped$.subscribe((isAmountCapped) => {
         expect(component.isNumber).toHaveBeenCalledOnceWith(0);
-        expect(isAmountCapped).toEqual(true);
+        expect(isAmountCapped).toBeTrue();
         done();
       });
     });
@@ -549,7 +549,7 @@ describe('ViewPerDiemPage', () => {
         expect(component.isNumber).toHaveBeenCalledTimes(2);
         expect(component.isNumber).toHaveBeenCalledWith(null);
         expect(component.isNumber).toHaveBeenCalledWith(0);
-        expect(isAmountCapped).toEqual(true);
+        expect(isAmountCapped).toBeTrue();
         done();
       });
     });
@@ -566,7 +566,7 @@ describe('ViewPerDiemPage', () => {
         expect(component.isNumber).toHaveBeenCalledTimes(2);
         expect(component.isNumber).toHaveBeenCalledWith(null);
         expect(component.isNumber).toHaveBeenCalledWith(null);
-        expect(isAmountCapped).toEqual(false);
+        expect(isAmountCapped).toBeFalse();
         done();
       });
     });
@@ -575,9 +575,9 @@ describe('ViewPerDiemPage', () => {
       component.ionViewWillEnter();
       tick(100);
 
-      expect(component.isExpenseFlagged).toEqual(false);
+      expect(component.isExpenseFlagged).toBeFalse();
       component.updateFlag$.subscribe((updateFlag) => {
-        expect(updateFlag).toEqual(null);
+        expect(updateFlag).toBeNull();
       });
     }));
 

--- a/src/app/fyle/view-per-diem/view-per-diem.page.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.ts
@@ -50,7 +50,7 @@ export class ViewPerDiemPage {
 
   isAmountCapped$: Observable<boolean>;
 
-  policyViloations$: Observable<IndividualExpensePolicyState[]>;
+  policyViolations$: Observable<IndividualExpensePolicyState[]>;
 
   canFlagOrUnflag$: Observable<boolean>;
 
@@ -108,7 +108,7 @@ export class ViewPerDiemPage {
     private trackingService: TrackingService,
     private expenseFieldsService: ExpenseFieldsService,
     private orgSettingsService: OrgSettingsService,
-    private dependentFieldsService: DependentFieldsService
+    private dependentFieldsService: DependentFieldsService,
   ) {}
 
   get ExpenseView(): typeof ExpenseView {
@@ -171,10 +171,10 @@ export class ViewPerDiemPage {
 
     this.extendedPerDiem$ = this.updateFlag$.pipe(
       switchMap(() =>
-        from(this.loaderService.showLoader()).pipe(switchMap(() => this.transactionService.getExpenseV2(id)))
+        from(this.loaderService.showLoader()).pipe(switchMap(() => this.transactionService.getExpenseV2(id))),
       ),
       finalize(() => from(this.loaderService.hideLoader())),
-      shareReplay(1)
+      shareReplay(1),
     );
 
     this.txnFields$ = this.expenseFieldsService.getAllMap().pipe(shareReplay(1));
@@ -184,14 +184,14 @@ export class ViewPerDiemPage {
       txnFields: this.txnFields$.pipe(take(1)),
     }).pipe(
       filter(
-        ({ extendedPerDiem, txnFields }) => extendedPerDiem.tx_custom_properties && txnFields.project_id?.length > 0
+        ({ extendedPerDiem, txnFields }) => extendedPerDiem.tx_custom_properties && txnFields.project_id?.length > 0,
       ),
       switchMap(({ extendedPerDiem, txnFields }) =>
         this.dependentFieldsService.getDependentFieldValuesForBaseField(
           extendedPerDiem.tx_custom_properties,
-          txnFields.project_id[0]?.id
-        )
-      )
+          txnFields.project_id[0]?.id,
+        ),
+      ),
     );
 
     this.costCenterDependentCustomProperties$ = forkJoin({
@@ -199,15 +199,16 @@ export class ViewPerDiemPage {
       txnFields: this.txnFields$.pipe(take(1)),
     }).pipe(
       filter(
-        ({ extendedPerDiem, txnFields }) => extendedPerDiem.tx_custom_properties && txnFields.cost_center_id?.length > 0
+        ({ extendedPerDiem, txnFields }) =>
+          extendedPerDiem.tx_custom_properties && txnFields.cost_center_id?.length > 0,
       ),
       switchMap(({ extendedPerDiem, txnFields }) =>
         this.dependentFieldsService.getDependentFieldValuesForBaseField(
           extendedPerDiem.tx_custom_properties,
-          txnFields.cost_center_id[0]?.id
-        )
+          txnFields.cost_center_id[0]?.id,
+        ),
       ),
-      shareReplay(1)
+      shareReplay(1),
     );
 
     this.extendedPerDiem$.subscribe((extendedPerDiem) => {
@@ -234,7 +235,7 @@ export class ViewPerDiemPage {
           const isProjectMandatory = expenseFieldsMap?.project_id && expenseFieldsMap?.project_id[0]?.is_mandatory;
           this.isProjectShown =
             this.orgSettings?.projects?.enabled && (!!extendedPerDiem.tx_project_name || isProjectMandatory);
-        })
+        }),
       )
       .subscribe(noop);
 
@@ -248,21 +249,21 @@ export class ViewPerDiemPage {
 
     this.perDiemCustomFields$ = this.extendedPerDiem$.pipe(
       switchMap((res) =>
-        this.customInputsService.fillCustomProperties(res.tx_org_category_id, res.tx_custom_properties, true)
+        this.customInputsService.fillCustomProperties(res.tx_org_category_id, res.tx_custom_properties, true),
       ),
       map((res) =>
         res.map((customProperties) => {
           customProperties.displayValue = this.customInputsService.getCustomPropertyDisplayValue(customProperties);
           return customProperties;
-        })
-      )
+        }),
+      ),
     );
 
     this.perDiemRate$ = this.extendedPerDiem$.pipe(
       switchMap((res) => {
         const perDiemRateId = parseInt(res.tx_per_diem_rate_id, 10);
         return this.perDiemService.getRate(perDiemRateId);
-      })
+      }),
     );
 
     this.view = this.activatedRoute.snapshot.params.view as ExpenseView;
@@ -271,42 +272,43 @@ export class ViewPerDiemPage {
       filter(() => this.view === ExpenseView.team),
       map(
         (etxn) =>
-          ['COMPLETE', 'POLICY_APPROVED', 'APPROVER_PENDING', 'APPROVED', 'PAYMENT_PENDING'].indexOf(etxn.tx_state) > -1
-      )
+          ['COMPLETE', 'POLICY_APPROVED', 'APPROVER_PENDING', 'APPROVED', 'PAYMENT_PENDING'].indexOf(etxn.tx_state) >
+          -1,
+      ),
     );
 
     this.canDelete$ = this.extendedPerDiem$.pipe(
       filter(() => this.view === ExpenseView.team),
       switchMap((etxn) =>
-        this.reportService.getTeamReport(etxn.tx_report_id).pipe(map((report) => ({ report, etxn })))
+        this.reportService.getTeamReport(etxn.tx_report_id).pipe(map((report) => ({ report, etxn }))),
       ),
       map(({ report, etxn }) => {
         if (report.rp_num_transactions === 1) {
           return false;
         }
         return ['PAYMENT_PENDING', 'PAYMENT_PROCESSING', 'PAID'].indexOf(etxn.tx_state) < 0;
-      })
+      }),
     );
 
     if (id) {
-      this.policyViloations$ =
+      this.policyViolations$ =
         this.view === ExpenseView.team
           ? this.policyService.getApproverExpensePolicyViolations(id)
           : this.policyService.getSpenderExpensePolicyViolations(id);
     } else {
-      this.policyViloations$ = of(null);
+      this.policyViolations$ = of(null);
     }
 
     this.comments$ = this.statusService.find('transactions', id);
 
     this.isCriticalPolicyViolated$ = this.extendedPerDiem$.pipe(
-      map((res) => this.isNumber(res.tx_policy_amount) && res.tx_policy_amount < 0.0001)
+      map((res) => this.isNumber(res.tx_policy_amount) && res.tx_policy_amount < 0.0001),
     );
 
     this.getPolicyDetails(id);
 
     this.isAmountCapped$ = this.extendedPerDiem$.pipe(
-      map((res) => this.isNumber(res.tx_admin_amount) || this.isNumber(res.tx_policy_amount))
+      map((res) => this.isNumber(res.tx_admin_amount) || this.isNumber(res.tx_policy_amount)),
     );
 
     this.extendedPerDiem$.subscribe((etxn) => {
@@ -377,12 +379,12 @@ export class ViewPerDiemPage {
           concatMap(() =>
             etxn.tx_manual_flag
               ? this.transactionService.manualUnflag(etxn.tx_id)
-              : this.transactionService.manualFlag(etxn.tx_id)
+              : this.transactionService.manualFlag(etxn.tx_id),
           ),
           finalize(() => {
             this.updateFlag$.next(null);
             this.loaderService.hideLoader();
-          })
+          }),
         )
         .subscribe(noop);
     }

--- a/src/app/fyle/view-per-diem/view-per-diem.page.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.ts
@@ -29,6 +29,7 @@ import { CustomInput } from 'src/app/core/models/custom-input.model';
 import { OrgSettings } from 'src/app/core/models/org-settings.model';
 import { PerDiemRates } from 'src/app/core/models/v1/per-diem-rates.model';
 import { IndividualExpensePolicyState } from 'src/app/core/models/platform/platform-individual-expense-policy-state.model';
+import { ExpenseDeletePopoverParams } from 'src/app/core/models/expense-delete-popover-params.model';
 
 @Component({
   selector: 'app-view-per-diem',
@@ -324,10 +325,8 @@ export class ViewPerDiemPage {
     this.activeEtxnIndex = parseInt(this.activatedRoute.snapshot.params.activeIndex as string, 10);
   }
 
-  async removeExpenseFromReport(): Promise<void> {
-    const etxn = await this.transactionService.getEtxn(this.activatedRoute.snapshot.params.id as string).toPromise();
-
-    const deletePopover = await this.popoverController.create({
+  getDeleteDialogProps(etxn: Expense): ExpenseDeletePopoverParams {
+    return {
       component: FyDeleteDialogComponent,
       cssClass: 'delete-dialog',
       backdropDismiss: false,
@@ -339,7 +338,13 @@ export class ViewPerDiemPage {
         ctaLoadingText: 'Removing',
         deleteMethod: () => this.reportService.removeTransaction(etxn.tx_report_id, etxn.tx_id),
       },
-    });
+    };
+  }
+
+  async removeExpenseFromReport(): Promise<void> {
+    const etxn = await this.transactionService.getEtxn(this.activatedRoute.snapshot.params.id as string).toPromise();
+
+    const deletePopover = await this.popoverController.create(this.getDeleteDialogProps(etxn));
 
     await deletePopover.present();
     const { data } = (await deletePopover.onDidDismiss()) as { data: { status: string } };


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 466e610</samp>

This pull request fixes a typo and adds some formatting changes to `view-per-diem.page.ts`, and adds unit tests for the `ionViewWillEnter` method of the `ViewPerDiemPage` class in `view-per-diem.page.spec.ts`. The purpose is to improve the code quality and reliability of the view per diem feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 466e610</samp>

> _Sing, O Muse, of the valiant coder who tested the view of per diem_
> _With skillful mind and nimble fingers, he crafted many a unit exam_
> _To probe the logic of observables and services, `policyViolations$` and `comments$`_
> _And `isCriticalPolicyViolated$` and `isAmountCapped$` and `updateFlag$`_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 466e610</samp>

*  Fix a typo in the `policyViolations$` property name and add commas to multiline arguments in various observables and methods in `view-per-diem.page.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L53-R53), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L111-R111), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L174-R177), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L187-R194), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L202-R211), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L237-R238), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L251-R252), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L257-R259), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L265-R266), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L274-R277), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L281-R283), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L288-R299), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L303-R305), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L309-R311), [link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L380-R387))
* Add unit tests for the `ionViewWillEnter` method in `view-per-diem.page.spec.ts` to check the behavior of various observables and services, such as `policyViolations$`, `comments$`, `isCriticalPolicyViolated$`, `isAmountCapped$`, `updateFlag$`, `numEtxnsInReport` and `activeEtxnIndex` ([link](https://github.com/fylein/fyle-mobile-app/pull/2360/files?diff=unified&w=0#diff-aa7434f7715887f5188bf634482b759f816a20bd7f5d51ef219f9754ec71a057R454-R590))

## Clickup
app.clickup.com

## Code Coverage
79.52% Statements 101/127
75.51% Branches 37/49
79.48% Functions 31/39
79.2% Lines 99/125

## UI Preview
Please add screenshots for UI changes