### PR TITLE
fix: mat-form-field clear icon size

### DIFF
--- a/src/assets/styles/_fy_select.scss
+++ b/src/assets/styles/_fy_select.scss
@@ -104,6 +104,7 @@ $sub-title: #ababab;
     display: flex;
     align-items: center;
     padding: 0px;
+    font-size: 18px;
   }
 
   ::ng-deep .mdc-notched-outline > * {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba2c856</samp>

Increased font size of `fy-select` component in `src/assets/styles/_fy_select.scss` to improve UI of expense creation screen.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ba2c856</samp>

> _`fy-select` grows_
> _A UI refresh for spring_
> _Expenses look clear_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba2c856</samp>

*  Increased the font size of the fy-select component to 18px for better readability and consistency ([link](https://github.com/fylein/fyle-mobile-app/pull/2368/files?diff=unified&w=0#diff-482f64621779d5b22afc391b0cf914255a7f3ed8526e71830c6a34c4a243bec7R107))

## Clickup
https://app.clickup.com/t/85ztxhv1j

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes