### PR TITLE
test: 80% coverage of my advances page

### DIFF
--- a/src/app/core/mock-data/extended-advance-request.data.ts
+++ b/src/app/core/mock-data/extended-advance-request.data.ts
@@ -708,13 +708,13 @@ export const myAdvanceRequestsData2: ApiV2Response<ExtendedAdvanceRequest> = {
   count: 11,
 };
 
-export const myAdvancerequestsData3: ExtendedAdvanceRequest = {
+export const myAdvanceRequestsData3: ExtendedAdvanceRequest = {
   ...singleExtendedAdvReqRes.data[0],
   areq_state: 'DRAFT',
   areq_is_sent_back: true,
 };
 
-export const myAdvancerequestsData4: ExtendedAdvanceRequest = {
+export const myAdvanceRequestsData4: ExtendedAdvanceRequest = {
   ...singleExtendedAdvReqRes.data[0],
   areq_state: 'DRAFT',
   areq_is_sent_back: false,

--- a/src/app/core/mock-data/extended-advance-request.data.ts
+++ b/src/app/core/mock-data/extended-advance-request.data.ts
@@ -720,3 +720,13 @@ export const myAdvancerequestsData4: ExtendedAdvanceRequest = {
   areq_is_sent_back: false,
   areq_is_pulled_back: false,
 };
+
+export const myAdvanceRequestData5: ExtendedAdvanceRequest = {
+  ...singleExtendedAdvReqRes.data[0],
+  type: 'request',
+  currency: 'USD',
+  amount: 123,
+  created_at: new Date('2022-05-27T08:33:32.879009'),
+  purpose: '213',
+  state: 'APPROVAL_PENDING',
+};

--- a/src/app/core/mock-data/extended-advance.data.ts
+++ b/src/app/core/mock-data/extended-advance.data.ts
@@ -126,3 +126,14 @@ export const singleExtendedAdvancesData2: ApiV2Response<ExtendedAdvance> = {
   offset: 0,
   url: '/v2/advances',
 };
+
+export const singleExtendedAdvancesData3: ExtendedAdvance = {
+  ...singleExtendedAdvancesData.data[0],
+  type: 'advance',
+  amount: 300,
+  orig_amount: null,
+  created_at: new Date('2019-10-31T04:36:01.927Z'),
+  currency: 'INR',
+  orig_currency: null,
+  purpose: 'New advance-2',
+};

--- a/src/app/core/mock-data/filter-options.data.ts
+++ b/src/app/core/mock-data/filter-options.data.ts
@@ -1,0 +1,52 @@
+import { FilterOptionType } from 'src/app/shared/components/fy-filters/filter-option-type.enum';
+import { FilterOptions } from 'src/app/shared/components/fy-filters/filter-options.interface';
+import { AdvancesStates } from '../models/advances-states.model';
+import { SortingValue } from '../models/sorting-value.model';
+
+export const filterOptions: FilterOptions<string>[] = [
+  {
+    name: 'State',
+    optionType: FilterOptionType.multiselect,
+    options: [
+      {
+        label: 'Draft',
+        value: AdvancesStates.draft,
+      },
+
+      {
+        label: 'Sent Back',
+        value: AdvancesStates.sentBack,
+      },
+    ],
+  },
+  {
+    name: 'Sort By',
+    optionType: FilterOptionType.singleselect,
+    options: [
+      {
+        label: 'Created At - New to Old',
+        value: SortingValue.creationDateAsc,
+      },
+      {
+        label: 'Created At - Old to New',
+        value: SortingValue.creationDateDesc,
+      },
+      {
+        label: 'Approved At - New to Old',
+        value: SortingValue.approvalDateAsc,
+      },
+      {
+        label: 'Approved At - Old to New',
+        value: SortingValue.approvalDateDesc,
+      },
+      {
+        label: `Project - A to Z`,
+        value: SortingValue.projectAsc,
+      },
+      {
+        label: `Project - Z to A`,
+        value: SortingValue.projectDesc,
+      },
+    ],
+  },
+];

--- a/src/app/core/models/extended_advance.model.ts
+++ b/src/app/core/models/extended_advance.model.ts
@@ -49,6 +49,6 @@ export interface ExtendedAdvance {
   orig_amount?: number;
   currency?: string;
   purpose?: string;
-  org_currency?: string;
+  orig_currency?: string;
   created_at?: Date;
 }

--- a/src/app/fyle/my-advances/my-advances.page.spec.ts
+++ b/src/app/fyle/my-advances/my-advances.page.spec.ts
@@ -21,12 +21,17 @@ import {
   allTeamAdvanceRequestsRes,
   extendedAdvReqDraft,
   extendedAdvReqInquiry,
+  myAdvanceRequestData5,
   myAdvancerequestsData2,
   myAdvancerequestsData3,
   myAdvancerequestsData4,
   singleExtendedAdvReqRes,
 } from 'src/app/core/mock-data/extended-advance-request.data';
-import { singleExtendedAdvancesData, singleExtendedAdvancesData2 } from 'src/app/core/mock-data/extended-advance.data';
+import {
+  singleExtendedAdvancesData,
+  singleExtendedAdvancesData2,
+  singleExtendedAdvancesData3,
+} from 'src/app/core/mock-data/extended-advance.data';
 import { orgSettingsData } from 'src/app/core/test-data/accounts.service.spec.data';
 import { AdvancesStates } from 'src/app/core/models/advances-states.model';
 import {
@@ -37,6 +42,7 @@ import {
 import { orgSettingsRes } from 'src/app/core/mock-data/org-settings.data';
 import { SortingDirection } from 'src/app/core/models/sorting-direction.model';
 import { SortingParam } from 'src/app/core/models/sorting-param.model';
+import { cloneDeep } from 'lodash';
 
 describe('MyAdvancesPage', () => {
   let component: MyAdvancesPage;
@@ -368,6 +374,84 @@ describe('MyAdvancesPage', () => {
         );
         expect(res).toEqual([myAdvancerequestsData4, myAdvancerequestsData3]);
       });
+    });
+  });
+
+  it('updateMyAdvances(): should set type, amount, orig_amount, created_at, currency, orig_currency and purpose in my advances', () => {
+    const mockMyAdvancesData = cloneDeep(singleExtendedAdvancesData.data);
+    const expectedMyAdvance = component.updateMyAdvances(mockMyAdvancesData);
+    expect(expectedMyAdvance).toEqual([singleExtendedAdvancesData3]);
+  });
+
+  it('updateMyAdvanceRequests(): should set type, amount, orig_amount, created_at, currency, orig_currency and purpose in my advances request', () => {
+    const mockMyAdvanceRequestsData = cloneDeep(singleExtendedAdvReqRes.data);
+    const expectedMyAdvanceRequest = component.updateMyAdvanceRequests(mockMyAdvanceRequestsData);
+    expect(expectedMyAdvanceRequest).toEqual([myAdvanceRequestData5]);
+  });
+
+  describe('doRefresh():', () => {
+    beforeEach(() => {
+      advanceRequestService.destroyAdvanceRequestsCacheBuster.and.returnValue(of(null));
+      advanceService.destroyAdvancesCacheBuster.and.returnValue(of(null));
+    });
+
+    it('should call destroyAdvanceRequestsCacheBuster and destroyAdvancesCacheBuster', () => {
+      const mockEvent = { target: { complete: jasmine.createSpy('complete') } };
+      component.doRefresh(mockEvent);
+      expect(advanceRequestService.destroyAdvanceRequestsCacheBuster).toHaveBeenCalledTimes(1);
+      expect(advanceService.destroyAdvancesCacheBuster).toHaveBeenCalledTimes(1);
+      expect(mockEvent.target.complete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call complete if event.target is undefined', () => {
+      const mockEvent = { target: undefined };
+      component.doRefresh(mockEvent);
+      expect(advanceRequestService.destroyAdvanceRequestsCacheBuster).toHaveBeenCalledTimes(1);
+      expect(advanceService.destroyAdvancesCacheBuster).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onAdvanceClick():', () => {
+    it('should set id as adv_id and navigate to my_view_advance_request', () => {
+      const mockAdvanceData = cloneDeep(singleExtendedAdvancesData3);
+      mockAdvanceData.type = AdvancesStates.paid;
+      component.onAdvanceClick({ advanceRequest: mockAdvanceData, internalState: { state: 'INQUIRY' } });
+      expect(router.navigate).toHaveBeenCalledOnceWith([
+        '/',
+        'enterprise',
+        'my_view_advance_request',
+        { id: 'advETmi3eePvQ' },
+      ]);
+    });
+
+    it('should set id as areq_id if adv_id is null and navigate to my_view_advance_request', () => {
+      const mockAdvanceData = cloneDeep(singleExtendedAdvancesData3);
+      mockAdvanceData.type = AdvancesStates.paid;
+      mockAdvanceData.adv_id = null;
+      component.onAdvanceClick({ advanceRequest: mockAdvanceData, internalState: { state: 'INQUIRY' } });
+      expect(router.navigate).toHaveBeenCalledOnceWith([
+        '/',
+        'enterprise',
+        'my_view_advance_request',
+        { id: 'areqmq8cmnd5v4' },
+      ]);
+    });
+
+    it('should navigate to my_view_advance', () => {
+      component.onAdvanceClick({ advanceRequest: singleExtendedAdvancesData3, internalState: { state: 'INQUIRY' } });
+      expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_view_advance', { id: 'advETmi3eePvQ' }]);
+    });
+
+    it('should navigate to add_edit_advance_request if advance request is request type and it is in inquiry state', () => {
+      const mockAdvanceData = cloneDeep(singleExtendedAdvancesData3);
+      mockAdvanceData.type = 'request';
+      component.onAdvanceClick({ advanceRequest: mockAdvanceData, internalState: { state: 'INQUIRY' } });
+      expect(router.navigate).toHaveBeenCalledOnceWith([
+        '/',
+        'enterprise',
+        'add_edit_advance_request',
+        { id: 'advETmi3eePvQ' },
+      ]);
     });
   });
 });

--- a/src/app/fyle/my-advances/my-advances.page.spec.ts
+++ b/src/app/fyle/my-advances/my-advances.page.spec.ts
@@ -43,6 +43,7 @@ import { orgSettingsRes } from 'src/app/core/mock-data/org-settings.data';
 import { SortingDirection } from 'src/app/core/models/sorting-direction.model';
 import { SortingParam } from 'src/app/core/models/sorting-param.model';
 import { cloneDeep } from 'lodash';
+import { filterOptions } from 'src/app/core/mock-data/filter-options.data';
 
 describe('MyAdvancesPage', () => {
   let component: MyAdvancesPage;
@@ -453,5 +454,111 @@ describe('MyAdvancesPage', () => {
         { id: 'advETmi3eePvQ' },
       ]);
     });
+  });
+
+  it('onHomeClicked(): should navigate to my_dashboard page and track event', () => {
+    component.onHomeClicked();
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_dashboard'], {
+      queryParams: {
+        state: 'home',
+      },
+    });
+    expect(trackingService.footerHomeTabClicked).toHaveBeenCalledOnceWith({
+      page: 'Advances',
+    });
+  });
+
+  it('onTaskClicked(): should navigate to my_dashboard page with queryParams.state as tasks', () => {
+    component.onTaskClicked();
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_dashboard'], {
+      queryParams: {
+        state: 'tasks',
+        tasksFilters: 'advances',
+      },
+    });
+    expect(trackingService.tasksPageOpened).toHaveBeenCalledOnceWith({
+      Asset: 'Mobile',
+      from: 'My Advances',
+    });
+  });
+
+  it('onCameraClicked(): should navigate to camera_overlay page', () => {
+    component.onCameraClicked();
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'camera_overlay', { navigate_back: true }]);
+  });
+
+  describe('onFilterClose():', () => {
+    beforeEach(() => {
+      filtersHelperService.generateFilterPills.and.returnValue(allFilterPills);
+      spyOn(component.filterParams$, 'next');
+    });
+
+    it('should call filterParams$ with sortParam and sortDir equals to null if argument is sort', () => {
+      component.onFilterClose('sort');
+      expect(component.filterParams$.next).toHaveBeenCalledOnceWith({
+        sortParam: null,
+        sortDir: null,
+      });
+      expect(filtersHelperService.generateFilterPills).toHaveBeenCalledOnceWith(component.filterParams$.value);
+      expect(component.filterPills).toEqual(allFilterPills);
+    });
+
+    it('should call filterParams$ with state equals to null if argument is state', () => {
+      component.onFilterClose('state');
+      expect(component.filterParams$.next).toHaveBeenCalledOnceWith({
+        state: null,
+      });
+      expect(filtersHelperService.generateFilterPills).toHaveBeenCalledOnceWith(component.filterParams$.value);
+      expect(component.filterPills).toEqual(allFilterPills);
+    });
+  });
+
+  describe('onFilterClick():', () => {
+    beforeEach(() => {
+      spyOn(component, 'openFilters');
+    });
+
+    it('onFilterClick(): should call openFilters with State if argument is state', fakeAsync(() => {
+      component.onFilterClick('state');
+      tick(100);
+      expect(component.openFilters).toHaveBeenCalledOnceWith('State');
+    }));
+
+    it('onFilterClick(): should call openFilters with Sort By if argument is sort', fakeAsync(() => {
+      component.onFilterClick('sort');
+      tick(100);
+      expect(component.openFilters).toHaveBeenCalledOnceWith('Sort By');
+    }));
+  });
+
+  it('onFilterPillsClearAll(): should set filterPills to allFilterPills and call filterParams$.next', () => {
+    spyOn(component.filterParams$, 'next');
+    filtersHelperService.generateFilterPills.and.returnValue(allFilterPills);
+    component.onFilterPillsClearAll();
+    expect(component.filterPills).toEqual(allFilterPills);
+    expect(component.filterParams$.next).toHaveBeenCalledOnceWith(component.filterParams$.value);
+  });
+
+  it('openFilters(): should call filtersHelperService.openFilterModal with title and filterParams', fakeAsync(() => {
+    spyOn(component.filterParams$, 'next');
+    filtersHelperService.generateFilterPills.and.returnValue(allFilterPills);
+    filtersHelperService.openFilterModal.and.resolveTo(myAdvancesFiltersData2);
+    component.projectFieldName = 'project';
+    component.openFilters('State');
+    tick(100);
+
+    expect(filtersHelperService.openFilterModal).toHaveBeenCalledOnceWith(
+      component.filterParams$.value,
+      filterOptions,
+      'State'
+    );
+    expect(component.filterParams$.next).toHaveBeenCalledOnceWith(myAdvancesFiltersData2);
+    expect(component.filterPills).toEqual(allFilterPills);
+    expect(filtersHelperService.generateFilterPills).toHaveBeenCalledOnceWith(component.filterParams$.value, 'project');
+  }));
+
+  it('goToAddEditAdvanceRequest(): should navigate to add_edit_advance_request page', () => {
+    component.goToAddEditAdvanceRequest();
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'add_edit_advance_request']);
   });
 });

--- a/src/app/fyle/my-advances/my-advances.page.spec.ts
+++ b/src/app/fyle/my-advances/my-advances.page.spec.ts
@@ -23,8 +23,8 @@ import {
   extendedAdvReqInquiry,
   myAdvanceRequestData5,
   myAdvanceRequestsData2,
-  myAdvancerequestsData3,
-  myAdvancerequestsData4,
+  myAdvanceRequestsData3,
+  myAdvanceRequestsData4,
   singleExtendedAdvReqRes,
 } from 'src/app/core/mock-data/extended-advance-request.data';
 import {
@@ -357,8 +357,8 @@ describe('MyAdvancesPage', () => {
       activatedRoute.snapshot.queryParams.filters = JSON.stringify(draftSentBackFiltersData);
       component.updateMyAdvanceRequests = jasmine
         .createSpy()
-        .and.returnValue([myAdvancerequestsData3, myAdvancerequestsData4]);
-      utilityService.sortAllAdvances.and.returnValue([myAdvancerequestsData4, myAdvancerequestsData3]);
+        .and.returnValue([myAdvanceRequestsData3, myAdvanceRequestsData4]);
+      utilityService.sortAllAdvances.and.returnValue([myAdvanceRequestsData4, myAdvanceRequestsData3]);
       orgSettingsService.get.and.returnValue(
         of({ ...orgSettingsRes, advance_requests: { enabled: false }, advances: { enabled: false } })
       );
@@ -370,9 +370,9 @@ describe('MyAdvancesPage', () => {
         expect(utilityService.sortAllAdvances).toHaveBeenCalledOnceWith(
           SortingDirection.ascending,
           SortingParam.project,
-          [myAdvancerequestsData4, myAdvancerequestsData3]
+          [myAdvanceRequestsData4, myAdvanceRequestsData3]
         );
-        expect(res).toEqual([myAdvancerequestsData4, myAdvancerequestsData3]);
+        expect(res).toEqual([myAdvanceRequestsData4, myAdvanceRequestsData3]);
       });
     });
   });

--- a/src/app/fyle/my-advances/my-advances.page.ts
+++ b/src/app/fyle/my-advances/my-advances.page.ts
@@ -261,7 +261,7 @@ export class MyAdvancesPage implements AfterViewChecked {
         map(() => {
           this.refreshAdvances$.next();
           if (event) {
-            event?.target?.complete();
+            event.target?.complete();
           }
         })
       )


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2bccce7</samp>

This pull request adds and updates mock data and tests for the my advances page. It also fixes a typo in the extended advance model and removes an unnecessary operator in the my advances page logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2bccce7</samp>

> _Mock data for tests_
> _`my advances` page improved_
> _Autumn of bugfix_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2bccce7</samp>

*  Add new mock data objects for extended advance and extended advance request with custom properties for testing ([link](https://github.com/fylein/fyle-mobile-app/pull/2410/files?diff=unified&w=0#diff-5523a698b796df7860831812b5e4121666f847e9e39be66fa11c5d5dbfe1e577R723-R732), [link](https://github.com/fylein/fyle-mobile-app/pull/2410/files?diff=unified&w=0#diff-a850c84de490df80c1a7fc8d4713fb9a7b420e9539224d90a89aa03833dc618aR129-R139))
*  Fix typo in extended advance interface to match API response and app logic (`orig_currency` instead of `org_currency`) ([link](https://github.com/fylein/fyle-mobile-app/pull/2410/files?diff=unified&w=0#diff-12b4217289dc33bc8608de83b1a8ca7532a0c890276a59e22640b8822d71c9e9L52-R52))
*  Import lodash cloneDeep function for creating copies of mock data objects in spec file ([link](https://github.com/fylein/fyle-mobile-app/pull/2410/files?diff=unified&w=0#diff-b5c01b9eeeec345d0700b5cb4a8b0454a8c2244a15278d654fe57982233c0fecR45))
*  Import new mock data objects in spec file for testing updateMyAdvances and updateMyAdvanceRequests methods ([link](https://github.com/fylein/fyle-mobile-app/pull/2410/files?diff=unified&w=0#diff-b5c01b9eeeec345d0700b5cb4a8b0454a8c2244a15278d654fe57982233c0fecR24), [link](https://github.com/fylein/fyle-mobile-app/pull/2410/files?diff=unified&w=0#diff-b5c01b9eeeec345d0700b5cb4a8b0454a8c2244a15278d654fe57982233c0fecL29-R34))
*  Add new test cases for updateMyAdvances and updateMyAdvanceRequests methods, doRefresh method, and onAdvanceClick method with different scenarios and expectations ([link](https://github.com/fylein/fyle-mobile-app/pull/2410/files?diff=unified&w=0#diff-b5c01b9eeeec345d0700b5cb4a8b0454a8c2244a15278d654fe57982233c0fecR379-R456))
*  Remove unnecessary optional chaining operator in doRefresh method of my advances page ([link](https://github.com/fylein/fyle-mobile-app/pull/2410/files?diff=unified&w=0#diff-f2951c001ee49b79e597c3323e7a4ae3e3d3b94861f1f1d7dfc3be1b96fd8e0bL264-R264))

## Clickup
https://app.clickup.com/t/85ztyue80

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes