### PR TITLE
test: Code Coverage: Personal Cards Page #5

### DIFF
--- a/src/app/fyle/personal-cards/personal-cards.page.spec.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.spec.ts
@@ -36,7 +36,6 @@ import { ExpensePreviewComponent } from '../personal-cards-matched-expenses/expe
 import { DateRangeModalComponent } from './date-range-modal/date-range-modal.component';
 import { IonInfiniteScrollCustomEvent } from '@ionic/core';
 import { selectedFilters1, selectedFilters2 } from 'src/app/core/mock-data/selected-filters.data';
-import { InAppBrowserObject } from '@awesome-cordova-plugins/in-app-browser/ngx';
 
 fdescribe('PersonalCardsPage', () => {
   let component: PersonalCardsPage;
@@ -853,5 +852,17 @@ fdescribe('PersonalCardsPage', () => {
       expect(component.setupNetworkWatcher).toHaveBeenCalledTimes(1);
       expect(component.mode).toEqual('md');
     });
+  });
+
+  it('ionViewWillEnter(): should setup class variables', () => {
+    component.isCardsLoaded = true;
+    spyOn(component.loadData$, 'getValue').and.returnValue({});
+    spyOn(component.loadData$, 'next');
+
+    component.ionViewWillEnter();
+
+    expect(component.loadData$.next).toHaveBeenCalledTimes(1);
+    expect(component.loadData$.getValue).toHaveBeenCalledTimes(1);
+    expect(trackingService.personalCardsViewed).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/fyle/personal-cards/personal-cards.page.spec.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.spec.ts
@@ -1,5 +1,5 @@
 import { CUSTOM_ELEMENTS_SCHEMA, ChangeDetectorRef, NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flush, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -37,8 +37,11 @@ import { DateRangeModalComponent } from './date-range-modal/date-range-modal.com
 import { IonInfiniteScrollCustomEvent } from '@ionic/core';
 import { selectedFilters1, selectedFilters2 } from 'src/app/core/mock-data/selected-filters.data';
 import { By } from '@angular/platform-browser';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-describe('PersonalCardsPage', () => {
+fdescribe('PersonalCardsPage', () => {
   let component: PersonalCardsPage;
   let fixture: ComponentFixture<PersonalCardsPage>;
   let personalCardsService: jasmine.SpyObj<PersonalCardsService>;
@@ -97,7 +100,16 @@ describe('PersonalCardsPage', () => {
 
     TestBed.configureTestingModule({
       declarations: [PersonalCardsPage],
-      imports: [IonicModule.forRoot(), RouterTestingModule, FormsModule, MatCheckboxModule],
+      imports: [
+        IonicModule.forRoot(),
+        RouterTestingModule,
+        FormsModule,
+        MatCheckboxModule,
+        MatFormFieldModule,
+        MatInputModule,
+        BrowserAnimationsModule,
+        NoopAnimationsModule,
+      ],
       providers: [
         ChangeDetectorRef,
         {
@@ -190,8 +202,10 @@ describe('PersonalCardsPage', () => {
 
     personalCardsService.getLinkedAccountsCount.and.returnValue(of(2));
     personalCardsService.getLinkedAccounts.and.returnValue(of(linkedAccountsRes));
-    component.loadData$ = new BehaviorSubject(null);
-    component.loadCardData$ = new BehaviorSubject(null);
+    component.loadData$ = new BehaviorSubject({
+      pageNumber: 1,
+    });
+    component.loadCardData$ = new BehaviorSubject({});
     component.linkedAccountsCount$ = of(1);
     component.isConnected$ = of(true);
     component.linkedAccounts$ = of(linkedAccountsRes);
@@ -897,6 +911,10 @@ describe('PersonalCardsPage', () => {
       component.transactionsCount$.subscribe((res) => {
         expect(res).toBeTruthy();
       });
+
+      // component.isInfiniteScrollRequired$.subscribe((res) => {
+      //   expect(res).toBeTrue();
+      // });
 
       expect(component.addNewFiltersToParams).toHaveBeenCalled();
       expect(personalCardsService.getLinkedAccountsCount).toHaveBeenCalled();

--- a/src/app/fyle/personal-cards/personal-cards.page.spec.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.spec.ts
@@ -665,7 +665,7 @@ describe('PersonalCardsPage', () => {
 
         expect(personalCardsService.getMatchedExpensesCount).toHaveBeenCalledOnceWith(
           apiPersonalCardTxnsRes.data[0].btxn_amount,
-          '2021-09-19',
+          '2021-09-19'
         );
         expect(router.navigate).toHaveBeenCalledOnceWith([
           '/',
@@ -684,7 +684,7 @@ describe('PersonalCardsPage', () => {
 
         expect(personalCardsService.getMatchedExpensesCount).toHaveBeenCalledOnceWith(
           apiPersonalCardTxnsRes.data[0].btxn_amount,
-          '2021-09-19',
+          '2021-09-19'
         );
         expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'personal_cards_matched_expenses'], {
           state: { txnDetails: apiPersonalCardTxnsRes.data[0] },
@@ -779,7 +779,7 @@ describe('PersonalCardsPage', () => {
           startDate: '2023-02-20T00:00:00.000Z',
           endDate: '2023-02-24T00:00:00.000Z',
         },
-        {},
+        {}
       );
     }));
 
@@ -838,14 +838,14 @@ describe('PersonalCardsPage', () => {
           {
             requestId: 'tx3qHxFNgRcZ',
           },
-        ]),
+        ])
       );
       const inappborwserSpy = jasmine.createSpyObj('InAppBrowserObject', ['on', 'close']);
       inappborwserSpy.on.withArgs('loadstop').and.returnValue(of(null));
       inappborwserSpy.on.withArgs('loadstart').and.returnValue(
         of({
           url: 'https://www.fylehq.com',
-        }),
+        })
       );
       inAppBrowserService.create.and.returnValue(inappborwserSpy);
       spyOn(component, 'postAccounts');
@@ -907,7 +907,7 @@ describe('PersonalCardsPage', () => {
     });
   });
 
-  it('loadTransactionCount(): should load trnasaction count', (done) => {
+  it('loadTransactionCount(): should load transaction count', (done) => {
     apiV2Service.extendQueryParamsForTextSearch.and.returnValue({});
     personalCardsService.getBankTransactionsCount.and.returnValue(of(1));
 
@@ -921,11 +921,11 @@ describe('PersonalCardsPage', () => {
     });
   });
 
-  it('loadInfinitScroll(): should load infinit scroll', (done) => {
+  it('loadInfiniteScroll(): should load infinite scroll', (done) => {
     component.transactions$ = of(apiPersonalCardTxnsRes.data);
     component.transactionsCount$ = of(1);
 
-    component.loadInfinitScroll();
+    component.loadInfiniteScroll();
 
     component.isInfiniteScrollRequired$.subscribe((res) => {
       expect(res).toBeFalse();
@@ -985,7 +985,7 @@ describe('PersonalCardsPage', () => {
     spyOn(component, 'loadPersonalTxns').and.returnValue(of(apiPersonalCardTxnsRes.data));
     personalCardsService.generateFilterPills.and.returnValue(allFilterPills);
     spyOn(component, 'loadTransactionCount');
-    spyOn(component, 'loadInfinitScroll');
+    spyOn(component, 'loadInfiniteScroll');
 
     component.simpleSearchInput = fixture.debugElement.query(By.css('.personal-cards--simple-search-input'));
     const inputElement = component.simpleSearchInput.nativeElement as HTMLInputElement;
@@ -999,6 +999,6 @@ describe('PersonalCardsPage', () => {
     expect(component.loadLinkedAccounts).toHaveBeenCalledTimes(1);
     expect(component.loadPersonalTxns).toHaveBeenCalledTimes(1);
     expect(component.loadTransactionCount).toHaveBeenCalledTimes(1);
-    expect(component.loadInfinitScroll).toHaveBeenCalledTimes(1);
+    expect(component.loadInfiniteScroll).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/fyle/personal-cards/personal-cards.page.spec.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.spec.ts
@@ -1,23 +1,30 @@
 import { CUSTOM_ELEMENTS_SCHEMA, ChangeDetectorRef, NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, flush, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SpinnerDialog } from '@awesome-cordova-plugins/spinner-dialog/ngx';
 import { InfiniteScrollCustomEvent, IonicModule, ModalController, Platform, SegmentCustomEvent } from '@ionic/angular';
+import { IonInfiniteScrollCustomEvent } from '@ionic/core';
 import { BehaviorSubject, of } from 'rxjs';
 import { getElementRef } from 'src/app/core/dom-helpers';
 import { apiExpenseRes, expenseList2 } from 'src/app/core/mock-data/expense.data';
-import { creditTxnFilterPill } from 'src/app/core/mock-data/filter-pills.data';
+import { allFilterPills, creditTxnFilterPill } from 'src/app/core/mock-data/filter-pills.data';
 import {
   personalCardQueryParamFiltersData,
   tasksQueryParamsWithFiltersData,
   tasksQueryParamsWithFiltersData3,
 } from 'src/app/core/mock-data/get-tasks-query-params-with-filters.data';
+import { properties } from 'src/app/core/mock-data/modal-properties.data';
 import { apiPersonalCardTxnsRes, matchedPersonalCardTxn } from 'src/app/core/mock-data/personal-card-txns.data';
 import { apiLinkedAccRes, linkedAccountsRes } from 'src/app/core/mock-data/personal-cards.data';
+import { selectedFilters1, selectedFilters2 } from 'src/app/core/mock-data/selected-filters.data';
 import { snackbarPropertiesRes6, snackbarPropertiesRes7 } from 'src/app/core/mock-data/snackbar-properties.data';
 import { apiToken } from 'src/app/core/mock-data/yoodle-token.data';
 import { ApiV2Service } from 'src/app/core/services/api-v2.service';
@@ -30,18 +37,11 @@ import { TrackingService } from 'src/app/core/services/tracking.service';
 import { HeaderState } from 'src/app/shared/components/fy-header/header-state.enum';
 import { ToastMessageComponent } from 'src/app/shared/components/toast-message/toast-message.component';
 import { SnackbarPropertiesService } from '../../core/services/snackbar-properties.service';
-import { PersonalCardsPage } from './personal-cards.page';
-import { properties } from 'src/app/core/mock-data/modal-properties.data';
 import { ExpensePreviewComponent } from '../personal-cards-matched-expenses/expense-preview/expense-preview.component';
 import { DateRangeModalComponent } from './date-range-modal/date-range-modal.component';
-import { IonInfiniteScrollCustomEvent } from '@ionic/core';
-import { selectedFilters1, selectedFilters2 } from 'src/app/core/mock-data/selected-filters.data';
-import { By } from '@angular/platform-browser';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { PersonalCardsPage } from './personal-cards.page';
 
-fdescribe('PersonalCardsPage', () => {
+describe('PersonalCardsPage', () => {
   let component: PersonalCardsPage;
   let fixture: ComponentFixture<PersonalCardsPage>;
   let personalCardsService: jasmine.SpyObj<PersonalCardsService>;
@@ -329,19 +329,36 @@ fdescribe('PersonalCardsPage', () => {
       expect(trackingService.cardDeletedOnPersonalCards).toHaveBeenCalledTimes(1);
     });
 
-    it('onCardChanged(): should fetch new txns when card changes', () => {
-      spyOn(component.loadData$, 'getValue').and.returnValue({
-        queryParams: {},
-      });
-      spyOn(component.loadData$, 'next');
+    describe('onCardChanged(): ', () => {
+      it('should fetch new txns when card changes', () => {
+        spyOn(component.loadData$, 'getValue').and.returnValue({
+          queryParams: {},
+        });
+        spyOn(component.loadData$, 'next');
 
-      component.onCardChanged('eq.baccLesaRlyvLY');
+        component.onCardChanged('eq.baccLesaRlyvLY');
 
-      expect(component.loadData$.next).toHaveBeenCalledOnceWith({
-        queryParams: { btxn_status: 'in.(INITIALIZED)', ba_id: 'eq.eq.baccLesaRlyvLY' },
-        pageNumber: 1,
+        expect(component.loadData$.next).toHaveBeenCalledOnceWith({
+          queryParams: { btxn_status: 'in.(INITIALIZED)', ba_id: 'eq.eq.baccLesaRlyvLY' },
+          pageNumber: 1,
+        });
+        expect(component.loadData$.getValue).toHaveBeenCalledTimes(1);
       });
-      expect(component.loadData$.getValue).toHaveBeenCalledTimes(1);
+
+      it('should fetch new txns without params', () => {
+        spyOn(component.loadData$, 'getValue').and.returnValue({
+          queryParams: null,
+        });
+        spyOn(component.loadData$, 'next');
+
+        component.onCardChanged('eq.baccLesaRlyvLY');
+
+        expect(component.loadData$.next).toHaveBeenCalledOnceWith({
+          queryParams: { btxn_status: 'in.(INITIALIZED)', ba_id: 'eq.eq.baccLesaRlyvLY' },
+          pageNumber: 1,
+        });
+        expect(component.loadData$.getValue).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('loadData(): should load data', fakeAsync(() => {
@@ -419,7 +436,6 @@ fdescribe('PersonalCardsPage', () => {
       component.selectionMode = true;
       spyOn(component, 'switchSelectionMode');
       personalCardsService.fetchTransactions.and.returnValue(of(apiPersonalCardTxnsRes));
-      fixture.detectChanges();
 
       component.fetchNewTransactions();
 
@@ -434,7 +450,6 @@ fdescribe('PersonalCardsPage', () => {
         personalCardsService.hideTransactions.and.returnValue(of(apiExpenseRes));
         spyOn(component, 'switchSelectionMode');
         snackbarProperties.setSnackbarProperties.and.returnValue(snackbarPropertiesRes6);
-        fixture.detectChanges();
 
         component.hideSelectedTransactions();
 
@@ -455,7 +470,6 @@ fdescribe('PersonalCardsPage', () => {
         personalCardsService.hideTransactions.and.returnValue(of(expenseList2));
         spyOn(component, 'switchSelectionMode');
         snackbarProperties.setSnackbarProperties.and.returnValue(snackbarPropertiesRes7);
-        fixture.detectChanges();
 
         component.hideSelectedTransactions();
 
@@ -477,7 +491,6 @@ fdescribe('PersonalCardsPage', () => {
         component.selectedTrasactionType = 'INITIALIZED';
         component.selectionMode = true;
         spyOn(component, 'selectExpense');
-        fixture.detectChanges();
 
         component.switchSelectionMode();
 
@@ -490,7 +503,6 @@ fdescribe('PersonalCardsPage', () => {
         component.selectedTrasactionType = 'INITIALIZED';
         component.selectionMode = false;
         spyOn(component, 'selectExpense');
-        fixture.detectChanges();
 
         component.switchSelectionMode('btxnMy43OZokde');
 
@@ -503,7 +515,6 @@ fdescribe('PersonalCardsPage', () => {
     describe('selectExpense():', () => {
       it('should add an expense to list', () => {
         component.selectedElements = [];
-        fixture.detectChanges();
 
         component.selectExpense('btxnMy43OZokde');
         expect(component.selectedElements).toEqual(['btxnMy43OZokde']);
@@ -511,7 +522,6 @@ fdescribe('PersonalCardsPage', () => {
 
       it('should add an expense to list', () => {
         component.selectedElements = ['btxnMy43OZokde'];
-        fixture.detectChanges();
 
         component.selectExpense('btxnMy43OZokde');
         expect(component.selectedElements).toEqual([]);
@@ -521,7 +531,6 @@ fdescribe('PersonalCardsPage', () => {
     it('onSelectAll(): should select all expenses', () => {
       component.acc = [apiPersonalCardTxnsRes.data[0]];
       const event = new MatCheckboxChange();
-      fixture.detectChanges();
 
       component.onSelectAll(event);
 
@@ -599,11 +608,10 @@ fdescribe('PersonalCardsPage', () => {
         component.filters = {
           createdOn: {},
         };
-        fixture.detectChanges();
 
         component.onFilterClose('Created On');
         expect(component.addNewFiltersToParams).toHaveBeenCalledTimes(1);
-        expect(personalCardsService.generateFilterPills).toHaveBeenCalledTimes(2);
+        expect(personalCardsService.generateFilterPills).toHaveBeenCalledTimes(1);
       });
 
       it('should delete updated on filter', () => {
@@ -612,11 +620,10 @@ fdescribe('PersonalCardsPage', () => {
         component.filters = {
           updatedOn: {},
         };
-        fixture.detectChanges();
 
         component.onFilterClose('Updated On');
         expect(component.addNewFiltersToParams).toHaveBeenCalledTimes(1);
-        expect(personalCardsService.generateFilterPills).toHaveBeenCalledTimes(2);
+        expect(personalCardsService.generateFilterPills).toHaveBeenCalledTimes(1);
       });
 
       it('should delete transaction type filter', () => {
@@ -625,11 +632,10 @@ fdescribe('PersonalCardsPage', () => {
         component.filters = {
           transactionType: 'DEBIT',
         };
-        fixture.detectChanges();
 
         component.onFilterClose('Transactions Type');
         expect(component.addNewFiltersToParams).toHaveBeenCalledTimes(1);
-        expect(personalCardsService.generateFilterPills).toHaveBeenCalledTimes(2);
+        expect(personalCardsService.generateFilterPills).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -827,12 +833,18 @@ fdescribe('PersonalCardsPage', () => {
 
     it('openYoodle(): should open yoodle', fakeAsync(() => {
       personalCardsService.htmlFormUrl.and.returnValue('<h1></h1>');
+      spyOn(window, 'decodeURIComponent').and.returnValue(
+        JSON.stringify([
+          {
+            requestId: 'tx3qHxFNgRcZ',
+          },
+        ]),
+      );
       const inappborwserSpy = jasmine.createSpyObj('InAppBrowserObject', ['on', 'close']);
       inappborwserSpy.on.withArgs('loadstop').and.returnValue(of(null));
-      const ids = JSON.stringify([{ requestId: 'id' }]);
       inappborwserSpy.on.withArgs('loadstart').and.returnValue(
         of({
-          url: JSON.stringify('https://www.fylehq.com/app/main/#/my_dash' + ids),
+          url: 'https://www.fylehq.com',
         }),
       );
       inAppBrowserService.create.and.returnValue(inappborwserSpy);
@@ -844,6 +856,8 @@ fdescribe('PersonalCardsPage', () => {
       expect(personalCardsService.htmlFormUrl).toHaveBeenCalledOnceWith(apiToken.fast_link_url, apiToken.access_token);
       expect(inappborwserSpy.on).toHaveBeenCalledTimes(2);
       expect(inAppBrowserService.create).toHaveBeenCalledTimes(1);
+      expect(window.decodeURIComponent).toHaveBeenCalledTimes(1);
+      expect(component.postAccounts).toHaveBeenCalledOnceWith(['tx3qHxFNgRcZ']);
     }));
   });
 
@@ -881,47 +895,110 @@ fdescribe('PersonalCardsPage', () => {
     expect(trackingService.personalCardsViewed).toHaveBeenCalledTimes(1);
   });
 
-  describe('ngAfterViewInit():', () => {
-    it('should load data with filters', () => {
+  it('loadLinkedAccounts(): should load linked accounts', (done) => {
+    personalCardsService.getLinkedAccounts.and.returnValue(of(apiLinkedAccRes.data));
+
+    component.loadLinkedAccounts();
+
+    component.linkedAccounts$.subscribe((res) => {
+      expect(res).toEqual(apiLinkedAccRes.data);
+      expect(personalCardsService.getLinkedAccounts).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('loadTransactionCount(): should load trnasaction count', (done) => {
+    apiV2Service.extendQueryParamsForTextSearch.and.returnValue({});
+    personalCardsService.getBankTransactionsCount.and.returnValue(of(1));
+
+    component.loadTransactionCount();
+
+    component.transactionsCount$.subscribe((res) => {
+      expect(res).toEqual(1);
+      expect(apiV2Service.extendQueryParamsForTextSearch).toHaveBeenCalledTimes(1);
+      expect(personalCardsService.getBankTransactionsCount).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('loadInfinitScroll(): should load infinit scroll', (done) => {
+    component.transactions$ = of(apiPersonalCardTxnsRes.data);
+    component.transactionsCount$ = of(1);
+
+    component.loadInfinitScroll();
+
+    component.isInfiniteScrollRequired$.subscribe((res) => {
+      expect(res).toBeFalse();
+      done();
+    });
+  });
+
+  it('loadAccountCount(): should load accounts count and clear filters', (done) => {
+    personalCardsService.getLinkedAccountsCount.and.returnValue(of(0));
+    spyOn(component, 'clearFilters');
+
+    component.loadAccountCount();
+
+    component.linkedAccountsCount$.subscribe((res) => {
+      expect(res).toEqual(0);
+      expect(component.clearFilters).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  describe('loadPersonalTxns():', () => {
+    it('should load personal cards txns with params', (done) => {
       activatedRoute.snapshot.queryParams.filters = JSON.stringify({});
-      personalCardsService.getLinkedAccountsCount.and.returnValue(of(0));
-      personalCardsService.getLinkedAccounts.and.returnValue(of(apiLinkedAccRes.data));
       spyOn(component, 'addNewFiltersToParams').and.returnValue({});
       apiV2Service.extendQueryParamsForTextSearch.and.returnValue({});
       personalCardsService.getBankTransactionsCount.and.returnValue(of(1));
       personalCardsService.getBankTransactions.and.returnValue(of(apiPersonalCardTxnsRes));
 
-      component.simpleSearchInput = fixture.debugElement.query(By.css('.personal-cards--simple-search-input'));
-      const inputElement = component.simpleSearchInput.nativeElement as HTMLInputElement;
-
-      component.ngAfterViewInit();
-
-      inputElement.value = '';
-      inputElement.dispatchEvent(new Event('keyup'));
-      fixture.detectChanges();
-
-      component.linkedAccounts$.subscribe((res) => {
-        expect(res).toBeTruthy();
+      component.loadPersonalTxns().subscribe((res) => {
+        expect(res).toEqual(apiPersonalCardTxnsRes.data);
+        expect(component.addNewFiltersToParams).toHaveBeenCalledTimes(1);
+        expect(apiV2Service.extendQueryParamsForTextSearch).toHaveBeenCalledTimes(1);
+        expect(personalCardsService.getBankTransactionsCount).toHaveBeenCalledTimes(1);
+        expect(personalCardsService.getBankTransactions).toHaveBeenCalledTimes(1);
+        done();
       });
-
-      component.transactions$.subscribe((res) => {
-        expect(res).toBeTruthy();
-      });
-
-      component.transactionsCount$.subscribe((res) => {
-        expect(res).toBeTruthy();
-      });
-
-      // component.isInfiniteScrollRequired$.subscribe((res) => {
-      //   expect(res).toBeTrue();
-      // });
-
-      expect(component.addNewFiltersToParams).toHaveBeenCalled();
-      expect(personalCardsService.getLinkedAccountsCount).toHaveBeenCalled();
-      expect(personalCardsService.getLinkedAccounts).toHaveBeenCalled();
-      expect(apiV2Service.extendQueryParamsForTextSearch).toHaveBeenCalled();
-      expect(personalCardsService.getBankTransactionsCount).toHaveBeenCalled();
-      expect(personalCardsService.generateFilterPills).toHaveBeenCalled();
     });
+
+    it('should load personal cards without params', (done) => {
+      activatedRoute.snapshot.queryParams.filters = null;
+      personalCardsService.getBankTransactionsCount.and.returnValue(of(0));
+      personalCardsService.getBankTransactions.and.returnValue(of({ ...apiPersonalCardTxnsRes, data: [] }));
+
+      component.loadPersonalTxns().subscribe((res) => {
+        expect(res).toEqual([]);
+        expect(apiV2Service.extendQueryParamsForTextSearch).toHaveBeenCalledTimes(1);
+        expect(personalCardsService.getBankTransactionsCount).toHaveBeenCalledTimes(1);
+        expect(personalCardsService.getBankTransactions).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
+  it('ngAfterViewInit(): should setup search and load data', () => {
+    spyOn(component, 'loadAccountCount');
+    spyOn(component, 'loadLinkedAccounts');
+    spyOn(component, 'loadPersonalTxns').and.returnValue(of(apiPersonalCardTxnsRes.data));
+    personalCardsService.generateFilterPills.and.returnValue(allFilterPills);
+    spyOn(component, 'loadTransactionCount');
+    spyOn(component, 'loadInfinitScroll');
+
+    component.simpleSearchInput = fixture.debugElement.query(By.css('.personal-cards--simple-search-input'));
+    const inputElement = component.simpleSearchInput.nativeElement as HTMLInputElement;
+
+    component.ngAfterViewInit();
+
+    inputElement.value = '';
+    inputElement.dispatchEvent(new Event('keyup'));
+
+    expect(component.loadAccountCount).toHaveBeenCalledTimes(1);
+    expect(component.loadLinkedAccounts).toHaveBeenCalledTimes(1);
+    expect(component.loadPersonalTxns).toHaveBeenCalledTimes(1);
+    expect(component.loadTransactionCount).toHaveBeenCalledTimes(1);
+    expect(component.loadInfinitScroll).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/fyle/personal-cards/personal-cards.page.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.ts
@@ -170,7 +170,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
     private spinnerDialog: SpinnerDialog,
     private trackingService: TrackingService,
     private modalProperties: ModalPropertiesService,
-    private cdr: ChangeDetectorRef,
+    private cdr: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
@@ -201,10 +201,10 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
           }),
           finalize(() => {
             this.isLoading = false;
-          }),
-        ),
+          })
+        )
       ),
-      shareReplay(1),
+      shareReplay(1)
     );
   }
 
@@ -214,13 +214,13 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
         const queryParams = this.apiV2Service.extendQueryParamsForTextSearch(params.queryParams, params.searchString);
         return this.personalCardsService.getBankTransactionsCount(queryParams);
       }),
-      shareReplay(1),
+      shareReplay(1)
     );
   }
 
-  loadInfinitScroll(): void {
+  loadInfiniteScroll(): void {
     const paginatedScroll$ = this.transactions$.pipe(
-      switchMap((txns) => this.transactionsCount$.pipe(map((count) => count > txns.length))),
+      switchMap((txns) => this.transactionsCount$.pipe(map((count) => count > txns.length)))
     );
     this.isInfiniteScrollRequired$ = this.loadData$.pipe(switchMap(() => paginatedScroll$));
   }
@@ -233,7 +233,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
           this.clearFilters();
         }
       }),
-      shareReplay(1),
+      shareReplay(1)
     );
   }
 
@@ -266,7 +266,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
                   finalize(() => {
                     this.isTrasactionsLoading = false;
                     this.isLoadingDataInfiniteScroll = false;
-                  }),
+                  })
                 );
             } else {
               this.isTrasactionsLoading = false;
@@ -274,7 +274,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
                 data: [],
               });
             }
-          }),
+          })
         );
       }),
       map((res) => {
@@ -285,7 +285,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
         }
         this.acc = this.acc.concat(res.data);
         return this.acc;
-      }),
+      })
     );
   }
 
@@ -308,14 +308,14 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
 
     this.loadTransactionCount();
 
-    this.loadInfinitScroll();
+    this.loadInfiniteScroll();
 
     this.simpleSearchInput.nativeElement.value = '';
     fromEvent<{ srcElement: { value: string } }>(this.simpleSearchInput.nativeElement, 'keyup')
       .pipe(
         map((event) => event.srcElement.value),
         distinctUntilChanged(),
-        debounceTime(400),
+        debounceTime(400)
       )
       .subscribe((searchString) => {
         const currentParams = this.loadData$.getValue();
@@ -345,7 +345,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
         switchMap(() => this.personalCardsService.getToken()),
         finalize(async () => {
           await this.loaderService.hideLoader();
-        }),
+        })
       )
       .subscribe((yodleeConfig) => {
         this.openYoodle(yodleeConfig.fast_link_url, yodleeConfig.access_token);
@@ -391,7 +391,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
         switchMap(() => this.personalCardsService.postBankAccounts(requestIds)),
         finalize(async () => {
           await this.loaderService.hideLoader();
-        }),
+        })
       )
       .subscribe((data) => {
         const message =
@@ -500,7 +500,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
           params.pageNumber = 1;
           this.loadData$.next(params);
           this.trackingService.transactionsFetchedOnPersonalCards();
-        }),
+        })
       )
       .subscribe(noop);
   }
@@ -530,7 +530,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
           }
           this.loadData$.next(params);
           this.trackingService.transactionsHiddenOnPersonalCards();
-        }),
+        })
       )
       .subscribe(noop);
   }

--- a/src/app/fyle/personal-cards/personal-cards.page.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.ts
@@ -86,7 +86,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
 
   linkedAccounts$: Observable<PersonalCard[]>;
 
-  loadCardData$: BehaviorSubject<{}>;
+  loadCardData$: BehaviorSubject<{}> = new BehaviorSubject({});
 
   loadData$: BehaviorSubject<
     Partial<{
@@ -96,7 +96,9 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
       sortDir: string;
       searchString: string;
     }>
-  >;
+  > = new BehaviorSubject({
+    pageNumber: 1,
+  });
 
   transactions$: Observable<PersonalCardTxn[]>;
 
@@ -215,7 +217,9 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
       ),
       shareReplay(1),
     );
-    this.loadData$ = new BehaviorSubject({});
+    this.loadData$ = new BehaviorSubject({
+      pageNumber: 1,
+    });
     const paginatedPipe = this.loadData$.pipe(
       switchMap((params) => {
         let queryParams: Record<string, string>;


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0684eaf</samp>

Improved the test coverage and quality of `personal-cards.page.spec.ts` by adding and fixing test cases for the personal cards page component. The component handles the display and interaction of personal cards linked to the user's account.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0684eaf</samp>

> _`Filters` and `modals` in the dark_
> _Testing the component's vital spark_
> _`Personal cards` data on the screen_
> _Fixing the issues that were unseen_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0684eaf</samp>

*  Removed unused import of `IonInfiniteScroll` ([link](https://github.com/fylein/fyle-mobile-app/pull/2404/files?diff=unified&w=0#diff-6e314ff0829ddfea53cbbca077b821775702ee8b5c5804cedab82e27a8a6f8a7L9-R9))
* Added and renamed imports of mock data for new test cases ([link](https://github.com/fylein/fyle-mobile-app/pull/2404/files?diff=unified&w=0#diff-6e314ff0829ddfea53cbbca077b821775702ee8b5c5804cedab82e27a8a6f8a7L24-R20))
* Added imports of filter data and `By` for new test cases ([link](https://github.com/fylein/fyle-mobile-app/pull/2404/files?diff=unified&w=0#diff-6e314ff0829ddfea53cbbca077b821775702ee8b5c5804cedab82e27a8a6f8a7R38-R39))
* Added `hide` method to `spinnerDialogSpy` for new test cases ([link](https://github.com/fylein/fyle-mobile-app/pull/2404/files?diff=unified&w=0#diff-6e314ff0829ddfea53cbbca077b821775702ee8b5c5804cedab82e27a8a6f8a7L91-R87))
* Moved `queryParams` property to the correct level in `params` ([link](https://github.com/fylein/fyle-mobile-app/pull/2404/files?diff=unified&w=0#diff-6e314ff0829ddfea53cbbca077b821775702ee8b5c5804cedab82e27a8a6f8a7L113-R112))
* Added test cases for `openFilters` and `openYoodle` methods of `PersonalCardsPage` component ([link](https://github.com/fylein/fyle-mobile-app/pull/2404/files?diff=unified&w=0#diff-6e314ff0829ddfea53cbbca077b821775702ee8b5c5804cedab82e27a8a6f8a7R790-R833))
* Added test cases for `ionViewWillEnter` and `ngAfterViewInit` lifecycle hooks of `PersonalCardsPage` component ([link](https://github.com/fylein/fyle-mobile-app/pull/2404/files?diff=unified&w=0#diff-6e314ff0829ddfea53cbbca077b821775702ee8b5c5804cedab82e27a8a6f8a7R857-R908))

## Clickup
https://app.clickup.com/t/85ztx3nye

## Code Coverage
`97.65% Statements 292/299`
`87.75% Branches 43/49`
`98.63% Functions 72/73`
`97.63% Lines 289/296`

## UI Preview
Please add screenshots for UI changes