### PR TITLE
fix: team-report search icon is not aligned

### DIFF
--- a/src/app/fyle/team-reports/team-reports.page.scss
+++ b/src/app/fyle/team-reports/team-reports.page.scss
@@ -69,7 +69,7 @@
 
   &--simple-search-block {
     display: flex;
-    vertical-align: baseline;
+    align-items: center;
   }
 
   &--primary-cta {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23cbd0f</samp>

Fixed UI alignment issue in team reports page by using `align-items` instead of `vertical-align` in `team-reports.page.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 23cbd0f</samp>

> _`vertical-align`_
> _cut by `align-items` now_
> _team reports in fall_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23cbd0f</samp>

* Fix the alignment of the simple search block elements in the team reports page by replacing `vertical-align` with `align-items` ([link](https://github.com/fylein/fyle-mobile-app/pull/2373/files?diff=unified&w=0#diff-eef8d754b76614a7b435d9aaf8cb7baf7b984463abcf47bfe33492a85921d6a8L72-R72))

## Clickup
https://app.clickup.com/t/85ztxjy0q

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes