### PR TITLE
test: Code Coverage: My Profile Page #1 Fixing Existing Tests

### DIFF
--- a/src/app/core/mock-data/extended-org-user.data.ts
+++ b/src/app/core/mock-data/extended-org-user.data.ts
@@ -399,3 +399,11 @@ export const eouFlattended: EouApiResponse = {
   dwolla_bank_account_added: true,
   ou_cost_center_ids: [13792, 13793, 13794, 14018, 13795, 13995, 9493, 9494, 13785, 13787, 13788, 13789, 13790, 13791],
 };
+
+export const eouWithNoAttempts: ExtendedOrgUser = {
+  ...apiEouRes,
+  ou: {
+    ...apiEouRes.ou,
+    mobile_verification_attempts_left: 0,
+  },
+};

--- a/src/app/core/mock-data/org-user-settings.data.ts
+++ b/src/app/core/mock-data/org-user-settings.data.ts
@@ -670,3 +670,11 @@ export const orgUserSettingsWoDefaultProject: OrgUserSettings = {
     default_project_id: null,
   },
 };
+
+export const orgUserSettingsWoInstaFyle: OrgUserSettings = {
+  ...orgUserSettingsData,
+  insta_fyle_settings: {
+    ...orgUserSettingsData.insta_fyle_settings,
+    allowed: true,
+  },
+};

--- a/src/app/core/models/copy-card-details.model.ts
+++ b/src/app/core/models/copy-card-details.model.ts
@@ -1,0 +1,7 @@
+export interface CopyCardDetails {
+  title: string;
+  content: string;
+  contentToCopy: string;
+  toastMessageContent: string;
+  isHidden?: boolean;
+}

--- a/src/app/core/models/event-data.model.ts
+++ b/src/app/core/models/event-data.model.ts
@@ -1,0 +1,7 @@
+import { Currency } from './currency.model';
+
+export interface EventData {
+  key: 'instaFyle' | 'defaultCurrency' | 'formAutofill';
+  isEnabled: boolean;
+  selectedCurrency?: Currency;
+}

--- a/src/app/core/models/preference-setting.model.ts
+++ b/src/app/core/models/preference-setting.model.ts
@@ -1,0 +1,8 @@
+export interface PreferenceSetting {
+  title: string;
+  content: string;
+  key: 'instaFyle' | 'defaultCurrency' | 'formAutofill';
+  defaultCurrency?: string;
+  isEnabled: boolean;
+  isAllowed: boolean;
+}

--- a/src/app/fyle/my-profile/my-profile.page.spec.ts
+++ b/src/app/fyle/my-profile/my-profile.page.spec.ts
@@ -422,13 +422,14 @@ describe('MyProfilePage', () => {
     }));
 
     it('should should show success toast message if there are no more attempts left', fakeAsync(() => {
+      component.eou$ = of(eouWithNoAttempts);
       const popoverSpy = jasmine.createSpyObj('updateMobileNumberPopover', ['present', 'onWillDismiss']);
       popoverSpy.onWillDismiss.and.resolveTo({ data: { action: 'SUCCESS' } });
       popoverController.create.and.returnValue(Promise.resolve(popoverSpy));
+      fixture.detectChanges();
 
       component.updateMobileNumber(eouWithNoAttempts);
       tick(500);
-      fixture.detectChanges();
 
       expect(popoverController.create).toHaveBeenCalledOnceWith({
         component: UpdateMobileNumberComponent,
@@ -444,7 +445,7 @@ describe('MyProfilePage', () => {
       expect(popoverSpy.present).toHaveBeenCalledTimes(1);
       expect(popoverSpy.onWillDismiss).toHaveBeenCalledTimes(1);
       expect(component.loadEou$.next).toHaveBeenCalledOnceWith(null);
-      expect(component.showToastMessage).not.toHaveBeenCalled();
+      expect(component.showToastMessage).toHaveBeenCalledOnceWith('Mobile Number Updated Successfully', 'success');
     }));
 
     it('should open add number popover and show error toast message if api returns error', fakeAsync(() => {

--- a/src/app/fyle/my-profile/my-profile.page.spec.ts
+++ b/src/app/fyle/my-profile/my-profile.page.spec.ts
@@ -397,7 +397,7 @@ describe('MyProfilePage', () => {
     it('should open edit number popover and show success toast message if update is successful', fakeAsync(() => {
       const popoverSpy = jasmine.createSpyObj('updateMobileNumberPopover', ['present', 'onWillDismiss']);
       popoverSpy.onWillDismiss.and.resolveTo({ data: { action: 'SUCCESS' } });
-      popoverController.create.and.returnValue(Promise.resolve(popoverSpy));
+      popoverController.create.and.resolveTo(popoverSpy);
 
       component.updateMobileNumber(apiEouRes);
       tick(500);
@@ -425,7 +425,7 @@ describe('MyProfilePage', () => {
       component.eou$ = of(eouWithNoAttempts);
       const popoverSpy = jasmine.createSpyObj('updateMobileNumberPopover', ['present', 'onWillDismiss']);
       popoverSpy.onWillDismiss.and.resolveTo({ data: { action: 'SUCCESS' } });
-      popoverController.create.and.returnValue(Promise.resolve(popoverSpy));
+      popoverController.create.and.resolveTo(popoverSpy);
       fixture.detectChanges();
 
       component.updateMobileNumber(eouWithNoAttempts);
@@ -451,7 +451,7 @@ describe('MyProfilePage', () => {
     it('should open add number popover and show error toast message if api returns error', fakeAsync(() => {
       const popoverSpy = jasmine.createSpyObj('updateMobileNumberPopover', ['present', 'onWillDismiss']);
       popoverSpy.onWillDismiss.and.resolveTo({ data: { action: 'ERROR' } });
-      popoverController.create.and.returnValue(Promise.resolve(popoverSpy));
+      popoverController.create.and.resolveTo(popoverSpy);
 
       const eouWithoutMobileNumber = {
         ...apiEouRes,

--- a/src/app/fyle/my-profile/my-profile.page.ts
+++ b/src/app/fyle/my-profile/my-profile.page.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute } from '@angular/router';
 import { PopoverController } from '@ionic/angular';
 import { BehaviorSubject, Observable, Subscription, concat, forkJoin, from, noop } from 'rxjs';
 import { finalize, shareReplay, switchMap, take } from 'rxjs/operators';
-import { Currency } from 'src/app/core/models/currency.model';
 import { ExtendedOrgUser } from 'src/app/core/models/extended-org-user.model';
 import { InfoCardData } from 'src/app/core/models/info-card-data.model';
 import { Org } from 'src/app/core/models/org.model';
@@ -30,29 +29,9 @@ import { UpdateMobileNumberComponent } from './update-mobile-number/update-mobil
 import { VerifyNumberPopoverComponent } from './verify-number-popover/verify-number-popover.component';
 import { OrgSettings } from 'src/app/core/models/org-settings.model';
 import { OverlayResponse } from 'src/app/core/models/overlay-response.modal';
-
-type EventData = {
-  key: 'instaFyle' | 'defaultCurrency' | 'formAutofill';
-  isEnabled: boolean;
-  selectedCurrency?: Currency;
-};
-
-type PreferenceSetting = {
-  title: string;
-  content: string;
-  key: 'instaFyle' | 'defaultCurrency' | 'formAutofill';
-  defaultCurrency?: string;
-  isEnabled: boolean;
-  isAllowed: boolean;
-};
-
-type CopyCardDetails = {
-  title: string;
-  content: string;
-  contentToCopy: string;
-  toastMessageContent: string;
-  isHidden?: boolean;
-};
+import { EventData } from 'src/app/core/models/event-data.model';
+import { PreferenceSetting } from 'src/app/core/models/preference-setting.model';
+import { CopyCardDetails } from 'src/app/core/models/copy-card-details.model';
 
 @Component({
   selector: 'app-my-profile',


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 81c8ae1</samp>

This pull request adds and updates tests for the my profile page, especially for the mobile verification feature. It also removes some unused code and data from the my profile page spec file and the core mock data file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 81c8ae1</samp>

> _No more attempts to verify your phone_
> _You face the doom of the extended org_
> _The tests are fixed, the code is clean_
> _The popover mocks your mobile screen_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 81c8ae1</samp>

*  Add a new mock data object for an extended org user with no mobile verification attempts left ([link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-5e3f73aed0f96e97665e87dce92c5ca84889c41aa6cac07b6ec28ffff11f9d46R402-R409))
*  Import RouterTestingModule and VerifyNumberPopoverComponent in the spec file ([link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L2-R29))
*  Remove OrgUserService provider and postOrgUser mock data from the spec file ([link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L48-R145))
*  Move fixture and component initialization to the end of the providers array in the TestBed configuration ([link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L119-R164))
*  Enable and rewrite tests for the setInfoCardsData method, which sets the data for the info cards based on the org currency and the mobile verification status ([link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L139-R173))
*  Use the correct variable name snackbarProperties for the SnackbarPropertiesService provider in the showToastMessage method tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L173-R185), [link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L180-R192), [link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L201-R209), [link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L208-R216), [link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L229-R233), [link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L236-R243))
*  Use the correct spy name and method for the popover in the showSuccessPopover method test ([link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L247-R268))
*  Rewrite tests for the verifyMobileNumber method, using the VerifyNumberPopoverComponent component and adding the trackingService and loadEou$ expectations ([link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L280-R390))
*  Add the popoverController.create expectation and the updateMobileNumberPopover spy in the updateMobileNumber method test ([link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L341-R400))
*  Add a new test for the updateMobileNumber method, to check the case when there are no more attempts left for mobile verification ([link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L366-R453))
*  Remove the orgUserService.postOrgUser expectation from the updateMobileNumber method test ([link](https://github.com/fylein/fyle-mobile-app/pull/2381/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L394-R483))

## Clickup
https://app.clickup.com/t/85ztx3p2z

## Code Coverage
`52.67% Statements 59/112
`52.38% Branches 22/42`
`34.61% Functions 9/26`
`53.27% Lines 57/107`

## UI Preview
Please add screenshots for UI changes