### PR TITLE
test: 100% coverage of category-dependent-field-form

### DIFF
--- a/src/app/fyle/merge-expense/category-dependent-fields-form/category-dependent-fields-form.component.spec.ts
+++ b/src/app/fyle/merge-expense/category-dependent-fields-form/category-dependent-fields-form.component.spec.ts
@@ -45,10 +45,6 @@ describe('CategoryDependentFieldsFormComponent', () => {
     expect(component.fieldsTouched.emit).toHaveBeenCalledOnceWith(['location_1']);
   });
 
-  it('onTouched(): should return nothing', () => {
-    expect(component.onTouched()).toBeUndefined();
-  });
-
   it('ngOnDestroy(): should unsubscribe from onChangeSub', () => {
     component.onChangeSub = new Subscription();
     spyOn(component.onChangeSub, 'unsubscribe');

--- a/src/app/fyle/merge-expense/category-dependent-fields-form/category-dependent-fields-form.component.spec.ts
+++ b/src/app/fyle/merge-expense/category-dependent-fields-form/category-dependent-fields-form.component.spec.ts
@@ -2,25 +2,82 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { CategoryDependentFieldsFormComponent } from './category-dependent-fields-form.component';
+import { FormBuilder, FormControl } from '@angular/forms';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Subscription } from 'rxjs';
 
-xdescribe('CategoryDependentFieldsFormComponent', () => {
+describe('CategoryDependentFieldsFormComponent', () => {
   let component: CategoryDependentFieldsFormComponent;
   let fixture: ComponentFixture<CategoryDependentFieldsFormComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [CategoryDependentFieldsFormComponent],
-        imports: [IonicModule.forRoot()],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [CategoryDependentFieldsFormComponent],
+      imports: [IonicModule.forRoot()],
+      providers: [FormBuilder],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(CategoryDependentFieldsFormComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-    })
-  );
+    fixture = TestBed.createComponent(CategoryDependentFieldsFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('isFieldTouched(): should return false if field is untouched', () => {
+    component.categoryDependentFormGroup = new FormBuilder().group({
+      location_1: new FormControl(''),
+    });
+    expect(component.isFieldTouched('location_1')).toBe(false);
+  });
+
+  it('ngOnInit(): should emit fieldsTouched', () => {
+    spyOn(component.fieldsTouched, 'emit');
+    // Using returnValues as we only need to return first value as true and all other subsequent values as false
+    spyOn(component, 'isFieldTouched').and.returnValues(true);
+    component.ngOnInit();
+    component.categoryDependentFormGroup.patchValue({
+      location_1: 'test',
+    });
+    expect(component.fieldsTouched.emit).toHaveBeenCalledOnceWith(['location_1']);
+  });
+
+  it('onTouched(): should return nothing', () => {
+    expect(component.onTouched()).toBeUndefined();
+  });
+
+  it('ngOnDestroy(): should unsubscribe from onChangeSub', () => {
+    component.onChangeSub = new Subscription();
+    spyOn(component.onChangeSub, 'unsubscribe');
+    component.ngOnDestroy();
+    expect(component.onChangeSub.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('writeValue(): should patch value to form control', () => {
+    component.categoryDependentFormGroup = new FormBuilder().group({
+      location_1: new FormControl(''),
+    });
+    const newValue = new FormBuilder().group({
+      location_1: new FormControl('Pune'),
+    });
+    spyOn(component.categoryDependentFormGroup, 'patchValue');
+    component.writeValue(newValue);
+    expect(component.categoryDependentFormGroup.patchValue).toHaveBeenCalledOnceWith(newValue);
+  });
+
+  it('registerOnChange(): should subscribe to value changes', () => {
+    const onChange = (): void => {};
+    spyOn(component.categoryDependentFormGroup.valueChanges, 'subscribe');
+    component.registerOnChange(onChange);
+    expect(component.categoryDependentFormGroup.valueChanges.subscribe).toHaveBeenCalledOnceWith(onChange);
+  });
+
+  it('registerOnTouched(): should set onTouched', () => {
+    const onTouched = (): void => {};
+    component.registerOnTouched(onTouched);
+    expect(component.onTouched).toEqual(onTouched);
   });
 });

--- a/src/app/fyle/merge-expense/category-dependent-fields-form/category-dependent-fields-form.component.ts
+++ b/src/app/fyle/merge-expense/category-dependent-fields-form/category-dependent-fields-form.component.ts
@@ -1,25 +1,18 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { EventEmitter, Injector, Output, TemplateRef } from '@angular/core';
-import { Observable, Subscription } from 'rxjs';
-import {
-  FormControl,
-  FormGroup,
-  ControlValueAccessor,
-  NG_VALUE_ACCESSOR,
-  FormBuilder,
-  Validators,
-} from '@angular/forms';
+import { EventEmitter, Injector, Output } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { FormGroup, ControlValueAccessor, NG_VALUE_ACCESSOR, FormBuilder, FormControl } from '@angular/forms';
 
 type Option = Partial<{
   label: string;
-  value: any;
+  value: string;
 }>;
 
 type OptionsData = Partial<{
   options: Option[];
   areSameValues: boolean;
   name: string;
-  value: any;
+  value: string;
 }>;
 
 @Component({
@@ -59,7 +52,9 @@ export class CategoryDependentFieldsFormComponent implements OnInit, ControlValu
 
   constructor(private formBuilder: FormBuilder, private injector: Injector) {}
 
-  ngOnInit() {
+  isFieldTouched = (fieldName: string): boolean => this.categoryDependentFormGroup.get(fieldName).touched;
+
+  ngOnInit(): void {
     this.categoryDependentFormGroup = this.formBuilder.group({
       location_1: [],
       location_2: [],
@@ -73,10 +68,10 @@ export class CategoryDependentFieldsFormComponent implements OnInit, ControlValu
       distance_unit: [],
     });
 
-    this.categoryDependentFormGroup.valueChanges.subscribe((formControlNames) => {
-      const touchedItems = [];
+    this.categoryDependentFormGroup.valueChanges.subscribe((formControlNames: FormControl[]) => {
+      const touchedItems: string[] = [];
       Object.keys(formControlNames).forEach((key) => {
-        if (this.categoryDependentFormGroup.get(key).touched) {
+        if (this.isFieldTouched(key)) {
           touchedItems.push(key);
         }
       });
@@ -84,23 +79,24 @@ export class CategoryDependentFieldsFormComponent implements OnInit, ControlValu
     });
   }
 
-  onTouched = () => {};
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onTouched = (): void => {};
 
   ngOnDestroy(): void {
-    this.onChangeSub.unsubscribe();
+    this.onChangeSub?.unsubscribe();
   }
 
-  writeValue(value: any) {
+  writeValue(value: FormGroup): void {
     if (value) {
       this.categoryDependentFormGroup.patchValue(value);
     }
   }
 
-  registerOnChange(onChange): void {
+  registerOnChange(onChange: () => void): void {
     this.onChangeSub = this.categoryDependentFormGroup.valueChanges.subscribe(onChange);
   }
 
-  registerOnTouched(onTouched): void {
+  registerOnTouched(onTouched: () => void): void {
     this.onTouched = onTouched;
   }
 }

--- a/src/app/fyle/merge-expense/category-dependent-fields-form/category-dependent-fields-form.component.ts
+++ b/src/app/fyle/merge-expense/category-dependent-fields-form/category-dependent-fields-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { EventEmitter, Injector, Output } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { Subscription, noop } from 'rxjs';
 import { FormGroup, ControlValueAccessor, NG_VALUE_ACCESSOR, FormBuilder, FormControl } from '@angular/forms';
 
 type Option = Partial<{
@@ -50,6 +50,8 @@ export class CategoryDependentFieldsFormComponent implements OnInit, ControlValu
 
   onChangeSub: Subscription;
 
+  onTouched: () => void = noop;
+
   constructor(private formBuilder: FormBuilder, private injector: Injector) {}
 
   isFieldTouched = (fieldName: string): boolean => this.categoryDependentFormGroup.get(fieldName).touched;
@@ -78,9 +80,6 @@ export class CategoryDependentFieldsFormComponent implements OnInit, ControlValu
       this.fieldsTouched.emit(touchedItems);
     });
   }
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onTouched = (): void => {};
 
   ngOnDestroy(): void {
     this.onChangeSub?.unsubscribe();


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14c2f91</samp>

Refactored and improved the `CategoryDependentFieldsFormComponent` and its test suite. Removed unused imports, added type annotations, linting, and error handling, and simplified the event emission logic. Enabled and fixed the test cases for the component using the `FormBuilder` and the `NO_ERRORS_SCHEMA`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 14c2f91</samp>

> _Sing, O Muse, of the code that was changed by the skillful developer_
> _Who enabled the test suite of the CategoryDependentFieldsFormComponent_
> _And added the NO_ERRORS_SCHEMA to the test module, like a wise builder_
> _Who ignores the flaws of the stones he uses to erect a monument._

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 14c2f91</samp>

*  Enable and fix test suite for `CategoryDependentFieldsFormComponent` by replacing `xdescribe` with `describe`, adding `NO_ERRORS_SCHEMA` and `FormBuilder` to test module, and removing unused imports ([link](https://github.com/fylein/fyle-mobile-app/pull/2450/files?diff=unified&w=0#diff-2d02b4992373e0c25fc799de9b727822704c5c0a0ba51a6146fbe18470bca97dL5-R82))
*  Change the `value` property of the `Option` and `OptionsData` types from `any` to `string` to match the expected type of the form control value ([link](https://github.com/fylein/fyle-mobile-app/pull/2450/files?diff=unified&w=0#diff-37dbd84ad40c9609446ab0ca80c119f1d2d2a977049cac644e0562c829251257L2-R8), [link](https://github.com/fylein/fyle-mobile-app/pull/2450/files?diff=unified&w=0#diff-37dbd84ad40c9609446ab0ca80c119f1d2d2a977049cac644e0562c829251257L22-R15))
*  Add `isFieldTouched` method to check if a form control is touched and simplify the logic of emitting the `fieldsTouched` event ([link](https://github.com/fylein/fyle-mobile-app/pull/2450/files?diff=unified&w=0#diff-37dbd84ad40c9609446ab0ca80c119f1d2d2a977049cac644e0562c829251257L62-R57), [link](https://github.com/fylein/fyle-mobile-app/pull/2450/files?diff=unified&w=0#diff-37dbd84ad40c9609446ab0ca80c119f1d2d2a977049cac644e0562c829251257L76-R74))
*  Annotate methods with return types and parameters with types for clarity and type safety, and add checks and comments to avoid errors and linting issues ([link](https://github.com/fylein/fyle-mobile-app/pull/2450/files?diff=unified&w=0#diff-37dbd84ad40c9609446ab0ca80c119f1d2d2a977049cac644e0562c829251257L62-R57), [link](https://github.com/fylein/fyle-mobile-app/pull/2450/files?diff=unified&w=0#diff-37dbd84ad40c9609446ab0ca80c119f1d2d2a977049cac644e0562c829251257L76-R74), [link](https://github.com/fylein/fyle-mobile-app/pull/2450/files?diff=unified&w=0#diff-37dbd84ad40c9609446ab0ca80c119f1d2d2a977049cac644e0562c829251257L87-R89), [link](https://github.com/fylein/fyle-mobile-app/pull/2450/files?diff=unified&w=0#diff-37dbd84ad40c9609446ab0ca80c119f1d2d2a977049cac644e0562c829251257L99-R99))

## Clickup
https://app.clickup.com/t/85ztznvmj

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes