### PR TITLE
test: 100% coverage of format-date directive

### DIFF
--- a/src/app/shared/directive/format-date.directive.spec.ts
+++ b/src/app/shared/directive/format-date.directive.spec.ts
@@ -21,7 +21,7 @@ describe('FormatDateDirective', () => {
     fixture = TestBed.createComponent(TestFormatDateDirectiveComponent);
     component = fixture.componentInstance;
     inputEl = fixture.debugElement.query(By.css('input'));
-    directive = inputEl.injector.get(FormatDateDirective) as FormatDateDirective;
+    directive = inputEl.injector.get(FormatDateDirective);
   });
 
   it('should create an instance', () => {

--- a/src/app/shared/directive/format-date.directive.spec.ts
+++ b/src/app/shared/directive/format-date.directive.spec.ts
@@ -1,9 +1,68 @@
-// TODO: uncomment when elementRef is figured out for testing
-// import { FormatDateDirective } from './format-date.directive';
+import { Component, DebugElement, Renderer2 } from '@angular/core';
+import { FormatDateDirective } from './format-date.directive';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 
-// xdescribe('FormatDateDirective', () => {
-//   it('should create an instance', () => {
-//     const directive = new FormatDateDirective();
-//     expect(directive).toBeTruthy();
-//   });
-// });
+@Component({
+  template: `<input appFormatDate type="date" />`,
+})
+class TestFormatDateDirectiveComponent {}
+
+describe('FormatDateDirective', () => {
+  let component: TestFormatDateDirectiveComponent;
+  let fixture: ComponentFixture<TestFormatDateDirectiveComponent>;
+  let inputEl: DebugElement;
+  let directive: FormatDateDirective;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestFormatDateDirectiveComponent, FormatDateDirective],
+    });
+    fixture = TestBed.createComponent(TestFormatDateDirectiveComponent);
+    component = fixture.componentInstance;
+    inputEl = fixture.debugElement.query(By.css('input'));
+    directive = inputEl.injector.get(FormatDateDirective) as FormatDateDirective;
+  });
+
+  it('should create an instance', () => {
+    expect(directive).toBeTruthy();
+  });
+
+  it('get selectedElement(): should return the current html element', () => {
+    const selectedElement = inputEl.nativeElement;
+    expect(directive.selectedElement).toEqual(selectedElement);
+  });
+
+  it('onChange(): should call modifyDisplayValue once', () => {
+    spyOn(directive, 'modifyDisplayValue');
+    directive.onChange('2023-01-02');
+    expect(directive.modifyDisplayValue).toHaveBeenCalledOnceWith('2023-01-02');
+  });
+
+  it('ngOnInit(): should call modifyDisplayValue once with the initial value', () => {
+    spyOn(directive, 'modifyDisplayValue');
+    directive.ngOnInit();
+    expect(directive.modifyDisplayValue).toHaveBeenCalledOnceWith('');
+  });
+
+  describe('modifyDisplayValue()', () => {
+    it('should remove class date-input__placeholder and set data-date attribute to date provided in the input', () => {
+      directive.modifyDisplayValue('2023-01-02');
+      expect(inputEl.nativeElement.getAttribute('data-date')).toEqual('Jan 02, 2023');
+      expect(inputEl.nativeElement.classList.contains('date-input__placeholder')).toBeFalse();
+    });
+
+    it('should add class date-input__placeholder and set data-date attribute to Select date if no name attribute is present', () => {
+      directive.modifyDisplayValue('');
+      expect(inputEl.nativeElement.getAttribute('data-date')).toEqual('Select date');
+      expect(inputEl.nativeElement.classList.contains('date-input__placeholder')).toBeTrue();
+    });
+
+    it('should add class date-input__placeholder and set data-date attribute to Select journey date if name attribute is equal to journey date', () => {
+      inputEl.nativeElement.name = 'journey date';
+      directive.modifyDisplayValue('');
+      expect(inputEl.nativeElement.getAttribute('data-date')).toEqual('Select journey date');
+      expect(inputEl.nativeElement.classList.contains('date-input__placeholder')).toBeTrue();
+    });
+  });
+});


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 904f7fa</samp>

Implemented unit tests for `FormatDateDirective` in `format-date.directive.spec.ts`. The tests check the directive's methods and behavior for formatting date input values as placeholders.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 904f7fa</samp>

> _`FormatDateDirective`_
> _Testing its methods and view_
> _Autumn leaves mock time_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 904f7fa</samp>

*  Implement unit tests for FormatDateDirective ([link](https://github.com/fylein/fyle-mobile-app/pull/2423/files?diff=unified&w=0#diff-c90089f0caea14ef5ed115019d02161836377de66f3fb907514dc36771b2e2e7L1-R68))

## Clickup
https://app.clickup.com/t/85ztznx0r

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes