### PR TITLE
test: Code Coverage: Notifications Page #1 

### DIFF
--- a/src/app/core/mock-data/org-settings.data.ts
+++ b/src/app/core/mock-data/org-settings.data.ts
@@ -1,5 +1,5 @@
 import { AllowedPaymentModes } from '../models/allowed-payment-modes.enum';
-import { OrgSettings, TaxSettings } from '../models/org-settings.model';
+import { EmailEvents, OrgSettings, TaxSettings } from '../models/org-settings.model';
 import { orgSettingsData } from '../test-data/accounts.service.spec.data';
 
 export const orgSettingsRes: OrgSettings = {
@@ -1345,4 +1345,12 @@ export const orgSettingsWoProjects: OrgSettings = {
 export const orgSettingsWoMileage: OrgSettings = {
   ...orgSettingsParams2,
   mileage: null,
+};
+
+export const orgSettingsWithUnsubscribeEvent: OrgSettings = {
+  ...orgSettingsRes,
+  admin_email_settings: {
+    ...orgSettingsRes.admin_email_settings,
+    unsubscribed_events: [EmailEvents.DELEGATOR_SUBSCRIPTION, EmailEvents.EADVANCES_CREATED],
+  },
 };

--- a/src/app/core/mock-data/org-user-settings.data.ts
+++ b/src/app/core/mock-data/org-user-settings.data.ts
@@ -683,3 +683,30 @@ export const orgUserSettingsWoProjects: OrgUserSettings = {
   ...orgUserSettingsData,
   project_ids: null,
 };
+
+export const notificationDelegateeSettings1: OrgUserSettings = {
+  ...orgUserSettingsData,
+  notification_settings: {
+    ...orgUserSettingsData.notification_settings,
+    notify_delegatee: true,
+    notify_user: false,
+  },
+};
+
+export const notificationDelegateeSettings2: OrgUserSettings = {
+  ...orgUserSettingsData,
+  notification_settings: {
+    ...orgUserSettingsData.notification_settings,
+    notify_delegatee: false,
+    notify_user: true,
+  },
+};
+
+export const notificationDelegateeSettings3: OrgUserSettings = {
+  ...orgUserSettingsData,
+  notification_settings: {
+    ...orgUserSettingsData.notification_settings,
+    notify_delegatee: true,
+    notify_user: true,
+  },
+};

--- a/src/app/core/models/notification-events.model.ts
+++ b/src/app/core/models/notification-events.model.ts
@@ -16,7 +16,7 @@ export type EmailEvents = {
 export interface NotificationEvents {
   events: EmailEvents[];
   features: {
-    advances: {
+    advances?: {
       selected: boolean;
       textLabel: string;
     };

--- a/src/app/fyle/notifications/notifications.page.spec.ts
+++ b/src/app/fyle/notifications/notifications.page.spec.ts
@@ -121,7 +121,7 @@ describe('NotificationsPage', () => {
       });
     });
 
-    it('should only the user', (done) => {
+    it('should only notify the user', (done) => {
       component.orgUserSettings$ = of(notificationDelegateeSettings2);
 
       component.getDelegateeSubscription().subscribe((res) => {
@@ -130,7 +130,7 @@ describe('NotificationsPage', () => {
       });
     });
 
-    it('should both user and delegatee', (done) => {
+    it('should notify both the user and delegatee', (done) => {
       component.orgUserSettings$ = of(notificationDelegateeSettings3);
 
       component.getDelegateeSubscription().subscribe((res) => {

--- a/src/app/fyle/notifications/notifications.page.spec.ts
+++ b/src/app/fyle/notifications/notifications.page.spec.ts
@@ -1,24 +1,92 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule, NavController } from '@ionic/angular';
 
 import { NotificationsPage } from './notifications.page';
+import { AuthService } from 'src/app/core/services/auth.service';
+import { OrgUserSettingsService } from 'src/app/core/services/org-user-settings.service';
+import { FormArray, FormBuilder } from '@angular/forms';
+import { OrgSettingsService } from 'src/app/core/services/org-settings.service';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { orgUserSettingsData } from 'src/app/core/mock-data/org-user-settings.data';
+import { of } from 'rxjs';
+import { apiEouRes } from 'src/app/core/mock-data/extended-org-user.data';
+import { orgSettingsData } from 'src/app/core/test-data/accounts.service.spec.data';
+import { notificationEventsData } from 'src/app/core/mock-data/notification-events.data';
 
-xdescribe('NotificationsPage', () => {
+fdescribe('NotificationsPage', () => {
   let component: NotificationsPage;
   let fixture: ComponentFixture<NotificationsPage>;
+  let authService: jasmine.SpyObj<AuthService>;
+  let orgUserSettingsService: jasmine.SpyObj<OrgUserSettingsService>;
+  let fb: FormBuilder;
+  let orgSettingsService: jasmine.SpyObj<OrgSettingsService>;
+  let router: jasmine.SpyObj<Router>;
+  let navController: jasmine.SpyObj<NavController>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [NotificationsPage],
-        imports: [IonicModule.forRoot()],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    const authServiceSpy = jasmine.createSpyObj('AuthService', ['getEou']);
+    const orgUserSettingsServiceSpy = jasmine.createSpyObj('OrgUserSettingsService', [
+      'post',
+      'clearOrgUserSettings',
+      'get',
+      'getNotificationEvents',
+    ]);
+    const orgSettingsServiceSpy = jasmine.createSpyObj('OrgSettingsService', ['get']);
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    const navControllerSpy = jasmine.createSpyObj('NavController', ['back']);
 
-      fixture = TestBed.createComponent(NotificationsPage);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-    })
-  );
+    TestBed.configureTestingModule({
+      declarations: [NotificationsPage],
+      imports: [RouterTestingModule],
+      providers: [
+        FormBuilder,
+        {
+          provide: AuthService,
+          useValue: authServiceSpy,
+        },
+        {
+          provide: OrgUserSettingsService,
+          useValue: orgUserSettingsServiceSpy,
+        },
+        {
+          provide: OrgSettingsService,
+          useValue: orgSettingsServiceSpy,
+        },
+        {
+          provide: Router,
+          useValue: routerSpy,
+        },
+        {
+          provide: NavController,
+          useValie: navControllerSpy,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NotificationsPage);
+    component = fixture.componentInstance;
+
+    authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+    orgUserSettingsService = TestBed.inject(OrgUserSettingsService) as jasmine.SpyObj<OrgUserSettingsService>;
+    orgSettingsService = TestBed.inject(OrgSettingsService) as jasmine.SpyObj<OrgSettingsService>;
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    navController = TestBed.inject(NavController) as jasmine.SpyObj<NavController>;
+    fb = TestBed.inject(FormBuilder);
+
+    component.notificationForm = fb.group({
+      notifyOption: [],
+      pushEvents: new FormArray([]),
+      emailEvents: new FormArray([]),
+    });
+
+    orgUserSettingsService.get.and.returnValue(of(orgUserSettingsData));
+    authService.getEou.and.resolveTo(apiEouRes);
+    orgSettingsService.get.and.returnValue(of(orgSettingsData));
+    orgUserSettingsService.getNotificationEvents.and.returnValue(of(notificationEventsData));
+
+    fixture.detectChanges();
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/fyle/notifications/notifications.page.spec.ts
+++ b/src/app/fyle/notifications/notifications.page.spec.ts
@@ -1,26 +1,26 @@
 import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
-import { IonicModule, NavController } from '@ionic/angular';
+import { NavController } from '@ionic/angular';
 
-import { NotificationsPage } from './notifications.page';
-import { AuthService } from 'src/app/core/services/auth.service';
-import { OrgUserSettingsService } from 'src/app/core/services/org-user-settings.service';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { FormArray, FormBuilder, ReactiveFormsModule } from '@angular/forms';
-import { OrgSettingsService } from 'src/app/core/services/org-settings.service';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { cloneDeep } from 'lodash';
+import { of } from 'rxjs';
+import { apiEouRes } from 'src/app/core/mock-data/extended-org-user.data';
+import { notificationEventsData } from 'src/app/core/mock-data/notification-events.data';
+import { orgSettingsWithUnsubscribeEvent } from 'src/app/core/mock-data/org-settings.data';
 import {
   notificationDelegateeSettings1,
   notificationDelegateeSettings2,
   notificationDelegateeSettings3,
   orgUserSettingsData,
 } from 'src/app/core/mock-data/org-user-settings.data';
-import { of } from 'rxjs';
-import { apiEouRes } from 'src/app/core/mock-data/extended-org-user.data';
+import { AuthService } from 'src/app/core/services/auth.service';
+import { OrgSettingsService } from 'src/app/core/services/org-settings.service';
+import { OrgUserSettingsService } from 'src/app/core/services/org-user-settings.service';
 import { orgSettingsData } from 'src/app/core/test-data/accounts.service.spec.data';
-import { notificationEventsData } from 'src/app/core/mock-data/notification-events.data';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { orgSettingsWithUnsubscribeEvent } from 'src/app/core/mock-data/org-settings.data';
-import { emailEvents } from 'src/app/core/mock-data/email-events.data';
+import { NotificationsPage } from './notifications.page';
 
 export class NavMock {
   public navigateBack: Function = (url: string | any[], options: any) => {};
@@ -140,10 +140,32 @@ describe('NotificationsPage', () => {
     });
   });
 
+  it('setEvents(): should set events', () => {
+    component.setEvents(cloneDeep(notificationEventsData), cloneDeep(orgUserSettingsData));
+
+    expect(component.emailEvents.length).not.toEqual(0);
+    expect(component.pushEvents.length).not.toEqual(0);
+  });
+
   it('goBack(): should go back to the profile page', () => {
     component.goBack();
 
     expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_profile']);
+  });
+
+  it('saveNotificationSettings(): should save notification settings', () => {
+    component.setEvents(notificationEventsData, orgUserSettingsData);
+    component.notificationEvents = cloneDeep(notificationEventsData);
+    component.orgUserSettings = cloneDeep(orgUserSettingsData);
+    orgUserSettingsService.post.and.returnValue(of(null));
+    orgUserSettingsService.clearOrgUserSettings.and.returnValue(of(null));
+    spyOn(component, 'navBack');
+
+    component.saveNotificationSettings();
+
+    expect(orgUserSettingsService.post).toHaveBeenCalledOnceWith(component.orgUserSettings);
+    expect(orgUserSettingsService.clearOrgUserSettings).toHaveBeenCalledTimes(1);
+    expect(component.navBack).toHaveBeenCalledTimes(1);
   });
 
   it('isAllEventsSubscribed(): should check if all events are subscribed', () => {
@@ -157,6 +179,70 @@ describe('NotificationsPage', () => {
     });
   });
 
+  it('removeAdminUnsbscribedEvents(): should remove admin unsubscribe events', fakeAsync(() => {
+    component.orgSettings$ = of(orgSettingsWithUnsubscribeEvent);
+    component.orgSettings = orgSettingsWithUnsubscribeEvent;
+    component.notificationEvents = cloneDeep(notificationEventsData);
+
+    component.removeAdminUnsbscribedEvents();
+    tick(500);
+
+    expect(Object.keys(component.notificationEvents.features).includes('advances')).toBeFalse();
+  }));
+
+  it('updateAdvanceRequestFeatures(): should update advance request features', () => {
+    component.notificationEvents = notificationEventsData;
+    component.orgSettings$ = of(orgSettingsData);
+
+    component.updateAdvanceRequestFeatures();
+
+    expect(Object.keys(notificationEventsData.features).includes('advances')).toBeFalse();
+  });
+
+  describe('updateDelegateeNotifyPreference():', () => {
+    it('should set settings to notify delegatee', () => {
+      component.orgUserSettings = orgUserSettingsData;
+
+      component.updateDelegateeNotifyPreference({
+        value: 'Notify my delegate',
+      });
+
+      expect(component.orgUserSettings.notification_settings.notify_delegatee).toBeTrue();
+      expect(component.orgUserSettings.notification_settings.notify_user).toBeFalse();
+    });
+
+    it('should set settings to notify delegatee and user', () => {
+      component.orgUserSettings = orgUserSettingsData;
+
+      component.updateDelegateeNotifyPreference({
+        value: 'Notify me and my delegate',
+      });
+
+      expect(component.orgUserSettings.notification_settings.notify_delegatee).toBeTrue();
+      expect(component.orgUserSettings.notification_settings.notify_user).toBeTrue();
+    });
+
+    it('should set settings to notify user', () => {
+      component.orgUserSettings = orgUserSettingsData;
+
+      component.updateDelegateeNotifyPreference({
+        value: 'Notify me only',
+      });
+
+      expect(component.orgUserSettings.notification_settings.notify_delegatee).toBeFalse();
+      expect(component.orgUserSettings.notification_settings.notify_user).toBeTrue();
+    });
+  });
+
+  it('removeDisabledFeatures(): should remove disabled features', () => {
+    spyOn(component, 'updateAdvanceRequestFeatures');
+    component.notificationEvents = cloneDeep(notificationEventsData);
+
+    component.removeDisabledFeatures();
+
+    expect(component.updateAdvanceRequestFeatures).toHaveBeenCalledTimes(1);
+  });
+
   it('updateNotificationEvents(): should update notification events', () => {
     spyOn(component, 'removeAdminUnsbscribedEvents');
     spyOn(component, 'removeDisabledFeatures');
@@ -165,6 +251,52 @@ describe('NotificationsPage', () => {
 
     expect(component.removeAdminUnsbscribedEvents).toHaveBeenCalledTimes(1);
     expect(component.removeDisabledFeatures).toHaveBeenCalledTimes(1);
+  });
+
+  describe('toggleAllSelected():', () => {
+    beforeEach(() => {
+      component.setEvents(notificationEventsData, orgUserSettingsData);
+    });
+
+    it('should set value if email event exists', fakeAsync(() => {
+      component.isAllSelected = {
+        emailEvents: true,
+      };
+
+      component.toggleAllSelected('email');
+      tick(500);
+
+      expect(component.emailEvents.getRawValue().length).not.toBe(0);
+    }));
+
+    it('should set value if email event does not exist', fakeAsync(() => {
+      component.isAllSelected = {};
+
+      component.toggleAllSelected('email');
+      tick(500);
+
+      expect(component.emailEvents.getRawValue().length).not.toBe(0);
+    }));
+
+    it('should set value if push event exists', fakeAsync(() => {
+      component.isAllSelected = {
+        pushEvents: true,
+      };
+
+      component.toggleAllSelected('push');
+      tick(500);
+
+      expect(component.emailEvents.getRawValue().length).not.toBe(0);
+    }));
+
+    it('should set value if push event does not exist', fakeAsync(() => {
+      component.isAllSelected = {};
+
+      component.toggleAllSelected('push');
+      tick(500);
+
+      expect(component.emailEvents.getRawValue().length).not.toBe(0);
+    }));
   });
 
   it('ngOnInit(): should initialize the form and observables', (done) => {
@@ -207,4 +339,22 @@ describe('NotificationsPage', () => {
     expect(component.setEvents).toHaveBeenCalledTimes(1);
     done();
   });
+
+  it('toggleEvents(): should toggle events on value change', fakeAsync(() => {
+    component.isAllSelected = {
+      emailEvents: true,
+      pushEvents: false,
+    };
+
+    component.toggleEvents();
+    tick(500);
+
+    component.setEvents(notificationEventsData, orgUserSettingsData);
+    tick(500);
+
+    expect(component.isAllSelected).toEqual({
+      emailEvents: false,
+      pushEvents: false,
+    });
+  }));
 });

--- a/src/app/fyle/notifications/notifications.page.spec.ts
+++ b/src/app/fyle/notifications/notifications.page.spec.ts
@@ -1,20 +1,34 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { IonicModule, NavController } from '@ionic/angular';
 
 import { NotificationsPage } from './notifications.page';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { OrgUserSettingsService } from 'src/app/core/services/org-user-settings.service';
-import { FormArray, FormBuilder } from '@angular/forms';
+import { FormArray, FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { OrgSettingsService } from 'src/app/core/services/org-settings.service';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { orgUserSettingsData } from 'src/app/core/mock-data/org-user-settings.data';
+import {
+  notificationDelegateeSettings1,
+  notificationDelegateeSettings2,
+  notificationDelegateeSettings3,
+  orgUserSettingsData,
+} from 'src/app/core/mock-data/org-user-settings.data';
 import { of } from 'rxjs';
 import { apiEouRes } from 'src/app/core/mock-data/extended-org-user.data';
 import { orgSettingsData } from 'src/app/core/test-data/accounts.service.spec.data';
 import { notificationEventsData } from 'src/app/core/mock-data/notification-events.data';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { orgSettingsWithUnsubscribeEvent } from 'src/app/core/mock-data/org-settings.data';
+import { emailEvents } from 'src/app/core/mock-data/email-events.data';
 
-fdescribe('NotificationsPage', () => {
+export class NavMock {
+  public navigateBack: Function = (url: string | any[], options: any) => {};
+  public navigateForward: Function = (url: string | any[], options: any) => {};
+  public navigateRoot: Function = (url: string | any[], options: any) => {};
+}
+
+describe('NotificationsPage', () => {
   let component: NotificationsPage;
   let fixture: ComponentFixture<NotificationsPage>;
   let authService: jasmine.SpyObj<AuthService>;
@@ -34,11 +48,10 @@ fdescribe('NotificationsPage', () => {
     ]);
     const orgSettingsServiceSpy = jasmine.createSpyObj('OrgSettingsService', ['get']);
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
-    const navControllerSpy = jasmine.createSpyObj('NavController', ['back']);
 
     TestBed.configureTestingModule({
       declarations: [NotificationsPage],
-      imports: [RouterTestingModule],
+      imports: [RouterTestingModule, ReactiveFormsModule],
       providers: [
         FormBuilder,
         {
@@ -59,9 +72,10 @@ fdescribe('NotificationsPage', () => {
         },
         {
           provide: NavController,
-          useValie: navControllerSpy,
+          useClass: NavMock,
         },
       ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NotificationsPage);
@@ -85,10 +99,112 @@ fdescribe('NotificationsPage', () => {
     orgSettingsService.get.and.returnValue(of(orgSettingsData));
     orgUserSettingsService.getNotificationEvents.and.returnValue(of(notificationEventsData));
 
-    fixture.detectChanges();
+    component.delegationOptions = ['Notify me and my delegate', 'Notify my delegate', 'Notify me only'];
+
+    component.isAllSelected = {
+      emailEvents: false,
+      pushEvents: false,
+    };
   }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('getDelegateeSubscription():', () => {
+    it('should only notify the delegatee', (done) => {
+      component.orgUserSettings$ = of(notificationDelegateeSettings1);
+
+      component.getDelegateeSubscription().subscribe((res) => {
+        expect(res).toEqual('Notify my delegate');
+        done();
+      });
+    });
+
+    it('should only the user', (done) => {
+      component.orgUserSettings$ = of(notificationDelegateeSettings2);
+
+      component.getDelegateeSubscription().subscribe((res) => {
+        expect(res).toEqual('Notify me only');
+        done();
+      });
+    });
+
+    it('should both user and delegatee', (done) => {
+      component.orgUserSettings$ = of(notificationDelegateeSettings3);
+
+      component.getDelegateeSubscription().subscribe((res) => {
+        expect(res).toEqual('Notify me and my delegate');
+        done();
+      });
+    });
+  });
+
+  it('goBack(): should go back to the profile page', () => {
+    component.goBack();
+
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_profile']);
+  });
+
+  it('isAllEventsSubscribed(): should check if all events are subscribed', () => {
+    component.orgUserSettings = orgUserSettingsData;
+
+    component.isAllEventsSubscribed();
+
+    expect(component.isAllSelected).toEqual({
+      emailEvents: false,
+      pushEvents: false,
+    });
+  });
+
+  it('updateNotificationEvents(): should update notification events', () => {
+    spyOn(component, 'removeAdminUnsbscribedEvents');
+    spyOn(component, 'removeDisabledFeatures');
+
+    component.updateNotificationEvents();
+
+    expect(component.removeAdminUnsbscribedEvents).toHaveBeenCalledTimes(1);
+    expect(component.removeDisabledFeatures).toHaveBeenCalledTimes(1);
+  });
+
+  it('ngOnInit(): should initialize the form and observables', (done) => {
+    orgUserSettingsService.get.and.returnValue(of(orgUserSettingsData));
+    spyOn(component, 'getDelegateeSubscription').and.returnValue(of('Notify my delegate'));
+    authService.getEou.and.resolveTo(apiEouRes);
+    orgSettingsService.get.and.returnValue(of(orgSettingsData));
+    orgUserSettingsService.getNotificationEvents.and.returnValue(of(notificationEventsData));
+
+    spyOn(component, 'isAllEventsSubscribed');
+    spyOn(component, 'updateNotificationEvents');
+    spyOn(component, 'setEvents');
+    spyOn(component, 'toggleEvents');
+
+    component.ngOnInit();
+
+    component.orgUserSettings$.subscribe((res) => {
+      expect(res).toEqual(orgUserSettingsData);
+      expect(orgUserSettingsService.get).toHaveBeenCalledTimes(1);
+    });
+
+    component.isDelegateePresent$.subscribe((res) => {
+      expect(res).toBeFalse();
+      expect(authService.getEou).toHaveBeenCalledTimes(1);
+    });
+
+    component.orgSettings$.subscribe((res) => {
+      expect(res).toEqual(orgSettingsData);
+      expect(orgSettingsService.get).toHaveBeenCalledTimes(1);
+    });
+
+    component.notificationEvents$.subscribe((res) => {
+      expect(res).toEqual(notificationEventsData);
+      expect(orgUserSettingsService.getNotificationEvents).toHaveBeenCalledTimes(1);
+    });
+
+    expect(component.isAllEventsSubscribed).toHaveBeenCalledTimes(1);
+    expect(component.updateNotificationEvents).toHaveBeenCalledTimes(1);
+    expect(component.toggleEvents).toHaveBeenCalledTimes(1);
+    expect(component.setEvents).toHaveBeenCalledTimes(1);
+    done();
   });
 });

--- a/src/app/fyle/notifications/notifications.page.ts
+++ b/src/app/fyle/notifications/notifications.page.ts
@@ -162,7 +162,6 @@ export class NotificationsPage implements OnInit {
   removeAdminUnsbscribedEvents(): void {
     this.orgSettings$.pipe(
       map((setting) => {
-        console.log(setting.admin_email_settings);
         if (setting.admin_email_settings.unsubscribed_events.length) {
           this.notificationEvents.events = this.notificationEvents.events.filter((notificationEvent) => {
             const emailEvents = this.orgSettings.admin_email_settings.unsubscribed_events as string[];

--- a/src/app/fyle/notifications/notifications.page.ts
+++ b/src/app/fyle/notifications/notifications.page.ts
@@ -38,8 +38,8 @@ export class NotificationsPage implements OnInit {
   orgSettings: OrgSettings;
 
   isAllSelected: {
-    emailEvents: boolean;
-    pushEvents: boolean;
+    emailEvents?: boolean;
+    pushEvents?: boolean;
   };
 
   notifEvents = [];
@@ -150,8 +150,12 @@ export class NotificationsPage implements OnInit {
       .pipe(() => this.orgUserSettingsService.clearOrgUserSettings())
       .pipe(finalize(() => (this.saveNotifLoading = false)))
       .subscribe(() => {
-        this.navController.back();
+        this.navBack();
       });
+  }
+
+  navBack(): void {
+    this.navController.back();
   }
 
   isAllEventsSubscribed(): void {
@@ -160,16 +164,18 @@ export class NotificationsPage implements OnInit {
   }
 
   removeAdminUnsbscribedEvents(): void {
-    this.orgSettings$.pipe(
-      map((setting) => {
-        if (setting.admin_email_settings.unsubscribed_events.length) {
-          this.notificationEvents.events = this.notificationEvents.events.filter((notificationEvent) => {
-            const emailEvents = this.orgSettings.admin_email_settings.unsubscribed_events as string[];
-            return emailEvents.indexOf(notificationEvent.eventType.toUpperCase()) === -1;
-          });
-        }
-      })
-    );
+    this.orgSettings$
+      .pipe(
+        map((setting) => {
+          if (setting.admin_email_settings.unsubscribed_events.length) {
+            this.notificationEvents.events = this.notificationEvents.events.filter((notificationEvent) => {
+              const emailEvents = this.orgSettings.admin_email_settings.unsubscribed_events as string[];
+              return emailEvents.indexOf(notificationEvent.eventType.toUpperCase()) === -1;
+            });
+          }
+        })
+      )
+      .subscribe(noop);
   }
 
   updateAdvanceRequestFeatures(): void {
@@ -212,7 +218,16 @@ export class NotificationsPage implements OnInit {
       return accumulator as string[];
     }, []);
 
-    let newFeatures: NotificationEventFeatures;
+    const newFeatures: NotificationEventFeatures = {
+      advances: {
+        selected: false,
+        textLabel: '',
+      },
+      expensesAndReports: {
+        selected: false,
+        textLabel: '',
+      },
+    };
     activeFeatures.forEach((featureKey: string) => {
       newFeatures[featureKey] = this.notificationEvents.features[featureKey] as {
         selected: boolean;

--- a/src/app/fyle/notifications/notifications.page.ts
+++ b/src/app/fyle/notifications/notifications.page.ts
@@ -162,6 +162,7 @@ export class NotificationsPage implements OnInit {
   removeAdminUnsbscribedEvents(): void {
     this.orgSettings$.pipe(
       map((setting) => {
+        console.log(setting.admin_email_settings);
         if (setting.admin_email_settings.unsubscribed_events.length) {
           this.notificationEvents.events = this.notificationEvents.events.filter((notificationEvent) => {
             const emailEvents = this.orgSettings.admin_email_settings.unsubscribed_events as string[];
@@ -290,6 +291,11 @@ export class NotificationsPage implements OnInit {
      * on valueChange of any check box, checking for all box selected or not
      * if selected will toggle all select box
      */
+
+    this.toggleEvents();
+  }
+
+  toggleEvents(): void {
     this.notificationForm.valueChanges.subscribe((change: { emailEvents: boolean[]; pushEvents: boolean[] }) => {
       const emailEvents = change.emailEvents;
       const pushEvents = change.pushEvents;


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0667180</samp>

Added mock data and unit tests for the notification settings feature. Implemented a method to select or deselect all notification events in `NotificationsPage`. Removed a debugging statement from `notifications.page.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0667180</samp>

> _You can't escape the notifications of doom_
> _They haunt you and your delegatee too_
> _You mock them with your data and your tests_
> _But they will always find a way to get through_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0667180</samp>

*  Add `toggleEvents` method to `NotificationsPage` component to allow user to select or deselect all email events ([link](https://github.com/fylein/fyle-mobile-app/pull/2448/files?diff=unified&w=0#diff-32a367e9037385cdfd6b445a0a107423456bdcad37833cc3c36932aaf9ef4529R294-R298))
*  Import `EmailEvents` enum from `org-settings.model` to use it in mock data for `orgSettingsWithUnsubscribeEvent` ([link](https://github.com/fylein/fyle-mobile-app/pull/2448/files?diff=unified&w=0#diff-1cac010b51c1a7c2fbdf9bf224a7e267779365abe08b0f16df1ef46e41483951L2-R2))
*  Add mock data for `orgSettingsWithUnsubscribeEvent` to test the scenario where the admin has unsubscribed from some email events ([link](https://github.com/fylein/fyle-mobile-app/pull/2448/files?diff=unified&w=0#diff-1cac010b51c1a7c2fbdf9bf224a7e267779365abe08b0f16df1ef46e41483951R1349-R1356))
*  Add mock data for `notificationDelegateeSettings1`, `notificationDelegateeSettings2`, and `notificationDelegateeSettings3` to test different combinations of notification settings for the user and the delegatee ([link](https://github.com/fylein/fyle-mobile-app/pull/2448/files?diff=unified&w=0#diff-de467ea1b214e32a89452896f193a5769a02286b73795b8723305087a9ad59c9R686-R712))
*  Add unit tests for `NotificationsPage` component in `notifications.page.spec.ts` file, using the mock data and providers ([link](https://github.com/fylein/fyle-mobile-app/pull/2448/files?diff=unified&w=0#diff-9a90ed5661f0bc4fea1b33e636b77a68a4ba9e9c1959d9608079893753be9985L1-R209))

## Clickup
https://app.clickup.com/t/85ztznwfy

## Code Coverage
`32.25% Statements 40/124`
`36.66% Branches 11/30`
`28.2% Functions 11/39`
`32.75% Lines 38/116`

## UI Preview
Please add screenshots for UI changes