### PR TITLE
test: 99.2% coverage of view-per-diem page

### DIFF
--- a/src/app/fyle/view-per-diem/view-per-diem.page.spec.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.spec.ts
@@ -273,6 +273,7 @@ describe('ViewPerDiemPage', () => {
   });
 
   describe('ionViewWillEnter():', () => {
+    const mockCustomFields = cloneDeep(customFields);
     beforeEach(() => {
       loaderService.showLoader.and.resolveTo();
       loaderService.hideLoader.and.resolveTo();
@@ -280,7 +281,7 @@ describe('ViewPerDiemPage', () => {
       expenseFieldsService.getAllMap.and.returnValue(of(expenseFieldsMapResponse4));
       dependentFieldsService.getDependentFieldValuesForBaseField.and.returnValue(of(customInputData1));
       orgSettingsService.get.and.returnValue(of(orgSettingsData));
-      customInputsService.fillCustomProperties.and.returnValue(of(customFields));
+      customInputsService.fillCustomProperties.and.returnValue(of(mockCustomFields));
       customInputsService.getCustomPropertyDisplayValue.and.returnValue('customPropertyDisplayValue');
       perDiemService.getRate.and.returnValue(of(perDiemRatesData1));
       reportService.getTeamReport.and.returnValue(of(apiExtendedReportRes[0]));
@@ -394,9 +395,9 @@ describe('ViewPerDiemPage', () => {
         );
         // Called twice because of the two custom fields
         expect(customInputsService.getCustomPropertyDisplayValue).toHaveBeenCalledTimes(2);
-        expect(customInputsService.getCustomPropertyDisplayValue).toHaveBeenCalledWith(customFields[0]);
-        expect(customInputsService.getCustomPropertyDisplayValue).toHaveBeenCalledWith(customFields[1]);
-        expect(perDiemCustomFields).toEqual(customFields);
+        expect(customInputsService.getCustomPropertyDisplayValue).toHaveBeenCalledWith(mockCustomFields[0]);
+        expect(customInputsService.getCustomPropertyDisplayValue).toHaveBeenCalledWith(mockCustomFields[1]);
+        expect(perDiemCustomFields).toEqual(mockCustomFields);
       });
 
       component.perDiemRate$.subscribe((perDiemRate) => {

--- a/src/app/fyle/view-per-diem/view-per-diem.page.spec.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.spec.ts
@@ -592,7 +592,7 @@ describe('ViewPerDiemPage', () => {
     }));
   });
 
-  it('getDeleteDialogProps(): should return the props', () => {
+  it('getDeleteDialogProps(): should return modal params', () => {
     const props = component.getDeleteDialogProps(expenseData1);
     props.componentProps.deleteMethod();
     expect(reportService.removeTransaction).toHaveBeenCalledOnceWith(expenseData1.tx_report_id, expenseData1.tx_id);

--- a/src/app/fyle/view-per-diem/view-per-diem.page.spec.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.spec.ts
@@ -31,12 +31,14 @@ import { properties } from 'src/app/core/mock-data/modal-properties.data';
 import { expenseFieldsMapResponse4 } from 'src/app/core/mock-data/expense-fields-map.data';
 import { customInputData1 } from 'src/app/core/mock-data/custom-input.data';
 import { orgSettingsData } from 'src/app/core/test-data/accounts.service.spec.data';
-import { customFields } from 'src/app/core/mock-data/custom-field.data';
+import { customFieldData1, customFields } from 'src/app/core/mock-data/custom-field.data';
 import { perDiemRatesData1 } from 'src/app/core/mock-data/per-diem-rates.data';
 import { apiExtendedReportRes } from 'src/app/core/mock-data/report.data';
 import { estatusData1 } from 'src/app/core/test-data/status.service.spec.data';
 import { cloneDeep } from 'lodash';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
+import { FyPopoverComponent } from 'src/app/shared/components/fy-popover/fy-popover.component';
+import { txnStatusData } from 'src/app/core/mock-data/transaction-status.data';
 
 describe('ViewPerDiemPage', () => {
   let component: ViewPerDiemPage;
@@ -588,5 +590,133 @@ describe('ViewPerDiemPage', () => {
       expect(component.numEtxnsInReport).toEqual(3);
       expect(component.activeEtxnIndex).toEqual(0);
     }));
+  });
+
+  it('getDeleteDialogProps(): should return the props', () => {
+    const props = component.getDeleteDialogProps(expenseData1);
+    props.componentProps.deleteMethod();
+    expect(reportService.removeTransaction).toHaveBeenCalledOnceWith(expenseData1.tx_report_id, expenseData1.tx_id);
+  });
+
+  it('removeExpenseFromReport(): should remove the expense from report', fakeAsync(() => {
+    transactionService.getEtxn.and.returnValue(of(expenseData1));
+
+    spyOn(component, 'getDeleteDialogProps');
+    const deletePopoverSpy = jasmine.createSpyObj('HTMLIonPopoverElement', ['present', 'onDidDismiss']);
+    popoverController.create.and.returnValue(deletePopoverSpy);
+    deletePopoverSpy.onDidDismiss.and.resolveTo({ data: { status: 'success' } });
+
+    component.removeExpenseFromReport();
+    tick(100);
+    expect(transactionService.getEtxn).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id);
+    expect(popoverController.create).toHaveBeenCalledOnceWith(component.getDeleteDialogProps(expenseData1));
+    expect(deletePopoverSpy.present).toHaveBeenCalledTimes(1);
+    expect(deletePopoverSpy.onDidDismiss).toHaveBeenCalledTimes(1);
+    expect(trackingService.expenseRemovedByApprover).toHaveBeenCalledTimes(1);
+    expect(router.navigate).toHaveBeenCalledOnceWith([
+      '/',
+      'enterprise',
+      'view_team_report',
+      { id: expenseData1.tx_report_id, navigate_back: true },
+    ]);
+  }));
+
+  describe('flagUnflagExpense', () => {
+    it('should flag unflagged expense', fakeAsync(() => {
+      transactionService.getEtxn.and.returnValue(of(expenseData1));
+      loaderService.showLoader.and.resolveTo();
+      loaderService.hideLoader.and.resolveTo();
+
+      const title = 'Flag';
+      const flagPopoverSpy = jasmine.createSpyObj('HTMLIonPopoverElement', ['present', 'onWillDismiss']);
+      popoverController.create.and.returnValue(flagPopoverSpy);
+      const data = { comment: 'This is a comment for flagging' };
+      flagPopoverSpy.onWillDismiss.and.resolveTo({ data });
+      statusService.post.and.returnValue(of(txnStatusData));
+      transactionService.manualFlag.and.returnValue(of(expenseData2));
+
+      component.flagUnflagExpense();
+      tick(100);
+      expect(transactionService.getEtxn).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id);
+
+      expect(popoverController.create).toHaveBeenCalledOnceWith({
+        component: FyPopoverComponent,
+        componentProps: {
+          title,
+          formLabel: 'Reason for flaging expense',
+        },
+        cssClass: 'fy-dialog-popover',
+      });
+
+      expect(flagPopoverSpy.present).toHaveBeenCalledTimes(1);
+      expect(flagPopoverSpy.onWillDismiss).toHaveBeenCalledTimes(1);
+      expect(loaderService.showLoader).toHaveBeenCalledOnceWith('Please wait');
+      expect(statusService.post).toHaveBeenCalledOnceWith('transactions', expenseData1.tx_id, data, true);
+      expect(transactionService.manualFlag).toHaveBeenCalledOnceWith(expenseData1.tx_id);
+      expect(transactionService.manualUnflag).not.toHaveBeenCalled();
+      expect(loaderService.hideLoader).toHaveBeenCalledTimes(1);
+      expect(trackingService.expenseFlagUnflagClicked).toHaveBeenCalledOnceWith({ action: title });
+      expect(component.isExpenseFlagged).toBeFalse();
+    }));
+
+    it('should unflag flagged expense', fakeAsync(() => {
+      const mockExpenseData = {
+        ...expenseData1,
+        tx_manual_flag: true,
+      };
+      transactionService.getEtxn.and.returnValue(of(mockExpenseData));
+      loaderService.showLoader.and.resolveTo();
+      loaderService.hideLoader.and.resolveTo();
+      component.isExpenseFlagged = true;
+
+      const title = 'Unflag';
+      const flagPopoverSpy = jasmine.createSpyObj('HTMLIonPopoverElement', ['present', 'onWillDismiss']);
+      popoverController.create.and.returnValue(flagPopoverSpy);
+      const data = { comment: 'This is a comment for flagging' };
+      flagPopoverSpy.onWillDismiss.and.resolveTo({ data });
+      statusService.post.and.returnValue(of(txnStatusData));
+      transactionService.manualUnflag.and.returnValue(of(expenseData1));
+
+      component.flagUnflagExpense();
+      tick(100);
+      expect(transactionService.getEtxn).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id);
+
+      expect(popoverController.create).toHaveBeenCalledOnceWith({
+        component: FyPopoverComponent,
+        componentProps: {
+          title,
+          formLabel: 'Reason for unflaging expense',
+        },
+        cssClass: 'fy-dialog-popover',
+      });
+
+      expect(flagPopoverSpy.present).toHaveBeenCalledTimes(1);
+      expect(flagPopoverSpy.onWillDismiss).toHaveBeenCalledTimes(1);
+      expect(loaderService.showLoader).toHaveBeenCalledOnceWith('Please wait');
+      expect(statusService.post).toHaveBeenCalledOnceWith('transactions', mockExpenseData.tx_id, data, true);
+      expect(transactionService.manualUnflag).toHaveBeenCalledOnceWith(mockExpenseData.tx_id);
+      expect(transactionService.manualFlag).not.toHaveBeenCalled();
+      expect(loaderService.hideLoader).toHaveBeenCalledTimes(1);
+      expect(trackingService.expenseFlagUnflagClicked).toHaveBeenCalledOnceWith({ action: title });
+      expect(component.isExpenseFlagged).toBeTrue();
+    }));
+  });
+
+  describe('getDisplayValue():', () => {
+    it('should get the correct display value', () => {
+      const expectedProperty = 'record1, record2';
+      customInputsService.getCustomPropertyDisplayValue.and.returnValue(expectedProperty);
+      const result = component.getDisplayValue(customFieldData1[0]);
+      expect(customInputsService.getCustomPropertyDisplayValue).toHaveBeenCalledOnceWith(customFieldData1[0]);
+      expect(result).toEqual(expectedProperty);
+    });
+
+    it('should display Not Added if no value is added', () => {
+      const expectedProperty = '-';
+      customInputsService.getCustomPropertyDisplayValue.and.returnValue(expectedProperty);
+      const result = component.getDisplayValue(customFieldData1[0]);
+      expect(customInputsService.getCustomPropertyDisplayValue).toHaveBeenCalledOnceWith(customFieldData1[0]);
+      expect(result).toEqual('Not Added');
+    });
   });
 });

--- a/src/app/fyle/view-per-diem/view-per-diem.page.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.ts
@@ -29,6 +29,7 @@ import { CustomInput } from 'src/app/core/models/custom-input.model';
 import { OrgSettings } from 'src/app/core/models/org-settings.model';
 import { PerDiemRates } from 'src/app/core/models/v1/per-diem-rates.model';
 import { IndividualExpensePolicyState } from 'src/app/core/models/platform/platform-individual-expense-policy-state.model';
+import { ExpenseDeletePopoverParams } from 'src/app/core/models/expense-delete-popover-params.model';
 
 @Component({
   selector: 'app-view-per-diem',
@@ -324,10 +325,8 @@ export class ViewPerDiemPage {
     this.activeEtxnIndex = parseInt(this.activatedRoute.snapshot.params.activeIndex as string, 10);
   }
 
-  async removeExpenseFromReport(): Promise<void> {
-    const etxn = await this.transactionService.getEtxn(this.activatedRoute.snapshot.params.id as string).toPromise();
-
-    const deletePopover = await this.popoverController.create({
+  getDeleteDialogProps(etxn: Expense): ExpenseDeletePopoverParams {
+    return {
       component: FyDeleteDialogComponent,
       cssClass: 'delete-dialog',
       backdropDismiss: false,
@@ -339,7 +338,13 @@ export class ViewPerDiemPage {
         ctaLoadingText: 'Removing',
         deleteMethod: () => this.reportService.removeTransaction(etxn.tx_report_id, etxn.tx_id),
       },
-    });
+    };
+  }
+
+  async removeExpenseFromReport(): Promise<void> {
+    const etxn = await this.transactionService.getEtxn(this.activatedRoute.snapshot.params.id as string).toPromise();
+
+    const deletePopover = await this.popoverController.create(this.getDeleteDialogProps(etxn));
 
     await deletePopover.present();
     const { data } = (await deletePopover.onDidDismiss()) as { data: { status: string } };


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd88928</samp>

This pull request enhances the `ViewPerDiemPage` component by adding new test cases, mock data, and a flagging popover. It also simplifies the code for deleting an expense from a per diem report by using a new interface and method.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dd88928</samp>

> _We're testing the `ViewPerDiemPage` with mock data and flags_
> _We're refactoring the code for deleting an expense_
> _Heave away, me hearties, heave away with skill_
> _We're making our component better with every pull_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dd88928</samp>

*  Extract the logic of creating the delete popover props into a separate method `getDeleteDialogProps` and use it in the `removeExpenseFromReport` method ([link](https://github.com/fylein/fyle-mobile-app/pull/2366/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L327-R329), [link](https://github.com/fylein/fyle-mobile-app/pull/2366/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L342-R348)) in `view-per-diem.page.ts`

## Clickup
https://app.clickup.com/t/85zt9c349

## Code Coverage
99.21% Statements 127/128
100% Branches 49/49
97.5% Functions 39/40
99.2% Lines 125/126

## UI Preview
Please add screenshots for UI changes