### PR TITLE
fix: eslint fix in task component

### DIFF
--- a/src/app/core/mock-data/task-cta.data.ts
+++ b/src/app/core/mock-data/task-cta.data.ts
@@ -40,3 +40,8 @@ export const taskCtaData8: TaskCta = {
   event: TASKEVENT.expensesCreateNewReport,
   content: 'Create New Report',
 };
+
+export const taskCtaData9: TaskCta = {
+  event: TASKEVENT.mobileNumberVerification,
+  content: 'Verify Mobile Number',
+};

--- a/src/app/core/mock-data/task-filters.data.ts
+++ b/src/app/core/mock-data/task-filters.data.ts
@@ -49,3 +49,26 @@ export const taskFiltersParams3: TaskFilters = {
   teamReports: false,
   sentBackAdvances: false,
 };
+
+export const taskFiltersParams4: TaskFilters = {
+  ...taskFiltersData2,
+  unreportedExpenses: true,
+  draftExpenses: true,
+  potentialDuplicates: true,
+};
+
+export const taskFiltersParams5: TaskFilters = {
+  ...taskFiltersData2,
+  draftReports: true,
+  sentBackReports: true,
+};
+
+export const taskFiltersParams6: TaskFilters = {
+  ...taskFiltersData2,
+  teamReports: true,
+};
+
+export const taskFiltersParams7: TaskFilters = {
+  ...taskFiltersData2,
+  sentBackAdvances: true,
+};

--- a/src/app/fyle/dashboard/tasks/tasks-1.component.spec.ts
+++ b/src/app/fyle/dashboard/tasks/tasks-1.component.spec.ts
@@ -334,7 +334,7 @@ export function TestCases1(getTestBed) {
           Asset: 'Mobile',
           header: dashboardTasksData[0].header,
         });
-        expect(component.onExpensesToReportTaskClick).toHaveBeenCalledOnceWith(taskCtaData, dashboardTasksData[0]);
+        expect(component.onExpensesToReportTaskClick).toHaveBeenCalledTimes(1);
         expect(component.onOpenDraftReportsTaskClick).not.toHaveBeenCalled();
         expect(component.onSentBackReportTaskClick).not.toHaveBeenCalled();
         expect(component.onReviewExpensesTaskClick).not.toHaveBeenCalled();
@@ -382,7 +382,7 @@ export function TestCases1(getTestBed) {
         expect(component.onExpensesToReportTaskClick).not.toHaveBeenCalled();
         expect(component.onOpenDraftReportsTaskClick).not.toHaveBeenCalled();
         expect(component.onSentBackReportTaskClick).not.toHaveBeenCalled();
-        expect(component.onReviewExpensesTaskClick).toHaveBeenCalledOnceWith(taskCtaData4, dashboardTasksData[0]);
+        expect(component.onReviewExpensesTaskClick).toHaveBeenCalledTimes(1);
         expect(component.onTeamReportsTaskClick).not.toHaveBeenCalled();
         expect(component.onPotentialDuplicatesTaskClick).not.toHaveBeenCalled();
         expect(component.onSentBackAdvanceTaskClick).not.toHaveBeenCalled();
@@ -414,7 +414,7 @@ export function TestCases1(getTestBed) {
         expect(component.onSentBackReportTaskClick).not.toHaveBeenCalled();
         expect(component.onReviewExpensesTaskClick).not.toHaveBeenCalled();
         expect(component.onTeamReportsTaskClick).not.toHaveBeenCalled();
-        expect(component.onPotentialDuplicatesTaskClick).toHaveBeenCalledOnceWith(taskCtaData6, dashboardTasksData[0]);
+        expect(component.onPotentialDuplicatesTaskClick).toHaveBeenCalledTimes(1);
         expect(component.onSentBackAdvanceTaskClick).not.toHaveBeenCalled();
       });
 

--- a/src/app/fyle/dashboard/tasks/tasks-1.component.spec.ts
+++ b/src/app/fyle/dashboard/tasks/tasks-1.component.spec.ts
@@ -38,6 +38,7 @@ import {
   taskCtaData6,
   taskCtaData7,
   taskCtaData8,
+  taskCtaData9,
 } from 'src/app/core/mock-data/task-cta.data';
 
 export function TestCases1(getTestBed) {
@@ -326,6 +327,7 @@ export function TestCases1(getTestBed) {
         spyOn(component, 'onTeamReportsTaskClick');
         spyOn(component, 'onPotentialDuplicatesTaskClick');
         spyOn(component, 'onSentBackAdvanceTaskClick');
+        spyOn(component, 'onMobileNumberVerificationTaskClick');
       });
 
       it('should call onExpensesToReportTaskClick if clicked on expensesAddToReport', () => {
@@ -431,6 +433,22 @@ export function TestCases1(getTestBed) {
         expect(component.onTeamReportsTaskClick).not.toHaveBeenCalled();
         expect(component.onPotentialDuplicatesTaskClick).not.toHaveBeenCalled();
         expect(component.onSentBackAdvanceTaskClick).toHaveBeenCalledOnceWith(taskCtaData7, dashboardTasksData[0]);
+      });
+
+      it('should call onMobileNumberVerificationTaskClick if clicked on mobileNumberVerification', () => {
+        component.onTaskClicked(taskCtaData9, dashboardTasksData[0]);
+        expect(trackingService.tasksClicked).toHaveBeenCalledOnceWith({
+          Asset: 'Mobile',
+          header: dashboardTasksData[0].header,
+        });
+        expect(component.onExpensesToReportTaskClick).not.toHaveBeenCalled();
+        expect(component.onOpenDraftReportsTaskClick).not.toHaveBeenCalled();
+        expect(component.onSentBackReportTaskClick).not.toHaveBeenCalled();
+        expect(component.onReviewExpensesTaskClick).not.toHaveBeenCalled();
+        expect(component.onTeamReportsTaskClick).not.toHaveBeenCalled();
+        expect(component.onPotentialDuplicatesTaskClick).not.toHaveBeenCalled();
+        expect(component.onSentBackAdvanceTaskClick).not.toHaveBeenCalled();
+        expect(component.onMobileNumberVerificationTaskClick).toHaveBeenCalledOnceWith(taskCtaData9);
       });
 
       it('should only call trackingService.tasksClicked if none of them matches', () => {

--- a/src/app/fyle/dashboard/tasks/tasks-2.component.spec.ts
+++ b/src/app/fyle/dashboard/tasks/tasks-2.component.spec.ts
@@ -1,0 +1,297 @@
+import { ComponentFixture, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { ModalController } from '@ionic/angular';
+
+import { TasksComponent } from './tasks.component';
+import { TasksService } from 'src/app/core/services/tasks.service';
+import { TransactionService } from 'src/app/core/services/transaction.service';
+import { ReportService } from 'src/app/core/services/report.service';
+import { AdvanceRequestService } from 'src/app/core/services/advance-request.service';
+import { TrackingService } from 'src/app/core/services/tracking.service';
+import { LoaderService } from 'src/app/core/services/loader.service';
+import { MatBottomSheet } from '@angular/material/bottom-sheet';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { AuthService } from 'src/app/core/services/auth.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NetworkService } from 'src/app/core/services/network.service';
+import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
+import { of } from 'rxjs';
+import { apiReportAutoSubmissionDetails } from 'src/app/core/mock-data/report-auto-submission-details.data';
+import { dashboardTasksData } from 'src/app/core/mock-data/dashboard-task.data';
+import { typeFilterPill } from 'src/app/core/mock-data/filter-pills.data';
+import {
+  taskFiltersData2,
+  taskFiltersParams4,
+  taskFiltersParams5,
+  taskFiltersParams6,
+  taskFiltersParams7,
+} from 'src/app/core/mock-data/task-filters.data';
+import { taskCtaData3, taskCtaData9 } from 'src/app/core/mock-data/task-cta.data';
+import { expenseList } from 'src/app/core/mock-data/expense.data';
+import { cloneDeep } from 'lodash';
+import {
+  mileageCategoryUnflattenedExpense,
+  perDiemCategoryUnflattenedExpense,
+  unflattenedTxnData,
+} from 'src/app/core/mock-data/unflattened-txn.data';
+import { apiReportRes } from 'src/app/core/mock-data/api-reports.data';
+
+export function TestCases2(getTestBed) {
+  return describe('test case set 2', () => {
+    let component: TasksComponent;
+    let fixture: ComponentFixture<TasksComponent>;
+    let tasksService: jasmine.SpyObj<TasksService>;
+    let transactionService: jasmine.SpyObj<TransactionService>;
+    let reportService: jasmine.SpyObj<ReportService>;
+    let advanceRequestService: jasmine.SpyObj<AdvanceRequestService>;
+    let modalController: jasmine.SpyObj<ModalController>;
+    let trackingService: jasmine.SpyObj<TrackingService>;
+    let loaderService: jasmine.SpyObj<LoaderService>;
+    let matBottomSheet: jasmine.SpyObj<MatBottomSheet>;
+    let matSnackBar: jasmine.SpyObj<MatSnackBar>;
+    let snackbarProperties: jasmine.SpyObj<SnackbarPropertiesService>;
+    let authService: jasmine.SpyObj<AuthService>;
+    let router: jasmine.SpyObj<Router>;
+    let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+    let networkService: jasmine.SpyObj<NetworkService>;
+
+    beforeEach(waitForAsync(() => {
+      const TestBed = getTestBed();
+      fixture = TestBed.createComponent(TasksComponent);
+      component = fixture.componentInstance;
+      tasksService = TestBed.inject(TasksService) as jasmine.SpyObj<TasksService>;
+      transactionService = TestBed.inject(TransactionService) as jasmine.SpyObj<TransactionService>;
+      reportService = TestBed.inject(ReportService) as jasmine.SpyObj<ReportService>;
+      advanceRequestService = TestBed.inject(AdvanceRequestService) as jasmine.SpyObj<AdvanceRequestService>;
+      modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
+      trackingService = TestBed.inject(TrackingService) as jasmine.SpyObj<TrackingService>;
+      loaderService = TestBed.inject(LoaderService) as jasmine.SpyObj<LoaderService>;
+      matBottomSheet = TestBed.inject(MatBottomSheet) as jasmine.SpyObj<MatBottomSheet>;
+      matSnackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
+      snackbarProperties = TestBed.inject(SnackbarPropertiesService) as jasmine.SpyObj<SnackbarPropertiesService>;
+      authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+      router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+      activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
+      networkService = TestBed.inject(NetworkService) as jasmine.SpyObj<NetworkService>;
+    }));
+
+    describe('init():', () => {
+      beforeEach(() => {
+        reportService.getReportAutoSubmissionDetails.and.returnValue(of(apiReportAutoSubmissionDetails));
+        tasksService.getTasks.and.returnValue(of(dashboardTasksData));
+        spyOn(component, 'trackTasks');
+        tasksService.generateFilterPills.and.returnValue([typeFilterPill]);
+      });
+
+      it('should set autoSubmissionReportDate$', () => {
+        component.init();
+        component.autoSubmissionReportDate$.subscribe((res) => {
+          expect(reportService.getReportAutoSubmissionDetails).toHaveBeenCalledTimes(1);
+          expect(res).toEqual(apiReportAutoSubmissionDetails.data.next_at);
+        });
+      });
+
+      it('should call trackTasks and set taskCount equals to total tasks', () => {
+        component.init();
+        component.tasks$.subscribe((res) => {
+          // Called 2 times as tasks$ will update again because we are changing loadData$ value
+          expect(tasksService.getTasks).toHaveBeenCalledTimes(2);
+          expect(tasksService.getTasks).toHaveBeenCalledWith(true, component.loadData$.getValue());
+          expect(component.trackTasks).toHaveBeenCalledTimes(2);
+          expect;
+          expect(component.taskCount).toEqual(dashboardTasksData.length);
+          expect(res).toEqual(dashboardTasksData);
+        });
+      });
+
+      it('should set showReportAutoSubmissionInfoCard to true if autoSubmissionReportDate is defined, no expenses are incomplete and filter is not equal to team_reports', () => {
+        component.init();
+        expect(component.showReportAutoSubmissionInfoCard).toBeTrue();
+      });
+
+      it('should set showReportAutoSubmissionInfoCard to false if autoSubmissionReportDate is defined, no expenses are incomplete and filter is equal to team_reports', () => {
+        activatedRoute.snapshot.queryParams = { tasksFilters: 'team_reports' };
+        component.init();
+        expect(component.showReportAutoSubmissionInfoCard).toBeFalse();
+      });
+
+      it('should set all parameters to false in loadData and call generateFilterPills if filter is none', () => {
+        component.init();
+        const loadDataValue = component.loadData$.getValue();
+        expect(loadDataValue).toEqual(taskFiltersData2);
+        expect(tasksService.generateFilterPills).toHaveBeenCalledOnceWith(loadDataValue);
+        expect(component.filterPills).toEqual([typeFilterPill]);
+      });
+
+      it('should set draftExpenses, unreportedExpenses and potentialDuplicates to true in loadData and call generateFilterPills if filter is expenses', () => {
+        activatedRoute.snapshot.queryParams = { tasksFilters: 'expenses' };
+        component.init();
+        const loadDataValue = component.loadData$.getValue();
+        expect(loadDataValue).toEqual(taskFiltersParams4);
+        expect(tasksService.generateFilterPills).toHaveBeenCalledOnceWith(loadDataValue);
+        expect(component.filterPills).toEqual([typeFilterPill]);
+      });
+
+      it('should set draftReports and sentBackReports to true in loadData and call generateFilterPills if filter is reports', () => {
+        activatedRoute.snapshot.queryParams = { tasksFilters: 'reports' };
+        component.init();
+        const loadDataValue = component.loadData$.getValue();
+        expect(loadDataValue).toEqual(taskFiltersParams5);
+        expect(tasksService.generateFilterPills).toHaveBeenCalledOnceWith(loadDataValue);
+        expect(component.filterPills).toEqual([typeFilterPill]);
+      });
+
+      it('should set teamReports to true in loadData and call generateFilterPills if filter is team_reports', () => {
+        activatedRoute.snapshot.queryParams = { tasksFilters: 'team_reports' };
+        component.init();
+        const loadDataValue = component.loadData$.getValue();
+        expect(loadDataValue).toEqual(taskFiltersParams6);
+        expect(tasksService.generateFilterPills).toHaveBeenCalledOnceWith(loadDataValue);
+        expect(component.filterPills).toEqual([typeFilterPill]);
+      });
+
+      it('should set sentBackAdvances to true in loadData and call generateFilterPills if filter is advances', () => {
+        activatedRoute.snapshot.queryParams = { tasksFilters: 'advances' };
+        component.init();
+        const loadDataValue = component.loadData$.getValue();
+        expect(loadDataValue).toEqual(taskFiltersParams7);
+        expect(tasksService.generateFilterPills).toHaveBeenCalledOnceWith(loadDataValue);
+        expect(component.filterPills).toEqual([typeFilterPill]);
+      });
+    });
+
+    describe('onMobileNumberVerificationTaskClick():', () => {
+      it('should navigate to my profile page with verify_mobile_number popover if content is not equal to Add', () => {
+        component.onMobileNumberVerificationTaskClick(taskCtaData9);
+        expect(router.navigate).toHaveBeenCalledOnceWith([
+          '/',
+          'enterprise',
+          'my_profile',
+          { openPopover: 'verify_mobile_number' },
+        ]);
+      });
+
+      it('should navigate to my profile page with add_mobile_number popover if content is Add', () => {
+        component.onMobileNumberVerificationTaskClick({ ...taskCtaData9, content: 'Add' });
+        expect(router.navigate).toHaveBeenCalledOnceWith([
+          '/',
+          'enterprise',
+          'my_profile',
+          { openPopover: 'add_mobile_number' },
+        ]);
+      });
+    });
+
+    describe('onReviewExpensesTaskClick():', () => {
+      beforeEach(() => {
+        loaderService.showLoader.and.resolveTo();
+        loaderService.hideLoader.and.resolveTo();
+        transactionService.getAllExpenses.and.returnValue(of(cloneDeep(expenseList)));
+        transactionService.getETxnUnflattened.and.returnValue(of(unflattenedTxnData));
+      });
+
+      it('should get all expenses and navigate to add_edit_mileage if category is of type mileage', fakeAsync(() => {
+        transactionService.getETxnUnflattened.and.returnValue(of(mileageCategoryUnflattenedExpense));
+        component.onReviewExpensesTaskClick();
+        tick(100);
+        expect(loaderService.showLoader).toHaveBeenCalledOnceWith('please wait while we load your expenses', 3000);
+        expect(transactionService.getAllExpenses).toHaveBeenCalledOnceWith({
+          queryParams: {
+            tx_state: 'in.(DRAFT)',
+            tx_report_id: 'is.null',
+          },
+        });
+        expect(transactionService.getETxnUnflattened).toHaveBeenCalledOnceWith(expenseList[0].tx_id);
+        expect(loaderService.hideLoader).toHaveBeenCalledTimes(1);
+        expect(router.navigate).toHaveBeenCalledOnceWith([
+          '/',
+          'enterprise',
+          'add_edit_mileage',
+          { id: mileageCategoryUnflattenedExpense.tx.id, txnIds: '["txBphgnCHHeO"]', activeIndex: 0 },
+        ]);
+      }));
+
+      it('should get all expenses and navigate to add_edit_per_diem if category is of type per diem', fakeAsync(() => {
+        transactionService.getETxnUnflattened.and.returnValue(of(perDiemCategoryUnflattenedExpense));
+        component.onReviewExpensesTaskClick();
+        tick(100);
+        expect(loaderService.showLoader).toHaveBeenCalledOnceWith('please wait while we load your expenses', 3000);
+        expect(transactionService.getAllExpenses).toHaveBeenCalledOnceWith({
+          queryParams: {
+            tx_state: 'in.(DRAFT)',
+            tx_report_id: 'is.null',
+          },
+        });
+        expect(transactionService.getETxnUnflattened).toHaveBeenCalledOnceWith(expenseList[0].tx_id);
+        expect(loaderService.hideLoader).toHaveBeenCalledTimes(1);
+        expect(router.navigate).toHaveBeenCalledOnceWith([
+          '/',
+          'enterprise',
+          'add_edit_per_diem',
+          { id: mileageCategoryUnflattenedExpense.tx.id, txnIds: '["txBphgnCHHeO"]', activeIndex: 0 },
+        ]);
+      }));
+
+      it('should get all expenses and navigate to add_edit_expense if category is other than mileage or per diem', fakeAsync(() => {
+        transactionService.getETxnUnflattened.and.returnValue(of(unflattenedTxnData));
+        component.onReviewExpensesTaskClick();
+        tick(100);
+        expect(loaderService.showLoader).toHaveBeenCalledOnceWith('please wait while we load your expenses', 3000);
+        expect(transactionService.getAllExpenses).toHaveBeenCalledOnceWith({
+          queryParams: {
+            tx_state: 'in.(DRAFT)',
+            tx_report_id: 'is.null',
+          },
+        });
+        expect(transactionService.getETxnUnflattened).toHaveBeenCalledOnceWith(expenseList[0].tx_id);
+        expect(loaderService.hideLoader).toHaveBeenCalledTimes(1);
+        expect(router.navigate).toHaveBeenCalledOnceWith([
+          '/',
+          'enterprise',
+          'add_edit_expense',
+          { id: mileageCategoryUnflattenedExpense.tx.id, txnIds: '["txBphgnCHHeO"]', activeIndex: 0 },
+        ]);
+      }));
+    });
+
+    describe('onSentBackReportTaskClick():', () => {
+      beforeEach(() => {
+        loaderService.showLoader.and.resolveTo();
+        loaderService.hideLoader.and.resolveTo();
+        reportService.getMyReports.and.returnValue(of(apiReportRes));
+      });
+
+      it('should get all reports and navigate to my view report page if task count is 1', fakeAsync(() => {
+        const mockDashboardTasksData = cloneDeep(dashboardTasksData);
+        mockDashboardTasksData[0].count = 1;
+        component.onSentBackReportTaskClick(taskCtaData3, mockDashboardTasksData[0]);
+        tick(100);
+        expect(loaderService.showLoader).toHaveBeenCalledOnceWith('Opening your report...');
+        expect(reportService.getMyReports).toHaveBeenCalledOnceWith({
+          queryParams: {
+            rp_state: 'in.(APPROVER_INQUIRY)',
+          },
+          offset: 0,
+          limit: 1,
+        });
+        expect(loaderService.hideLoader).toHaveBeenCalledTimes(1);
+        expect(router.navigate).toHaveBeenCalledOnceWith([
+          '/',
+          'enterprise',
+          'my_view_report',
+          { id: apiReportRes.data[0].rp_id },
+        ]);
+      }));
+
+      it('should navigate to my reports page if task count is greater than 1', fakeAsync(() => {
+        component.onSentBackReportTaskClick(taskCtaData3, dashboardTasksData[0]);
+        tick(100);
+        expect(loaderService.showLoader).not.toHaveBeenCalled();
+        expect(reportService.getMyReports).not.toHaveBeenCalled();
+        expect(loaderService.hideLoader).not.toHaveBeenCalled();
+        expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_reports'], {
+          queryParams: { filters: '{"state":["APPROVER_INQUIRY"]}' },
+        });
+      }));
+    });
+  });
+}

--- a/src/app/fyle/dashboard/tasks/tasks.component.setup.spec.ts
+++ b/src/app/fyle/dashboard/tasks/tasks.component.setup.spec.ts
@@ -17,6 +17,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TestCases1 } from './tasks-1.component.spec';
+import { TestCases2 } from './tasks-2.component.spec';
 
 describe('TasksComponent', () => {
   const getTestBed = () => {
@@ -93,4 +94,5 @@ describe('TasksComponent', () => {
   };
 
   TestCases1(getTestBed);
+  TestCases2(getTestBed);
 });


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18OlG04DANkaznlTDRX2JBGebHUUzv96Xw%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=3JDysjO)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb86def</samp>

This pull request improves the test code and the tasks component code in the fyle-mobile-app. It replaces custom Jasmine matchers with standard ones, adds type annotations and code formatting, and introduces a new feature to review expenses from the tasks page. It also preserves the old feature for backward compatibility.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bb86def</samp>

> _Sing, O Muse, of the valiant coder who refined the tasks component_
> _And made it more readable and robust with type annotations and format_
> _Who also added a new feature, wondrous and splendid, to review expenses_
> _And kept the old one, wise and prudent, for the sake of compatibility_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bb86def</samp>

*  Add type annotations for methods, parameters, and data in `tasks.component.ts` to improve type safety and clarity ([link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL4-R7), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aR28), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL71-R75), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL87-R88), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL112-R113), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL124-R125), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL188-R197), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL207-R213), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL272-R273), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL283-R284), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL315-R316), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL323-R324), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL349-R350), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL358-R359), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL364-R365), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL377-R378), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL458-R459), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL481-R482), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL505-R506), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL529-R530), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL552-R553), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL560-R565), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL578-R583), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL620-R624), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL643-R643))
*  Add trailing commas for code formatting and readability in `tasks.component.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL97-R100), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL398-R399), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL409-R413), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL467-R468), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL491-R492), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL515-R516), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL538-R539), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL595-R593), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL610-R607), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL620-R624))
*  Remove unused parameters from task click methods in `tasks.component.ts` to simplify the code ([link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL349-R350), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL358-R359), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL364-R365))
*  Rename `onReviewExpensesTaskClick` to `onReviewExpensesTaskClickOld` and add a new `onReviewExpensesTaskClick` method in `tasks.component.ts` to support a new feature of reviewing expenses from the tasks page ([link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-a646052e2d515354b5e202eaed31c842fb40a103ccecd0cc4f3190777d17859aL388-R389))
*  Replace `toHaveBeenCalledOnceWith` with `toHaveBeenCalledTimes` and `toHaveBeenCalledWith` in `tasks-1.component.spec.ts` to avoid using a custom matcher and use the official Jasmine library instead ([link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-ed36a74d3acc3b08e99b4a331f393340db8d132f10f6acb82a67598386ec9e34L337-R337), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-ed36a74d3acc3b08e99b4a331f393340db8d132f10f6acb82a67598386ec9e34L385-R385), [link](https://github.com/fylein/fyle-mobile-app/pull/2367/files?diff=unified&w=0#diff-ed36a74d3acc3b08e99b4a331f393340db8d132f10f6acb82a67598386ec9e34L417-R417))

## Clickup
https://app.clickup.com/t/85ztx3mbc

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes