### PR TITLE
test: 100% coverage of custom-inputs-fields-form

### DIFF
--- a/src/app/core/mock-data/custom-inputs-field.data.ts
+++ b/src/app/core/mock-data/custom-inputs-field.data.ts
@@ -1,0 +1,29 @@
+import { FormBuilder } from '@angular/forms';
+import { CustomInputsField } from '../models/custom-inputs-field.model';
+const formBuilder = new FormBuilder();
+
+export const customInputsFieldData1: CustomInputsField[] = [
+  {
+    control: formBuilder.group({
+      name: 'Merchant',
+      value: 'Jio',
+    }),
+    id: '1',
+    mandatory: false,
+    name: 'Merchant',
+    options: [],
+    placeholder: 'placeholder',
+    prefix: 'prefix',
+    type: 'text',
+    value: 'Jio',
+  },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const expectedCustomInputsFieldWithoutControl = customInputsFieldData1.map(({ control, ...otherProps }) => ({
+  ...otherProps,
+}));
+
+export const expectedCustomInputsFieldControlValues = customInputsFieldData1.map(
+  ({ control }: { control: { value: { name: string; value: string } } }) => control.value
+);

--- a/src/app/core/models/custom-inputs-field.model.ts
+++ b/src/app/core/models/custom-inputs-field.model.ts
@@ -1,0 +1,14 @@
+import { AbstractControl } from '@angular/forms';
+import { Option } from 'src/app/shared/components/fy-select/fy-select-modal/fy-select-modal.interface';
+
+export interface CustomInputsField {
+  control: AbstractControl;
+  id: string;
+  mandatory: boolean;
+  name: string;
+  options: Option[];
+  placeholder: string;
+  prefix: string;
+  type: string;
+  value: string;
+}

--- a/src/app/fyle/merge-expense/custom-inputs-fields-form/custom-inputs-fields-form.component.spec.ts
+++ b/src/app/fyle/merge-expense/custom-inputs-fields-form/custom-inputs-fields-form.component.spec.ts
@@ -60,10 +60,6 @@ describe('CustomInputsFieldsFormComponent', () => {
     expect(customInputsFieldControlValues).toEqual(expectedCustomInputsFieldControlValues);
   });
 
-  it('onTouched(): should return nothing', () => {
-    expect(component.onTouched()).toBeUndefined();
-  });
-
   it('ngOnDestroy(): should unsubscribe from onChangeSub', () => {
     component.onChangeSub = jasmine.createSpyObj('onChangeSub', ['unsubscribe']);
     component.ngOnDestroy();

--- a/src/app/fyle/merge-expense/custom-inputs-fields-form/custom-inputs-fields-form.component.spec.ts
+++ b/src/app/fyle/merge-expense/custom-inputs-fields-form/custom-inputs-fields-form.component.spec.ts
@@ -2,25 +2,114 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { CustomInputsFieldsFormComponent } from './custom-inputs-fields-form.component';
+import { FormArray, FormBuilder, FormControl } from '@angular/forms';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import {
+  customInputsFieldData1,
+  expectedCustomInputsFieldControlValues,
+  expectedCustomInputsFieldWithoutControl,
+} from 'src/app/core/mock-data/custom-inputs-field.data';
 
-xdescribe('CustomInputsFieldsFormComponent', () => {
+describe('CustomInputsFieldsFormComponent', () => {
   let component: CustomInputsFieldsFormComponent;
   let fixture: ComponentFixture<CustomInputsFieldsFormComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [CustomInputsFieldsFormComponent],
-        imports: [IonicModule.forRoot()],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [CustomInputsFieldsFormComponent],
+      imports: [IonicModule.forRoot()],
+      providers: [FormBuilder],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(CustomInputsFieldsFormComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-    })
-  );
+    fixture = TestBed.createComponent(CustomInputsFieldsFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('ngOnInit(): should initialize formValues correctly', () => {
+    component.ngOnInit();
+    expect(component.customFieldsForm.value).toEqual({
+      fields: [],
+    });
+  });
+
+  it('generateCustomForm(): should generate form correctly', () => {
+    component.customInputs = customInputsFieldData1;
+    component.ngOnInit();
+    component.generateCustomForm();
+    expect(component.customFieldsForm.value).toEqual({
+      fields: [
+        {
+          name: 'Merchant',
+          value: 'Jio',
+        },
+      ],
+    });
+
+    const customInputsFieldWithoutControl = component.customFields.map(({ control, ...otherProps }) => ({
+      ...otherProps,
+    }));
+    expect(customInputsFieldWithoutControl).toEqual(expectedCustomInputsFieldWithoutControl);
+
+    const customInputsFieldControlValues = component.customFields.map(({ control }) => control.value);
+    expect(customInputsFieldControlValues).toEqual(expectedCustomInputsFieldControlValues);
+  });
+
+  it('onTouched(): should return nothing', () => {
+    expect(component.onTouched()).toBeUndefined();
+  });
+
+  it('ngOnDestroy(): should unsubscribe from onChangeSub', () => {
+    component.onChangeSub = jasmine.createSpyObj('onChangeSub', ['unsubscribe']);
+    component.ngOnDestroy();
+    expect(component.onChangeSub.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  describe('ngOnChanges():', () => {
+    beforeEach(() => {
+      spyOn(component, 'generateCustomForm');
+    });
+
+    it('should call generateCustomForm() when customFieldsForm is defined', () => {
+      component.ngOnChanges();
+      expect(component.generateCustomForm).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call generateCustomForm() when customFieldsForm is undefined', () => {
+      component.customFieldsForm = undefined;
+      component.ngOnChanges();
+      expect(component.generateCustomForm).not.toHaveBeenCalled();
+    });
+  });
+
+  it('writeValue(): should patch value to form control', () => {
+    component.customFieldsForm.patchValue({
+      fields: [[]],
+    });
+    const newValue = new FormBuilder().group({
+      name: 'Merchant',
+      value: 'Jio',
+    });
+    spyOn(component.customFieldsForm.controls.fields, 'patchValue');
+    component.writeValue(newValue);
+    expect(component.customFieldsForm.controls.fields.patchValue).toHaveBeenCalledOnceWith(newValue);
+  });
+
+  it('registerOnChange(): should subscribe to value changes', () => {
+    const onChange = (): void => {};
+    spyOn(component.customFieldsForm.valueChanges, 'subscribe');
+    component.registerOnChange(onChange);
+    expect(component.customFieldsForm.valueChanges.subscribe).toHaveBeenCalledOnceWith(onChange);
+  });
+
+  it('registerOnTouched(): should set onTouched', () => {
+    const onTouched = (): void => {};
+    component.registerOnTouched(onTouched);
+    expect(component.onTouched).toEqual(onTouched);
   });
 });

--- a/src/app/fyle/merge-expense/custom-inputs-fields-form/custom-inputs-fields-form.component.ts
+++ b/src/app/fyle/merge-expense/custom-inputs-fields-form/custom-inputs-fields-form.component.ts
@@ -1,40 +1,21 @@
-import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
-import { EventEmitter, Injector, Output, TemplateRef } from '@angular/core';
-import { Observable, Subscription } from 'rxjs';
-import {
-  FormControl,
-  FormGroup,
-  ControlValueAccessor,
-  NG_VALUE_ACCESSOR,
-  FormBuilder,
-  Validators,
-  FormArray,
-  AbstractControl,
-} from '@angular/forms';
+import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
+import { Injector } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { FormGroup, ControlValueAccessor, NG_VALUE_ACCESSOR, FormBuilder, FormArray } from '@angular/forms';
+import { CustomInputsField } from 'src/app/core/models/custom-inputs-field.model';
 
 type Option = Partial<{
   label: string;
-  value: any;
+  value: string;
 }>;
 
 type OptionsData = Partial<{
   options: Option[];
   areSameValues: boolean;
   name: string;
-  value: any;
-}>;
-
-type CustomInputs = Partial<{
-  control: AbstractControl;
-  id: string;
-  mandatory: boolean;
-  name: string;
-  options: Option[];
-  placeholder: string;
-  prefix: string;
-  type: string;
   value: string;
 }>;
+
 interface CombinedOptions {
   [key: string]: OptionsData;
 }
@@ -46,7 +27,7 @@ interface CombinedOptions {
   providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: CustomInputsFieldsFormComponent, multi: true }],
 })
 export class CustomInputsFieldsFormComponent implements OnInit, ControlValueAccessor, OnDestroy, OnChanges {
-  @Input() customInputs: CustomInputs[];
+  @Input() customInputs: CustomInputsField[];
 
   @Input() combinedCustomProperties: CombinedOptions;
 
@@ -56,17 +37,17 @@ export class CustomInputsFieldsFormComponent implements OnInit, ControlValueAcce
 
   customFieldsForm: FormGroup;
 
-  customFields: CustomInputs[];
+  customFields: CustomInputsField[];
 
   constructor(private formBuilder: FormBuilder, private injector: Injector) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.customFieldsForm = this.formBuilder.group({
       fields: new FormArray([]),
     });
   }
 
-  generateCustomForm() {
+  generateCustomForm(): void {
     const customFieldsFormArray = this.customFieldsForm?.controls?.fields as FormArray;
     customFieldsFormArray.clear();
     for (const customField of this.customInputs) {
@@ -84,29 +65,30 @@ export class CustomInputsFieldsFormComponent implements OnInit, ControlValueAcce
     }));
   }
 
-  onTouched = () => {};
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onTouched = (): void => {};
 
   ngOnDestroy(): void {
-    this.onChangeSub.unsubscribe();
+    this.onChangeSub?.unsubscribe();
   }
 
-  ngOnChanges() {
+  ngOnChanges(): void {
     if (this.customFieldsForm?.controls) {
       this.generateCustomForm();
     }
   }
 
-  writeValue(value: any) {
+  writeValue(value: FormGroup): void {
     if (value) {
       this.customFieldsForm.controls.fields.patchValue(value);
     }
   }
 
-  registerOnChange(onChange): void {
+  registerOnChange(onChange: () => void): void {
     this.onChangeSub = this.customFieldsForm.valueChanges.subscribe(onChange);
   }
 
-  registerOnTouched(onTouched): void {
+  registerOnTouched(onTouched: () => void): void {
     this.onTouched = onTouched;
   }
 }

--- a/src/app/fyle/merge-expense/custom-inputs-fields-form/custom-inputs-fields-form.component.ts
+++ b/src/app/fyle/merge-expense/custom-inputs-fields-form/custom-inputs-fields-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { Injector } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { Subscription, noop } from 'rxjs';
 import { FormGroup, ControlValueAccessor, NG_VALUE_ACCESSOR, FormBuilder, FormArray } from '@angular/forms';
 import { CustomInputsField } from 'src/app/core/models/custom-inputs-field.model';
 
@@ -39,6 +39,8 @@ export class CustomInputsFieldsFormComponent implements OnInit, ControlValueAcce
 
   customFields: CustomInputsField[];
 
+  onTouched: () => void = noop;
+
   constructor(private formBuilder: FormBuilder, private injector: Injector) {}
 
   ngOnInit(): void {
@@ -64,9 +66,6 @@ export class CustomInputsFieldsFormComponent implements OnInit, ControlValueAcce
       control: customFieldsFormArray.at(i),
     }));
   }
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onTouched = (): void => {};
 
   ngOnDestroy(): void {
     this.onChangeSub?.unsubscribe();


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63782ea</samp>

This pull request refactors and tests the custom inputs fields form component, which is used for merging expenses. It adds a model file for the custom inputs field object, a mock data file for testing, and improves the component file and the spec file with type annotations, linting rules, error handling, and readability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 63782ea</samp>

> _We mock the data for the fields of doom_
> _We define the interface for the custom inputs_
> _We test the logic and the methods of the form_
> _We refactor the component for the final output_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63782ea</samp>

*  Add and import model file for custom inputs field ([link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-598451382fd94814dd50f5e9b5eaf717c7920095f3c4c056a80feb0621cf9678R1-R29), [link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-612fe8b1d45e182a917dab4c417b65654d0ab6ff0d23a234290ac4bfe5d2c7d6R1-R14), [link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL1-R9), [link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL24-R18), [link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL49-R30))
*  Modify type definitions and annotations for component properties and methods ([link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL24-R18), [link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL59-R44), [link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL69-R50), [link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL87-R75), [link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL99-R81), [link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL105-R91))
*  Remove unused imports and add linting rules in `custom-inputs-fields-form.component.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL1-R9), [link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL87-R75))
*  Update unit tests and remove xdescribe in `custom-inputs-fields-form.component.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-0b98c8fd6b40ef19c912b762f275d2efe392b41f752ce5c04f4cb857a7b756c0L5-R114))
*  Add null check for `onChangeSub` in `ngOnDestroy` method ([link](https://github.com/fylein/fyle-mobile-app/pull/2453/files?diff=unified&w=0#diff-587ba40d3cbea36098ad22af515a4885e1a19aace53810f6db72a8c09f22c0dcL87-R75))

## Clickup
https://app.clickup.com/t/85ztznvmy

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes