### PR TITLE
test: Code Coverage: My Profile Page #3

### DIFF
--- a/src/app/fyle/my-profile/my-profile.page.spec.ts
+++ b/src/app/fyle/my-profile/my-profile.page.spec.ts
@@ -343,6 +343,27 @@ describe('MyProfilePage', () => {
       expect(component.reset).toHaveBeenCalledTimes(1);
       expect(component.verifyMobileNumber).toHaveBeenCalledOnceWith(apiEouRes);
     }));
+
+    it('should not open any modal if open popover is not passed as a param', fakeAsync(() => {
+      spyOn(component, 'setupNetworkWatcher');
+      authService.getEou.and.resolveTo(apiEouRes);
+      tokenService.getClusterDomain.and.resolveTo('domain');
+      spyOn(component, 'reset');
+      spyOn(component, 'verifyMobileNumber');
+      spyOn(component, 'updateMobileNumber');
+      activatedRoute.snapshot.params.openPopover = null;
+      fixture.detectChanges();
+
+      component.ionViewWillEnter();
+      tick(1000);
+
+      expect(component.setupNetworkWatcher).toHaveBeenCalledTimes(1);
+      expect(authService.getEou).not.toHaveBeenCalled();
+      expect(tokenService.getClusterDomain).toHaveBeenCalledTimes(1);
+      expect(component.reset).toHaveBeenCalledTimes(1);
+      expect(component.verifyMobileNumber).not.toHaveBeenCalled();
+      expect(component.updateMobileNumber).not.toHaveBeenCalled();
+    }));
   });
 
   it('reset(): should reset all settings', fakeAsync(() => {

--- a/src/app/fyle/my-profile/my-profile.page.spec.ts
+++ b/src/app/fyle/my-profile/my-profile.page.spec.ts
@@ -30,6 +30,7 @@ import { TrackingService } from '../../core/services/tracking.service';
 import { MyProfilePage } from './my-profile.page';
 import { UpdateMobileNumberComponent } from './update-mobile-number/update-mobile-number.component';
 import { VerifyNumberPopoverComponent } from './verify-number-popover/verify-number-popover.component';
+import { orgData1 } from 'src/app/core/mock-data/org.data';
 
 describe('MyProfilePage', () => {
   let component: MyProfilePage;
@@ -78,6 +79,16 @@ describe('MyProfilePage', () => {
       declarations: [MyProfilePage],
       imports: [IonicModule.forRoot(), RouterTestingModule],
       providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              params: {
+                openPopover: '',
+              },
+            },
+          },
+        },
         {
           provide: AuthService,
           useValue: authServiceSpy,
@@ -164,6 +175,7 @@ describe('MyProfilePage', () => {
     popoverController = TestBed.inject(PopoverController) as jasmine.SpyObj<PopoverController>;
     matSnackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
     snackbarProperties = TestBed.inject(SnackbarPropertiesService) as jasmine.SpyObj<SnackbarPropertiesService>;
+    activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
 
     component.loadEou$ = new BehaviorSubject(null);
     component.eou$ = of(apiEouRes);
@@ -292,6 +304,71 @@ describe('MyProfilePage', () => {
       });
     });
   });
+
+  describe('ionViewWillEnter():', () => {
+    it('should setup class observables and show update mobile number modal', fakeAsync(() => {
+      spyOn(component, 'setupNetworkWatcher');
+      authService.getEou.and.resolveTo(apiEouRes);
+      tokenService.getClusterDomain.and.resolveTo('domain');
+      spyOn(component, 'reset');
+      spyOn(component, 'updateMobileNumber');
+      activatedRoute.snapshot.params.openPopover = 'add_mobile_number';
+      fixture.detectChanges();
+
+      component.ionViewWillEnter();
+      tick(500);
+
+      expect(component.setupNetworkWatcher).toHaveBeenCalledTimes(1);
+      expect(authService.getEou).toHaveBeenCalledTimes(1);
+      expect(tokenService.getClusterDomain).toHaveBeenCalledTimes(1);
+      expect(component.reset).toHaveBeenCalledTimes(1);
+      expect(component.updateMobileNumber).toHaveBeenCalledOnceWith(apiEouRes);
+    }));
+
+    it('should setup class observables and show verify mobile number modal', fakeAsync(() => {
+      spyOn(component, 'setupNetworkWatcher');
+      authService.getEou.and.resolveTo(apiEouRes);
+      tokenService.getClusterDomain.and.resolveTo('domain');
+      spyOn(component, 'reset');
+      spyOn(component, 'verifyMobileNumber');
+      activatedRoute.snapshot.params.openPopover = 'verify_mobile_number';
+      fixture.detectChanges();
+
+      component.ionViewWillEnter();
+      tick(1000);
+
+      expect(component.setupNetworkWatcher).toHaveBeenCalledTimes(1);
+      expect(authService.getEou).toHaveBeenCalledTimes(1);
+      expect(tokenService.getClusterDomain).toHaveBeenCalledTimes(1);
+      expect(component.reset).toHaveBeenCalledTimes(1);
+      expect(component.verifyMobileNumber).toHaveBeenCalledOnceWith(apiEouRes);
+    }));
+  });
+
+  it('reset(): should reset all settings', fakeAsync(() => {
+    orgUserSettingsService.get.and.returnValue(of(orgUserSettingsData));
+    orgService.getCurrentOrg.and.returnValue(of(orgData1[0]));
+    orgSettingsService.get.and.returnValue(of(orgSettingsData));
+    loaderService.showLoader.and.resolveTo();
+    loaderService.hideLoader.and.resolveTo();
+    spyOn(component, 'setInfoCardsData');
+    spyOn(component, 'setPreferenceSettings');
+    fixture.detectChanges();
+
+    component.reset();
+    tick(500);
+
+    expect(orgUserSettingsService.get).toHaveBeenCalledTimes(1);
+    expect(orgService.getCurrentOrg).toHaveBeenCalledTimes(1);
+    expect(orgSettingsService.get).toHaveBeenCalledTimes(1);
+    expect(component.setInfoCardsData).toHaveBeenCalledOnceWith(apiEouRes);
+    expect(component.setPreferenceSettings).toHaveBeenCalledTimes(1);
+    expect(loaderService.showLoader).toHaveBeenCalledTimes(1);
+    expect(loaderService.hideLoader).toHaveBeenCalledTimes(1);
+
+    expect(component.orgUserSettings).toEqual(orgUserSettingsData);
+    expect(component.orgSettings).toEqual(orgSettingsData);
+  }));
 
   it('setPreferenceSettings(): should set preference settings', () => {
     component.orgSettings = orgSettingsData;


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c87a2a</samp>

This pull request improves the test coverage and functionality of the `my-profile` page component. It uses mock data and services to test different scenarios and modals. It also adds a dependency on the `ActivatedRoute` service.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1c87a2a</samp>

> _We mock the data and spy on the calls_
> _We test the component in all its forms_
> _We use the route to trigger the modals_
> _We are the masters of the my-profile storm_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c87a2a</samp>

*  Import mock org data for testing the my-profile page component ([link](https://github.com/fylein/fyle-mobile-app/pull/2383/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5R33))
*  Add provider for activated route service and mock the openPopover parameter ([link](https://github.com/fylein/fyle-mobile-app/pull/2383/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5R83-R92))
*  Assign activated route service to a variable for spying on its snapshot property ([link](https://github.com/fylein/fyle-mobile-app/pull/2383/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5R178))
*  Test the ionViewWillEnter method of the my-profile page component, which sets up the network watcher, gets the current user and org data, and calls the reset and modal methods ([link](https://github.com/fylein/fyle-mobile-app/pull/2383/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5R308-R372))
*  Test the reset method of the my-profile page component, which gets the org user and org settings, and sets the info cards and preference settings ([link](https://github.com/fylein/fyle-mobile-app/pull/2383/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5R308-R372))

## Clickup
https://app.clickup.com/t/85ztx3p2z

## Code Coverage
`97.32% Statements 109/112`
`97.61% Branches 41/42`
`100% Functions 26/26`
`97.19% Lines 104/107`

## UI Preview
Please add screenshots for UI changes