### PR TITLE
fix: The cross button should be right aligned inside the input box

### DIFF
--- a/src/app/fyle/my-expenses/my-expenses.page.scss
+++ b/src/app/fyle/my-expenses/my-expenses.page.scss
@@ -117,7 +117,6 @@
     mat-form-field {
       ::ng-deep .mat-mdc-text-field-wrapper {
         padding-left: 6px;
-        padding-right: 6px;
       }
 
       ::ng-deep .mat-icon {
@@ -143,7 +142,6 @@
     }
 
     &-close {
-      margin: -10px;
       font-size: 18px;
     }
   }

--- a/src/app/fyle/my-reports/my-reports.page.scss
+++ b/src/app/fyle/my-reports/my-reports.page.scss
@@ -38,7 +38,6 @@
     mat-form-field {
       ::ng-deep .mat-mdc-text-field-wrapper {
         padding-left: 6px;
-        padding-right: 6px;
       }
 
       ::ng-deep .mat-icon {
@@ -64,7 +63,6 @@
     }
 
     &-close {
-      margin: -10px;
       font-size: 18px;
     }
   }

--- a/src/app/fyle/personal-cards/personal-cards.page.scss
+++ b/src/app/fyle/personal-cards/personal-cards.page.scss
@@ -294,7 +294,6 @@
     mat-form-field {
       ::ng-deep .mat-mdc-text-field-wrapper {
         padding-left: 6px;
-        padding-right: 6px;
       }
 
       ::ng-deep .mat-icon {
@@ -320,7 +319,6 @@
     }
 
     &-close {
-      margin: -10px;
       font-size: 18px;
       background-color: transparent;
       color: $black-light;

--- a/src/app/fyle/team-reports/team-reports.page.scss
+++ b/src/app/fyle/team-reports/team-reports.page.scss
@@ -38,7 +38,6 @@
     mat-form-field {
       ::ng-deep .mat-mdc-text-field-wrapper {
         padding-left: 6px;
-        padding-right: 6px;
       }
 
       ::ng-deep .mat-icon {
@@ -64,7 +63,6 @@
     }
 
     &-close {
-      margin: -10px;
       font-size: 18px;
     }
   }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e60fba3</samp>

This pull request fixes some UI issues with the card components on the my expenses, my reports, and personal cards pages. It improves the alignment and spacing of the card content by removing unnecessary padding and margin from the `ion-item` elements.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e60fba3</samp>

> _`ion-item` trimmed_
> _Card content aligned neatly_
> _Winter of whitespace_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e60fba3</samp>

*  Remove right padding from `ion-item` elements inside card components to align content with header and footer ([link](https://github.com/fylein/fyle-mobile-app/pull/2370/files?diff=unified&w=0#diff-e46d03de671d7f5a249945c81110d9112ec7ba3bfc3e8f6a838cb1b517a9f39cL120), [link](https://github.com/fylein/fyle-mobile-app/pull/2370/files?diff=unified&w=0#diff-aed7009d6846df8e844aa74f45c2f71faa878898b8c776cde8f8c5c51a6b7e05L41), [link](https://github.com/fylein/fyle-mobile-app/pull/2370/files?diff=unified&w=0#diff-d7d1cbc4f41ca8414e63721843777beabda33d2900b5a4cda1a6ea2f8f42bf83L297))
*  Remove negative margin from `ion-item` elements inside card components to prevent content from overlapping with border and maintain consistent margin ([link](https://github.com/fylein/fyle-mobile-app/pull/2370/files?diff=unified&w=0#diff-e46d03de671d7f5a249945c81110d9112ec7ba3bfc3e8f6a838cb1b517a9f39cL146), [link](https://github.com/fylein/fyle-mobile-app/pull/2370/files?diff=unified&w=0#diff-aed7009d6846df8e844aa74f45c2f71faa878898b8c776cde8f8c5c51a6b7e05L67), [link](https://github.com/fylein/fyle-mobile-app/pull/2370/files?diff=unified&w=0#diff-d7d1cbc4f41ca8414e63721843777beabda33d2900b5a4cda1a6ea2f8f42bf83L323))

## Clickup
https://app.clickup.com/t/85ztxauby

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes