### PR TITLE
test: Unified card enrollment flow remaining branches code coverage

### DIFF
--- a/src/app/core/mock-data/ccc-expense.details.data.ts
+++ b/src/app/core/mock-data/ccc-expense.details.data.ts
@@ -59,9 +59,9 @@ export const expectedAssignedCCCStats: CCCDetails = {
   ],
 };
 
-export const mastercardRTFCCCStats: CCCDetails = {
-  totalTxns: 6,
-  totalAmount: 937.2,
+export const mastercardCCCStats: CCCDetails = {
+  totalTxns: 12,
+  totalAmount: 1874.4,
   cardDetails: [
     {
       aggregates: [
@@ -86,6 +86,32 @@ export const mastercardRTFCCCStats: CCCDetails = {
         {
           column_name: 'tx_state',
           column_value: 'DRAFT',
+        },
+      ],
+    },
+    {
+      aggregates: [
+        {
+          function_name: 'count(tx_id)',
+          function_value: 6,
+        },
+        {
+          function_name: 'sum(tx_amount)',
+          function_value: 937.2,
+        },
+      ],
+      key: [
+        {
+          column_name: 'corporate_credit_card_bank_name',
+          column_value: 'MASTERCARD_BANK',
+        },
+        {
+          column_name: 'corporate_credit_card_account_number',
+          column_value: '5555',
+        },
+        {
+          column_name: 'tx_state',
+          column_value: 'COMPLETE',
         },
       ],
     },

--- a/src/app/core/mock-data/platform-corporate-card-detail-data.ts
+++ b/src/app/core/mock-data/platform-corporate-card-detail-data.ts
@@ -36,3 +36,17 @@ export const cardDetailsRes: PlatformCorporateCardDetail[] = [
     },
   },
 ];
+
+export const statementUploadedCardDetail: PlatformCorporateCardDetail[] = [
+  {
+    card: statementUploadedCard,
+    stats: {
+      totalDraftTxns: 6,
+      totalDraftValue: 937.2,
+      totalCompleteTxns: 6,
+      totalCompleteExpensesValue: 937.2,
+      totalTxnsCount: 12,
+      totalAmountValue: 1874.4,
+    },
+  },
+];

--- a/src/app/core/mock-data/platform-corporate-card.data.ts
+++ b/src/app/core/mock-data/platform-corporate-card.data.ts
@@ -50,7 +50,7 @@ export const visaRTFCard: PlatformCorporateCard = {
 export const statementUploadedCard: PlatformCorporateCard = {
   assignor_user_id: 'usvKA4X8Ugcr',
   bank_name: 'MASTERCARD_BANK',
-  card_number: '555555******5555',
+  card_number: '5555',
   cardholder_name: null,
   code: null,
   created_at: '2023-03-03T07:16:46.376082+00:00',

--- a/src/app/core/services/corporate-credit-card-expense.service.spec.ts
+++ b/src/app/core/services/corporate-credit-card-expense.service.spec.ts
@@ -13,12 +13,13 @@ import { cardAggregateStatParam } from '../mock-data/card-aggregate-stats.data';
 import { DateService } from './date.service';
 import { expectedUniqueCardStats } from '../mock-data/unique-cards-stats.data';
 import { apiAssignedCardDetailsRes } from '../mock-data/stats-response.data';
-import { expectedAssignedCCCStats } from '../mock-data/ccc-expense.details.data';
+import { expectedAssignedCCCStats, mastercardCCCStats } from '../mock-data/ccc-expense.details.data';
 import { apiEouRes } from '../mock-data/extended-org-user.data';
 import { eCCCApiResponse } from '../mock-data/corporate-card-expense-flattened.data';
-import { mastercardRTFCard } from '../mock-data/platform-corporate-card.data';
+import { mastercardRTFCard, statementUploadedCard } from '../mock-data/platform-corporate-card.data';
 import { StatsResponse } from '../models/v2/stats-response.model';
 import { bankFeedSourcesData } from '../mock-data/bank-feed-sources.data';
+import { statementUploadedCardDetail } from '../mock-data/platform-corporate-card-detail-data';
 
 describe('CorporateCreditCardExpenseService', () => {
   let cccExpenseService: CorporateCreditCardExpenseService;
@@ -64,7 +65,7 @@ describe('CorporateCreditCardExpenseService', () => {
     apiV2Service = TestBed.inject(ApiV2Service) as jasmine.SpyObj<ApiV2Service>;
     authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
     spenderPlatformV1ApiService = TestBed.inject(
-      SpenderPlatformV1ApiService
+      SpenderPlatformV1ApiService,
     ) as jasmine.SpyObj<SpenderPlatformV1ApiService>;
     dataTransformService = TestBed.inject(DataTransformService);
     dateService = TestBed.inject(DateService) as jasmine.SpyObj<DateService>;
@@ -126,7 +127,7 @@ describe('CorporateCreditCardExpenseService', () => {
           queryParams +
           '&corporate_credit_card_account_number=not.is.null&debit=is.true&tx_org_user_id=eq.' +
           apiEouRes.ou.id,
-        {}
+        {},
       );
       expect(cccExpenseService.constructInQueryParamStringForV2).toHaveBeenCalledOnceWith(['COMPLETE', 'DRAFT']);
       done();
@@ -137,6 +138,15 @@ describe('CorporateCreditCardExpenseService', () => {
     const result = cccExpenseService.getExpenseDetailsInCards(uniqueCardsParam, cardAggregateStatParam);
 
     expect(result).toEqual(expectedUniqueCardStats);
+  });
+
+  it('getPlatformCorporateCardDetails(): should get expense details in platform card', () => {
+    const result = cccExpenseService.getPlatformCorporateCardDetails(
+      [statementUploadedCard],
+      mastercardCCCStats.cardDetails,
+    );
+
+    expect(result).toEqual(statementUploadedCardDetail);
   });
 
   it('getv2CardTransactions(): should get all card transactions', (done) => {

--- a/src/app/core/services/corporate-credit-card-expense.service.spec.ts
+++ b/src/app/core/services/corporate-credit-card-expense.service.spec.ts
@@ -140,7 +140,7 @@ describe('CorporateCreditCardExpenseService', () => {
     expect(result).toEqual(expectedUniqueCardStats);
   });
 
-  it('getPlatformCorporateCardDetails(): should get expense details in platform card', () => {
+  it('getPlatformCorporateCardDetails(): should get corporate card details', () => {
     const result = cccExpenseService.getPlatformCorporateCardDetails(
       [statementUploadedCard],
       mastercardCCCStats.cardDetails,

--- a/src/app/core/services/real-time-feed.service.spec.ts
+++ b/src/app/core/services/real-time-feed.service.spec.ts
@@ -155,7 +155,7 @@ describe('RealTimeFeedService', () => {
   });
 
   describe('unenroll()', () => {
-    it('should handle unenrollment of visa rtf cards', () => {
+    it('should unenroll visa rtf card when VISA card is passed', () => {
       spyOn(realTimeFeedService, 'getCardType').and.returnValue(CardNetworkType.VISA);
       spenderPlatformV1ApiService.post.and.returnValue(of(null));
 
@@ -170,7 +170,7 @@ describe('RealTimeFeedService', () => {
       });
     });
 
-    it('should handle unenrollment of mastercard rtf cards', () => {
+    it('should unenroll mastercard rtf card when Mastercard card is passed', () => {
       spyOn(realTimeFeedService, 'getCardType').and.returnValue(CardNetworkType.MASTERCARD);
       spenderPlatformV1ApiService.post.and.returnValue(of(null));
 

--- a/src/app/core/services/real-time-feed.service.ts
+++ b/src/app/core/services/real-time-feed.service.ts
@@ -52,13 +52,14 @@ export class RealTimeFeedService {
     return checksum % 10 === 0;
   }
 
-  unenroll(cardType: CardNetworkType, cardId: string): Observable<void> {
-    const card: PlatformApiPayload<UnenrollCardPayload> = {
+  unenroll(card: PlatformCorporateCard): Observable<void> {
+    const cardToUnenroll: PlatformApiPayload<UnenrollCardPayload> = {
       data: {
-        id: cardId,
+        id: card.id,
       },
     };
 
+    const cardType = this.getCardType(card);
     let endpoint: string;
 
     switch (cardType) {
@@ -74,7 +75,7 @@ export class RealTimeFeedService {
         throw new Error(`Invalid card type ${cardType}`);
     }
 
-    return this.spenderPlatformV1ApiService.post<void>(endpoint, card);
+    return this.spenderPlatformV1ApiService.post<void>(endpoint, cardToUnenroll);
   }
 
   enroll(cardNumber: string, cardId?: string): Observable<PlatformCorporateCard> {
@@ -109,7 +110,7 @@ export class RealTimeFeedService {
       catchError((err: HttpErrorResponse) => {
         const error = err.error as PlatformApiError;
         return throwError(() => Error(error.message));
-      })
+      }),
     );
   }
 

--- a/src/app/fyle/dashboard/card-stats/card-stats.component.spec.ts
+++ b/src/app/fyle/dashboard/card-stats/card-stats.component.spec.ts
@@ -17,7 +17,7 @@ import {
   orgSettingsRTFDisabled,
 } from 'src/app/core/mock-data/org-settings.data';
 import { orgUserSettingsData } from 'src/app/core/mock-data/org-user-settings.data';
-import { emptyCCCStats, mastercardRTFCCCStats } from 'src/app/core/mock-data/ccc-expense.details.data';
+import { emptyCCCStats, mastercardCCCStats } from 'src/app/core/mock-data/ccc-expense.details.data';
 import { mastercardRTFCard } from 'src/app/core/mock-data/platform-corporate-card.data';
 import { By } from '@angular/platform-browser';
 import { cardDetailsRes } from 'src/app/core/mock-data/platform-corporate-card-detail-data';
@@ -49,7 +49,7 @@ class MockAddCardComponent {
 
 describe('CardStatsComponent', () => {
   const cards = [mastercardRTFCard];
-  const cardStats = mastercardRTFCCCStats;
+  const cardStats = mastercardCCCStats;
   const cardDetails = [cardDetailsRes[1]];
 
   let component: CardStatsComponent;

--- a/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
+++ b/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
@@ -9,7 +9,7 @@ import { NgxMaskModule } from 'ngx-mask';
 import { ReactiveFormsModule } from '@angular/forms';
 import { Component, Input } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { visaRTFCard } from 'src/app/core/mock-data/platform-corporate-card.data';
+import { statementUploadedCard, visaRTFCard } from 'src/app/core/mock-data/platform-corporate-card.data';
 import { of, throwError } from 'rxjs';
 import { CardNetworkType } from 'src/app/core/enums/card-network-type';
 
@@ -177,7 +177,7 @@ describe('AddCorporateCardComponent', () => {
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
       expect(errorMessage.innerText).toBe(
-        'Enter a valid Mastercard number. If you have other cards, please contact your admin.'
+        'Enter a valid Mastercard number. If you have other cards, please contact your admin.',
       );
     });
 
@@ -201,7 +201,7 @@ describe('AddCorporateCardComponent', () => {
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
       expect(errorMessage.innerText).toBe(
-        'Enter a valid Visa number. If you have other cards, please contact your admin.'
+        'Enter a valid Visa number. If you have other cards, please contact your admin.',
       );
     });
 
@@ -225,13 +225,13 @@ describe('AddCorporateCardComponent', () => {
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
       expect(errorMessage.innerText).toBe(
-        'Enter a valid Visa or Mastercard number. If you have other cards, please contact your admin.'
+        'Enter a valid Visa or Mastercard number. If you have other cards, please contact your admin.',
       );
     });
   });
 
   describe('card enrollment flow', () => {
-    it('should successfully enroll the card and close the popover if the user clicks on add corporate card button with a valid card number', () => {
+    it('should successfully enroll the card and close the popover', () => {
       realTimeFeedService.isCardNumberValid.and.returnValue(true);
       realTimeFeedService.getCardTypeFromNumber.and.returnValue(CardNetworkType.VISA);
       realTimeFeedService.enroll.and.returnValue(of(visaRTFCard));
@@ -251,6 +251,31 @@ describe('AddCorporateCardComponent', () => {
       fixture.detectChanges();
 
       expect(realTimeFeedService.enroll).toHaveBeenCalledOnceWith('4555555555555555', null);
+      expect(popoverController.dismiss).toHaveBeenCalledOnceWith({ success: true });
+    });
+
+    it('should successfully enroll an existing card to rtf and close the popover', () => {
+      realTimeFeedService.isCardNumberValid.and.returnValue(true);
+      realTimeFeedService.getCardTypeFromNumber.and.returnValue(CardNetworkType.VISA);
+      realTimeFeedService.enroll.and.returnValue(of(visaRTFCard));
+
+      component.card = statementUploadedCard;
+
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      const cardNumberInput = getElementBySelector(fixture, '[data-testid="card-number-input"]') as HTMLInputElement;
+      cardNumberInput.value = '4555555555555555';
+      cardNumberInput.dispatchEvent(new Event('input'));
+
+      fixture.detectChanges();
+
+      const addCorporateCardBtn = getElementBySelector(fixture, '[data-testid="add-btn"]') as HTMLButtonElement;
+      addCorporateCardBtn.click();
+
+      fixture.detectChanges();
+
+      expect(realTimeFeedService.enroll).toHaveBeenCalledOnceWith('4555555555555555', statementUploadedCard.id);
       expect(popoverController.dismiss).toHaveBeenCalledOnceWith({ success: true });
     });
 
@@ -306,7 +331,7 @@ describe('AddCorporateCardComponent', () => {
       expect(errorMessage.innerText).toBe('Something went wrong. Please try after some time.');
     });
 
-    it('should disallow card enrollment if the user clicks on add corporate card button but the card number is invalid', () => {
+    it('should disallow card enrollment if the entered card number is invalid', () => {
       realTimeFeedService.isCardNumberValid.and.returnValue(false);
       realTimeFeedService.getCardTypeFromNumber.and.returnValue(CardNetworkType.VISA);
 
@@ -346,7 +371,7 @@ describe('AddCorporateCardComponent', () => {
       expect(alertMessageComponent).toBeTruthy();
       expect(alertMessageComponent.componentInstance.type).toBe('information');
       expect(alertMessageComponent.componentInstance.message).toBe(
-        'Enter a valid Visa or Mastercard number. If you have other cards, please add them on Fyle Web or contact your admin.'
+        'Enter a valid Visa or Mastercard number. If you have other cards, please add them on Fyle Web or contact your admin.',
       );
 
       const addCorporateCardBtn = getElementBySelector(fixture, '[data-testid="add-btn"]') as HTMLButtonElement;

--- a/src/app/fyle/manage-corporate-cards/manage-corporate-cards.page.spec.ts
+++ b/src/app/fyle/manage-corporate-cards/manage-corporate-cards.page.spec.ts
@@ -356,7 +356,7 @@ describe('ManageCorporateCardsPage', () => {
       });
 
       expect(disconnectPopoverSpy.present).toHaveBeenCalledTimes(1);
-      expect(realTimeFeedService.unenroll).toHaveBeenCalledOnceWith(CardNetworkType.VISA, visaRTFCard.id);
+      expect(realTimeFeedService.unenroll).toHaveBeenCalledOnceWith(visaRTFCard);
       expect(corporateCreditCardExpenseService.clearCache).toHaveBeenCalledTimes(1);
       expect(component.loadCorporateCards$.next).toHaveBeenCalledTimes(1);
     }));

--- a/src/app/fyle/manage-corporate-cards/manage-corporate-cards.page.ts
+++ b/src/app/fyle/manage-corporate-cards/manage-corporate-cards.page.ts
@@ -38,7 +38,7 @@ export class ManageCorporateCardsPage {
     private popoverController: PopoverController,
     private orgSettingsService: OrgSettingsService,
     private orgUserSettingsService: OrgUserSettingsService,
-    private realTimeFeedService: RealTimeFeedService
+    private realTimeFeedService: RealTimeFeedService,
   ) {}
 
   refresh(event: RefresherCustomEvent): void {
@@ -54,21 +54,23 @@ export class ManageCorporateCardsPage {
 
   ionViewWillEnter(): void {
     this.corporateCards$ = this.loadCorporateCards$.pipe(
-      switchMap(() => this.corporateCreditCardExpenseService.getCorporateCards())
+      switchMap(() => this.corporateCreditCardExpenseService.getCorporateCards()),
     );
 
     const orgSettings$ = this.orgSettingsService.get();
     const orgUserSettings$ = this.orgUserSettingsService.get();
 
     this.isVisaRTFEnabled$ = orgSettings$.pipe(
-      map((orgSettings) => orgSettings.visa_enrollment_settings.allowed && orgSettings.visa_enrollment_settings.enabled)
+      map(
+        (orgSettings) => orgSettings.visa_enrollment_settings.allowed && orgSettings.visa_enrollment_settings.enabled,
+      ),
     );
 
     this.isMastercardRTFEnabled$ = orgSettings$.pipe(
       map(
         (orgSettings) =>
-          orgSettings.mastercard_enrollment_settings.allowed && orgSettings.mastercard_enrollment_settings.enabled
-      )
+          orgSettings.mastercard_enrollment_settings.allowed && orgSettings.mastercard_enrollment_settings.enabled,
+      ),
     );
 
     this.isYodleeEnabled$ = forkJoin([orgSettings$, orgUserSettings$]).pipe(
@@ -76,8 +78,8 @@ export class ManageCorporateCardsPage {
         ([orgSettings, orgUserSettings]) =>
           orgSettings.bank_data_aggregation_settings.allowed &&
           orgSettings.bank_data_aggregation_settings.enabled &&
-          orgUserSettings.bank_data_aggregation_settings.enabled
-      )
+          orgUserSettings.bank_data_aggregation_settings.enabled,
+      ),
     );
   }
 
@@ -116,7 +118,7 @@ export class ManageCorporateCardsPage {
         }
 
         return actionSheetButtons;
-      })
+      }),
     );
   }
 
@@ -153,7 +155,7 @@ export class ManageCorporateCardsPage {
         if (popoverResponse.data?.success) {
           this.handleEnrollmentSuccess();
         }
-      }
+      },
     );
   }
 
@@ -197,7 +199,7 @@ export class ManageCorporateCardsPage {
 
     if (popoverResponse.data?.action === 'disconnect') {
       forkJoin([
-        this.realTimeFeedService.unenroll(cardType, card.id),
+        this.realTimeFeedService.unenroll(card),
         this.corporateCreditCardExpenseService.clearCache(),
       ]).subscribe(() => {
         this.loadCorporateCards$.next();


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1ixspmrQA1iy1xGb25uz5wwUvfcuRZrdw%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=XFHgzqU)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 004a3c3</samp>

This pull request improves the testing and code quality of the real-time feed service and the manage corporate cards page. It simplifies the unenrollment of corporate cards by passing the whole card object instead of its parts. It also fixes some minor code style issues with trailing commas and line breaks.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 004a3c3</samp>

> _`unenroll` changes_
> _simplify card management_
> _code style improved too_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 004a3c3</samp>

*  Simplify the `unenroll` method of the `RealTimeFeedService` to accept a `PlatformCorporateCard` object instead of a `cardType` and a `cardId` ([link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-aea5e7bc6f6a6327858f8ff03ba55f605d40ebd49f410603a103e1e787bae292L55-R62), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-aea5e7bc6f6a6327858f8ff03ba55f605d40ebd49f410603a103e1e787bae292L77-R78))
* Update the `disconnectCard` method of the `ManageCorporateCardsPage` and its test case to use the `card` object instead of the `cardType` and `cardId` when calling the `unenroll` method ([link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-b389a5d0241bda35125b36240b1d1cc470932c179782063153e1d1ad67705ed8L359-R359), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL200-R202))
* Add new test cases for the `getCardType` method of the `RealTimeFeedService` to check if it returns the correct card type based on the card network ([link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-ca3a1b86f7fac325f1f5f728e37c80dcd0ab178fcdfd9a33ffec734878b4b9b4R55-R68))
* Add new test cases for the `unenroll` method of the `RealTimeFeedService` to check if it handles the unenrollment of visa and mastercard rtf cards and throws an error if the card is not enrolled to rtf ([link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-ca3a1b86f7fac325f1f5f728e37c80dcd0ab178fcdfd9a33ffec734878b4b9b4R157-R198))
* Add a trailing comma to various method calls for consistency with the code style ([link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-ca3a1b86f7fac325f1f5f728e37c80dcd0ab178fcdfd9a33ffec734878b4b9b4L29-R29), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-ca3a1b86f7fac325f1f5f728e37c80dcd0ab178fcdfd9a33ffec734878b4b9b4L94-R108), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-ca3a1b86f7fac325f1f5f728e37c80dcd0ab178fcdfd9a33ffec734878b4b9b4L109-R124), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-ca3a1b86f7fac325f1f5f728e37c80dcd0ab178fcdfd9a33ffec734878b4b9b4L119-R133), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-aea5e7bc6f6a6327858f8ff03ba55f605d40ebd49f410603a103e1e787bae292L112-R113), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL41-R41), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL57-R57), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL64-R66), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL70-R73), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL79-R82), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL119-R121), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL156-R158))
* Add a line break to various `map` calls for consistency with the code style ([link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL64-R66), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL70-R73), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL79-R82), [link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-450aa28d32fd44fd50bd49190bd3028ca78d9b54b8849b79192b7a2fc10a008fL119-R121))
* Import a new mock data object `statementUploadedCard` for testing the `RealTimeFeedService` ([link](https://github.com/fylein/fyle-mobile-app/pull/2398/files?diff=unified&w=0#diff-ca3a1b86f7fac325f1f5f728e37c80dcd0ab178fcdfd9a33ffec734878b4b9b4L5-R5))

## Clickup
https://app.clickup.com