### PR TITLE
test: 80% coverage of stats component

### DIFF
--- a/src/app/fyle/dashboard/stats/stats.component.spec.ts
+++ b/src/app/fyle/dashboard/stats/stats.component.spec.ts
@@ -16,6 +16,8 @@ import { EventEmitter } from '@angular/core';
 import { orgSettingsParamsWithSimplifiedReport, orgSettingsRes } from 'src/app/core/mock-data/org-settings.data';
 import { expectedReportStats } from 'src/app/core/mock-data/report-stats.data';
 import { reportStatsData1, reportStatsData2 } from 'src/app/core/mock-data/report-stats-data.data';
+import { expectedIncompleteExpStats, expectedUnreportedExpStats } from 'src/app/core/mock-data/stats.data';
+import { PerfTrackers } from 'src/app/core/models/perf-trackers.enum';
 
 describe('StatsComponent', () => {
   let component: StatsComponent;
@@ -28,6 +30,7 @@ describe('StatsComponent', () => {
   let orgSettingsService: jasmine.SpyObj<OrgSettingsService>;
   let orgService: jasmine.SpyObj<OrgService>;
   let paymentModeService: jasmine.SpyObj<PaymentModesService>;
+  let performance: jasmine.SpyObj<Performance>;
 
   beforeEach(waitForAsync(() => {
     const dashboardServiceSpy = jasmine.createSpyObj('DashboardService', [
@@ -194,6 +197,122 @@ describe('StatsComponent', () => {
       component.processingStats$.subscribe((res) => {
         expect(res).toEqual(expectedReportStats.processing);
       });
+    });
+  });
+
+  it('initializeExpensesStats(): should set unreportedExpensesStats$ and incompleteExpensesStats$', (done) => {
+    dashboardService.getUnreportedExpensesStats.and.returnValue(of(expectedUnreportedExpStats));
+    dashboardService.getIncompleteExpensesStats.and.returnValue(of(expectedIncompleteExpStats));
+
+    component.initializeExpensesStats();
+
+    component.unreportedExpensesStats$.subscribe((res) => {
+      expect(res).toEqual(expectedUnreportedExpStats);
+      expect(dashboardService.getUnreportedExpensesStats).toHaveBeenCalledTimes(1);
+      expect(component.isUnreportedExpensesStatsLoading).toBeFalse();
+    });
+
+    component.incompleteExpensesStats$.subscribe((res) => {
+      expect(res).toEqual(expectedIncompleteExpStats);
+      expect(dashboardService.getIncompleteExpensesStats).toHaveBeenCalledTimes(1);
+      expect(component.isIncompleteExpensesStatsLoading).toBeFalse();
+      done();
+    });
+  });
+
+  describe('trackOrgLaunchTime()', () => {
+    it('should track org launch time if getEntriesByName() returns empty array', () => {
+      const performance = {
+        mark: jasmine.createSpy('mark'),
+        measure: jasmine.createSpy('measure'),
+        getEntriesByName: jasmine
+          .createSpy('getEntriesByName')
+          .and.returnValues([], [{ duration: 12000 }], [{ detail: true }]),
+        now: jasmine.createSpy('now'),
+      };
+      Object.defineProperty(window, 'performance', {
+        value: performance,
+      });
+      component.trackOrgLaunchTime(true);
+      expect(performance.mark).toHaveBeenCalledOnceWith(PerfTrackers.appLaunchEndTime);
+      expect(performance.measure).toHaveBeenCalledOnceWith(
+        PerfTrackers.appLaunchTime,
+        PerfTrackers.appLaunchStartTime,
+        PerfTrackers.appLaunchEndTime
+      );
+      expect(performance.getEntriesByName).toHaveBeenCalledTimes(3);
+      expect(trackingService.appLaunchTime).toHaveBeenCalledOnceWith({
+        'App launch time': '12.000',
+        'Is logged in': true,
+        'Is multi org': true,
+      });
+    });
+
+    it('should not track org launch time if getEntriesByName() returns undefined', () => {
+      const performance = {
+        mark: jasmine.createSpy('mark'),
+        measure: jasmine.createSpy('measure'),
+        getEntriesByName: jasmine.createSpy('getEntriesByName').and.returnValue(undefined),
+        now: jasmine.createSpy('now'),
+      };
+      Object.defineProperty(window, 'performance', {
+        value: performance,
+      });
+      component.trackOrgLaunchTime(true);
+      expect(performance.mark).not.toHaveBeenCalled();
+      expect(performance.measure).not.toHaveBeenCalled();
+      expect(performance.getEntriesByName).toHaveBeenCalledTimes(1);
+      expect(trackingService.appLaunchTime).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('init():', () => {
+    beforeEach(() => {
+      spyOn(component, 'initializeReportStats');
+      spyOn(component, 'initializeExpensesStats');
+      spyOn(component, 'trackOrgLaunchTime');
+      currencyService.getHomeCurrency.and.returnValue(of('INR'));
+      orgService.getOrgs.and.returnValue(of([]));
+    });
+
+    it('should call initializeReportStats(), initializeExpensesStats() and trackOrgLaunchTime() with false if org length is less than 1', () => {
+      component.init();
+
+      expect(component.initializeReportStats).toHaveBeenCalledTimes(1);
+      expect(component.initializeExpensesStats).toHaveBeenCalledTimes(1);
+      component.homeCurrency$.subscribe((res) => {
+        expect(res).toEqual('INR');
+      });
+      component.currencySymbol$.subscribe((res) => {
+        expect(res).toEqual('₹');
+      });
+      expect(component.trackOrgLaunchTime).toHaveBeenCalledOnceWith(false);
+    });
+
+    it('should call initializeReportStats(), initializeExpensesStats() and trackOrgLaunchTime() with false if org is undefined', () => {
+      orgService.getOrgs.and.returnValue(of(undefined));
+      component.init();
+
+      expect(component.initializeReportStats).toHaveBeenCalledTimes(1);
+      expect(component.initializeExpensesStats).toHaveBeenCalledTimes(1);
+      component.homeCurrency$.subscribe((res) => {
+        expect(res).toEqual('INR');
+      });
+      component.currencySymbol$.subscribe((res) => {
+        expect(res).toEqual('₹');
+      });
+      expect(component.trackOrgLaunchTime).toHaveBeenCalledOnceWith(false);
+    });
+  });
+
+  it('ngOnInit(): should setup homeCurrency and call setupNetworkWatcher once', () => {
+    spyOn(component, 'setupNetworkWatcher');
+    currencyService.getHomeCurrency.and.returnValue(of('INR'));
+    component.ngOnInit();
+
+    expect(component.setupNetworkWatcher).toHaveBeenCalledTimes(1);
+    component.homeCurrency$.subscribe((res) => {
+      expect(res).toEqual('INR');
     });
   });
 });


### PR DESCRIPTION

### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ac74f54</samp>

This pull request adds unit tests for the `stats.component` that displays the expenses statistics on the dashboard. The tests use mock data and a spy object to verify the component's behavior and performance. The tests are written in the `stats.component.spec.ts` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ac74f54</samp>

> _Sing, O Muse, of the cunning coder who devised_
> _A mock data set and a spy object, to test his skill_
> _Against the stats component, that displays the expenses_
> _Of heroes and their households, as they wage their wars._

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ac74f54</samp>

* Import mock data and enum for testing expenses stats and performance trackers ([link](https://github.com/fylein/fyle-mobile-app/pull/2446/files?diff=unified&w=0#diff-cdb812bdc51d4ffcf4bd86b3f922f6806ef7e05737e28199ec673f00df6ce88bR19-R20))
* Declare spy object for performance API to mock its methods and properties ([link](https://github.com/fylein/fyle-mobile-app/pull/2446/files?diff=unified&w=0#diff-cdb812bdc51d4ffcf4bd86b3f922f6806ef7e05737e28199ec673f00df6ce88bR33))
  - Initialization and fetching of stats data ([link](https://github.com/fylein/fyle-mobile-app/pull/2446/files?diff=unified&w=0#diff-cdb812bdc51d4ffcf4bd86b3f922f6806ef7e05737e28199ec673f00df6ce88bR202-R317))

## Clickup
https://app.clickup.com/t/85ztznw6h

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes