### PR TITLE
test: 100% coverage of generic-fields-form

### DIFF
--- a/src/app/fyle/merge-expense/generic-fields-form/generic-fields-form.component.spec.ts
+++ b/src/app/fyle/merge-expense/generic-fields-form/generic-fields-form.component.spec.ts
@@ -2,25 +2,115 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { GenericFieldsFormComponent } from './generic-fields-form.component';
+import { FormBuilder, FormControl } from '@angular/forms';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { dependentCustomProperties } from 'src/app/core/mock-data/custom-property.data';
+import { AllowedPaymentModes } from 'src/app/core/models/allowed-payment-modes.enum';
 
-xdescribe('GenericFieldsFormComponent', () => {
+describe('GenericFieldsFormComponent', () => {
   let component: GenericFieldsFormComponent;
   let fixture: ComponentFixture<GenericFieldsFormComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [GenericFieldsFormComponent],
-        imports: [IonicModule.forRoot()],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [GenericFieldsFormComponent],
+      imports: [IonicModule.forRoot()],
+      providers: [FormBuilder],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(GenericFieldsFormComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-    })
-  );
+    fixture = TestBed.createComponent(GenericFieldsFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit():', () => {
+    it('should emit categoryChanged event if category option changes', () => {
+      spyOn(component.categoryChanged, 'emit');
+      component.ngOnInit();
+      component.genericFieldsFormGroup.controls.category.setValue(32108);
+      expect(component.categoryChanged.emit).toHaveBeenCalledOnceWith(32108);
+    });
+
+    it('should assign projectDependentFields to projectDependentFieldsMapping.projectId if project option changes', () => {
+      component.projectDependentFieldsMapping = {
+        3943: dependentCustomProperties,
+      };
+      component.ngOnInit();
+      expect(component.projectDependentFields).toEqual([]);
+      component.genericFieldsFormGroup.controls.project.setValue(3943);
+      expect(component.projectDependentFields).toEqual(dependentCustomProperties);
+    });
+
+    it('should assign costCenterDependentFields to costCenterDependentFieldsMapping.costCenterId if cost center option changes', () => {
+      component.costCenterDependentFieldsMapping = {
+        13795: dependentCustomProperties,
+      };
+      component.ngOnInit();
+      expect(component.costCenterDependentFields).toEqual([]);
+      component.genericFieldsFormGroup.controls.costCenter.setValue(13795);
+      expect(component.costCenterDependentFields).toEqual(dependentCustomProperties);
+    });
+
+    it('should emit paymentModeChanged event if payment mode option changes', () => {
+      spyOn(component.paymentModeChanged, 'emit');
+      component.ngOnInit();
+      component.genericFieldsFormGroup.controls.paymentMode.setValue(AllowedPaymentModes.PERSONAL_ACCOUNT);
+      expect(component.paymentModeChanged.emit).toHaveBeenCalledOnceWith(AllowedPaymentModes.PERSONAL_ACCOUNT);
+    });
+
+    it('should emit receiptChanged event if receipt option changes', () => {
+      spyOn(component.receiptChanged, 'emit');
+      component.ngOnInit();
+      component.genericFieldsFormGroup.controls.receipt_ids.setValue('txErhlkzewZF');
+      expect(component.receiptChanged.emit).toHaveBeenCalledOnceWith('txErhlkzewZF');
+    });
+
+    it('should emit fieldsTouched event if any field is touched', () => {
+      spyOn(component.fieldsTouched, 'emit');
+      spyOn(component, 'isFieldTouched').and.returnValues(true);
+      component.ngOnInit();
+      component.genericFieldsFormGroup.controls.amount.setValue(100);
+      expect(component.fieldsTouched.emit).toHaveBeenCalledOnceWith(['amount']);
+    });
+  });
+
+  it('onTouched(): should return nothing', () => {
+    expect(component.onTouched()).toBeUndefined();
+  });
+
+  it('ngOnDestroy(): should unsubscribe from onChangeSub', () => {
+    component.onChangeSub = jasmine.createSpyObj('onChangeSub', ['unsubscribe']);
+    component.ngOnDestroy();
+    expect(component.onChangeSub.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('writeValue(): should patch value to form control', () => {
+    component.genericFieldsFormGroup = new FormBuilder().group({
+      location_1: new FormControl(),
+    });
+    const newValue = new FormBuilder().group({
+      location_1: new FormControl(200),
+    });
+    spyOn(component.genericFieldsFormGroup, 'patchValue');
+    component.writeValue(newValue);
+    expect(component.genericFieldsFormGroup.patchValue).toHaveBeenCalledOnceWith(newValue);
+  });
+
+  it('registerOnChange(): should subscribe to value changes', () => {
+    const onChange = (): void => {};
+    spyOn(component.genericFieldsFormGroup.valueChanges, 'subscribe');
+    component.registerOnChange(onChange);
+    expect(component.genericFieldsFormGroup.valueChanges.subscribe).toHaveBeenCalledOnceWith(onChange);
+  });
+
+  it('registerOnTouched(): should set onTouched', () => {
+    const onTouched = (): void => {};
+    component.registerOnTouched(onTouched);
+    expect(component.onTouched).toEqual(onTouched);
   });
 });

--- a/src/app/fyle/merge-expense/generic-fields-form/generic-fields-form.component.spec.ts
+++ b/src/app/fyle/merge-expense/generic-fields-form/generic-fields-form.component.spec.ts
@@ -79,10 +79,6 @@ describe('GenericFieldsFormComponent', () => {
     });
   });
 
-  it('onTouched(): should return nothing', () => {
-    expect(component.onTouched()).toBeUndefined();
-  });
-
   it('ngOnDestroy(): should unsubscribe from onChangeSub', () => {
     component.onChangeSub = jasmine.createSpyObj('onChangeSub', ['unsubscribe']);
     component.ngOnDestroy();

--- a/src/app/fyle/merge-expense/generic-fields-form/generic-fields-form.component.ts
+++ b/src/app/fyle/merge-expense/generic-fields-form/generic-fields-form.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Injector, Input, OnDestroy, OnInit, Output, TemplateRef } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { Subscription, noop } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { CorporateCardExpense } from 'src/app/core/models/v2/corporate-card-expense.model';
 import { FormGroup, ControlValueAccessor, NG_VALUE_ACCESSOR, FormBuilder, Validators } from '@angular/forms';
@@ -78,6 +78,8 @@ export class GenericFieldsFormComponent implements OnInit, ControlValueAccessor,
 
   costCenterDependentFields: CustomProperty<string>[] = [];
 
+  onTouched: () => void = noop;
+
   constructor(private formBuilder: FormBuilder, private injector: Injector) {}
 
   isFieldTouched = (fieldName: string): boolean => this.genericFieldsFormGroup.get(fieldName).touched;
@@ -132,9 +134,6 @@ export class GenericFieldsFormComponent implements OnInit, ControlValueAccessor,
       this.fieldsTouched.emit(touchedItems);
     });
   }
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onTouched = (): void => {};
 
   ngOnDestroy(): void {
     this.onChangeSub?.unsubscribe();


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 141866d</samp>

The pull request enhances the `GenericFieldsFormComponent` and its test suite by using better types and imports, adding a helper method, and fixing some bugs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 141866d</samp>

> _Oh we're the crew of the `GenericFieldsFormComponent`_
> _We test our code with `describe` and not with `xdescribe`_
> _We update our types and imports to make them nice and neat_
> _And we check the touched state of our controls with `isTouched`_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 141866d</samp>

*  Enable and update the test suite for the `GenericFieldsFormComponent` component ([link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-1f722c010e850d9c6f6846b5b5a55357346977f8939524d59a67604ad1c3b273L5-R115), [link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL5-R12), [link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL25-R19), [link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL61-R55), [link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL73-R71), [link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL89-R85), [link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL140-R143), [link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL152-R153))
  - Replace `xdescribe` with `describe` to run the test cases ([link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-1f722c010e850d9c6f6846b5b5a55357346977f8939524d59a67604ad1c3b273L5-R115))
  - Remove unused `FormControl` import and add `NO_ERRORS_SCHEMA` and `AllowedPaymentModes` imports ([link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL5-R12))
  - Change the `value` property of the `Option` type to `string` to match the test data ([link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL25-R19))
  - Change the `categoryDependentTemplate` input type to `TemplateRef<string[]>` to match the test template ([link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL61-R55))
  - Change the output types to emit specific values instead of `void` to match the test data ([link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL73-R71))
  - Add the `isFieldTouched` method to check the touched state of the form controls and use it in the test cases ([link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL89-R85), [link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL117-R128))
  - Type the parameters of the `categoryChanged`, `projectDependentFields`, `costCenterDependentFields`, `paymentModeChanged`, `receiptChanged`, and `valueChanges` events and assignments to match the test data ([link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL105-R101), [link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL111-R107), [link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL117-R128))
  - Annotate the `onTouched` method with an empty function comment and make the `onChangeSub` property optional ([link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL140-R143))
  - Type the parameters of the `writeValue`, `registerOnChange`, and `registerOnTouched` methods to match the test functions ([link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL140-R143), [link](https://github.com/fylein/fyle-mobile-app/pull/2455/files?diff=unified&w=0#diff-fc774057b998b5ed086b161cb446ce5838929e36b58c80cd52ae1374248e8efaL152-R153))

## Clickup
https://app.clickup.com/t/85ztznvnk

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes