### PR TITLE
test: remaining coverage of fy-input-popover comp

### DIFF
--- a/src/app/shared/components/fy-input-popover/fy-input-popover.component.spec.ts
+++ b/src/app/shared/components/fy-input-popover/fy-input-popover.component.spec.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { IonicModule, PopoverController } from '@ionic/angular';
-import { click, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
+import { click, getElementBySelector, getElementRef, getTextContent } from 'src/app/core/dom-helpers';
 import { FyInputPopoverComponent } from './fy-input-popover.component';
 
 describe('FyInputPopoverComponent', () => {
@@ -44,15 +44,28 @@ describe('FyInputPopoverComponent', () => {
     expect(popoverController.dismiss).toHaveBeenCalledTimes(1);
   }));
 
-  it('saveValue(): should save input value', fakeAsync(() => {
-    popoverController.dismiss.and.returnValue(Promise.resolve(true));
-    component.inputValue = 'input';
-    fixture.detectChanges();
+  describe('saveValue():', () => {
+    beforeEach(() => {
+      popoverController.dismiss.and.returnValue(Promise.resolve(true));
+      component.inputValue = 'input';
+    });
 
-    tick();
-    component.saveValue();
-    expect(popoverController.dismiss).toHaveBeenCalledOnceWith({ newValue: component.inputValue });
-  }));
+    it('should save input value', fakeAsync(() => {
+      fixture.detectChanges();
+
+      tick();
+      component.saveValue();
+      expect(popoverController.dismiss).toHaveBeenCalledOnceWith({ newValue: component.inputValue });
+    }));
+
+    it('should not call popoverController.dismiss if error length is greater than 0', () => {
+      component.error = 'Please enter a valid mobile number';
+      fixture.detectChanges();
+
+      component.saveValue();
+      expect(popoverController.dismiss).not.toHaveBeenCalled();
+    });
+  });
 
   it('should display title', () => {
     component.title = 'Title';
@@ -81,5 +94,58 @@ describe('FyInputPopoverComponent', () => {
 
     expect(getTextContent(getElementBySelector(fixture, '.input-popover--input-container__label'))).toEqual('Label  *');
     expect(getTextContent(getElementBySelector(fixture, '.input-popover--input-container__mandatory'))).toEqual('*');
+  });
+
+  it('onFocus(): should set error to null', () => {
+    component.error = 'Please enter valid mobile number';
+    fixture.detectChanges();
+
+    component.onFocus();
+    expect(component.error).toEqual(null);
+  });
+
+  it('ngAfterViewInit(): should focus on input element', fakeAsync(() => {
+    const inputEl = getElementRef(fixture, 'input');
+    const focusSpy = spyOn(inputEl.nativeElement, 'focus');
+    component.ngAfterViewInit();
+
+    tick(400);
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  }));
+
+  describe('validateInput():', () => {
+    beforeEach(() => {
+      component.isRequired = true;
+    });
+
+    it('should not change error if input value is not empty', () => {
+      component.error = null;
+      component.inputValue = 'value';
+      fixture.detectChanges();
+
+      component.validateInput();
+      expect(component.error).toBeNull();
+    });
+
+    it('should set error if input value is empty and other than tel', () => {
+      component.error = null;
+      component.inputLabel = 'Report Name';
+      component.inputValue = '';
+      fixture.detectChanges();
+
+      component.validateInput();
+      expect(component.error).toEqual('Please enter a Report Name');
+    });
+
+    it('should set error if input value is empty and type is tel but value is not valid', () => {
+      component.error = null;
+      component.inputLabel = 'Mobile Number';
+      component.inputValue = '9534';
+      component.inputType = 'tel';
+      fixture.detectChanges();
+
+      component.validateInput();
+      expect(component.error).toEqual('Please enter a valid mobile number with country code. e.g. +12025559975');
+    });
   });
 });

--- a/src/app/shared/components/fy-input-popover/fy-input-popover.component.spec.ts
+++ b/src/app/shared/components/fy-input-popover/fy-input-popover.component.spec.ts
@@ -53,7 +53,6 @@ describe('FyInputPopoverComponent', () => {
     it('should save input value', fakeAsync(() => {
       fixture.detectChanges();
 
-      tick();
       component.saveValue();
       expect(popoverController.dismiss).toHaveBeenCalledOnceWith({ newValue: component.inputValue });
     }));

--- a/src/app/shared/components/fy-input-popover/fy-input-popover.component.spec.ts
+++ b/src/app/shared/components/fy-input-popover/fy-input-popover.component.spec.ts
@@ -46,7 +46,7 @@ describe('FyInputPopoverComponent', () => {
 
   describe('saveValue():', () => {
     beforeEach(() => {
-      popoverController.dismiss.and.returnValue(Promise.resolve(true));
+      popoverController.dismiss.and.resolveTo(true);
       component.inputValue = 'input';
     });
 
@@ -57,7 +57,7 @@ describe('FyInputPopoverComponent', () => {
       expect(popoverController.dismiss).toHaveBeenCalledOnceWith({ newValue: component.inputValue });
     }));
 
-    it('should not call popoverController.dismiss if error length is greater than 0', () => {
+    it('should not save the input value and close the popover if the input value is invalid', () => {
       component.error = 'Please enter a valid mobile number';
       fixture.detectChanges();
 
@@ -105,11 +105,11 @@ describe('FyInputPopoverComponent', () => {
 
   it('ngAfterViewInit(): should focus on input element', fakeAsync(() => {
     const inputEl = getElementRef(fixture, 'input');
-    const focusSpy = spyOn(inputEl.nativeElement, 'focus');
+    spyOn(inputEl.nativeElement, 'focus');
     component.ngAfterViewInit();
 
     tick(400);
-    expect(focusSpy).toHaveBeenCalledTimes(1);
+    expect(inputEl.nativeElement.focus).toHaveBeenCalledTimes(1);
   }));
 
   describe('validateInput():', () => {


### PR DESCRIPTION

### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dfd5695</samp>

Improved unit testing for `fy-input-popover` component. Added tests for input access, saving, and validation. Covered different scenarios and edge cases.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dfd5695</samp>

> _To test `fy-input-popover`_
> _Some unit tests they did cover_
> _The input and save_
> _And how to behave_
> _When the input is not proper_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dfd5695</samp>

* Imported `getElementRef` function to access input element in tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2412/files?diff=unified&w=0#diff-6008c7ebd66841dc1b0938b837903ad9f9a5091e60108f6b0f73aa73bab298d7L6-R6))
* Tested `saveValue` function for valid and invalid input values and popover dismissal ([link](https://github.com/fylein/fyle-mobile-app/pull/2412/files?diff=unified&w=0#diff-6008c7ebd66841dc1b0938b837903ad9f9a5091e60108f6b0f73aa73bab298d7L47-R69))
* Tested `onFocus`, `ngAfterViewInit` and `validateInput` functions for input focus, error message and validation logic ([link](https://github.com/fylein/fyle-mobile-app/pull/2412/files?diff=unified&w=0#diff-6008c7ebd66841dc1b0938b837903ad9f9a5091e60108f6b0f73aa73bab298d7R98-R150))

## Clickup
app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI change