### PR TITLE
test: Code Coverage: Notifications Page #2

### DIFF
--- a/src/app/core/models/notification-events.model.ts
+++ b/src/app/core/models/notification-events.model.ts
@@ -16,7 +16,7 @@ export type EmailEvents = {
 export interface NotificationEvents {
   events: EmailEvents[];
   features: {
-    advances: {
+    advances?: {
       selected: boolean;
       textLabel: string;
     };

--- a/src/app/fyle/notifications/notifications.page.spec.ts
+++ b/src/app/fyle/notifications/notifications.page.spec.ts
@@ -28,7 +28,7 @@ export class NavMock {
   public navigateRoot: Function = (url: string | any[], options: any) => {};
 }
 
-fdescribe('NotificationsPage', () => {
+describe('NotificationsPage', () => {
   let component: NotificationsPage;
   let fixture: ComponentFixture<NotificationsPage>;
   let authService: jasmine.SpyObj<AuthService>;
@@ -154,6 +154,7 @@ fdescribe('NotificationsPage', () => {
   });
 
   it('saveNotificationSettings(): should save notification settings', () => {
+    component.setEvents(notificationEventsData, orgUserSettingsData);
     component.notificationEvents = cloneDeep(notificationEventsData);
     component.orgUserSettings = cloneDeep(orgUserSettingsData);
     orgUserSettingsService.post.and.returnValue(of(null));
@@ -180,13 +181,13 @@ fdescribe('NotificationsPage', () => {
 
   it('removeAdminUnsbscribedEvents(): should remove admin unsubscribe events', fakeAsync(() => {
     component.orgSettings$ = of(orgSettingsWithUnsubscribeEvent);
+    component.orgSettings = orgSettingsWithUnsubscribeEvent;
+    component.notificationEvents = cloneDeep(notificationEventsData);
 
     component.removeAdminUnsbscribedEvents();
     tick(500);
 
-    component.orgSettings$.subscribe((res) => {
-      // console.log(res);
-    });
+    expect(Object.keys(component.notificationEvents.features).includes('advances')).toBeFalse();
   }));
 
   it('updateAdvanceRequestFeatures(): should update advance request features', () => {
@@ -253,41 +254,49 @@ fdescribe('NotificationsPage', () => {
   });
 
   describe('toggleAllSelected():', () => {
-    it('should set value if email event exists', () => {
+    beforeEach(() => {
+      component.setEvents(notificationEventsData, orgUserSettingsData);
+    });
+
+    it('should set value if email event exists', fakeAsync(() => {
       component.isAllSelected = {
         emailEvents: true,
       };
 
       component.toggleAllSelected('email');
+      tick(500);
 
-      expect(component.emailEvents.value).toEqual([]);
-    });
+      expect(component.emailEvents.getRawValue().length).not.toBe(0);
+    }));
 
-    it('should set value if email event does not exist', () => {
+    it('should set value if email event does not exist', fakeAsync(() => {
       component.isAllSelected = {};
 
       component.toggleAllSelected('email');
+      tick(500);
 
-      expect(component.emailEvents.value).toEqual([]);
-    });
+      expect(component.emailEvents.getRawValue().length).not.toBe(0);
+    }));
 
-    it('should set value if push event exists', () => {
+    it('should set value if push event exists', fakeAsync(() => {
       component.isAllSelected = {
         pushEvents: true,
       };
 
       component.toggleAllSelected('push');
+      tick(500);
 
-      expect(component.pushEvents.value).toEqual([]);
-    });
+      expect(component.emailEvents.getRawValue().length).not.toBe(0);
+    }));
 
-    it('should set value if push event does not exist', () => {
+    it('should set value if push event does not exist', fakeAsync(() => {
       component.isAllSelected = {};
 
       component.toggleAllSelected('push');
+      tick(500);
 
-      expect(component.pushEvents.value).toEqual([]);
-    });
+      expect(component.emailEvents.getRawValue().length).not.toBe(0);
+    }));
   });
 
   it('ngOnInit(): should initialize the form and observables', (done) => {
@@ -332,10 +341,6 @@ fdescribe('NotificationsPage', () => {
   });
 
   it('toggleEvents(): should toggle events on value change', fakeAsync(() => {
-    component.notificationForm.patchValue({
-      emailEvents: [],
-      pushEvents: [],
-    });
     component.isAllSelected = {
       emailEvents: true,
       pushEvents: false,
@@ -344,15 +349,12 @@ fdescribe('NotificationsPage', () => {
     component.toggleEvents();
     tick(500);
 
-    component.notificationForm.patchValue({
-      emailEvents: [],
-      pushEvents: [],
-    });
+    component.setEvents(notificationEventsData, orgUserSettingsData);
     tick(500);
 
     expect(component.isAllSelected).toEqual({
-      emailEvents: true,
-      pushEvents: true,
+      emailEvents: false,
+      pushEvents: false,
     });
   }));
 });

--- a/src/app/fyle/notifications/notifications.page.ts
+++ b/src/app/fyle/notifications/notifications.page.ts
@@ -164,17 +164,18 @@ export class NotificationsPage implements OnInit {
   }
 
   removeAdminUnsbscribedEvents(): void {
-    this.orgSettings$.pipe(
-      map((setting) => {
-        console.log(setting.admin_email_settings);
-        if (setting.admin_email_settings.unsubscribed_events.length) {
-          this.notificationEvents.events = this.notificationEvents.events.filter((notificationEvent) => {
-            const emailEvents = this.orgSettings.admin_email_settings.unsubscribed_events as string[];
-            return emailEvents.indexOf(notificationEvent.eventType.toUpperCase()) === -1;
-          });
-        }
-      })
-    );
+    this.orgSettings$
+      .pipe(
+        map((setting) => {
+          if (setting.admin_email_settings.unsubscribed_events.length) {
+            this.notificationEvents.events = this.notificationEvents.events.filter((notificationEvent) => {
+              const emailEvents = this.orgSettings.admin_email_settings.unsubscribed_events as string[];
+              return emailEvents.indexOf(notificationEvent.eventType.toUpperCase()) === -1;
+            });
+          }
+        })
+      )
+      .subscribe(noop);
   }
 
   updateAdvanceRequestFeatures(): void {

--- a/src/app/fyle/notifications/notifications.page.ts
+++ b/src/app/fyle/notifications/notifications.page.ts
@@ -38,8 +38,8 @@ export class NotificationsPage implements OnInit {
   orgSettings: OrgSettings;
 
   isAllSelected: {
-    emailEvents: boolean;
-    pushEvents: boolean;
+    emailEvents?: boolean;
+    pushEvents?: boolean;
   };
 
   notifEvents = [];
@@ -150,8 +150,12 @@ export class NotificationsPage implements OnInit {
       .pipe(() => this.orgUserSettingsService.clearOrgUserSettings())
       .pipe(finalize(() => (this.saveNotifLoading = false)))
       .subscribe(() => {
-        this.navController.back();
+        this.navBack();
       });
+  }
+
+  navBack(): void {
+    this.navController.back();
   }
 
   isAllEventsSubscribed(): void {
@@ -213,7 +217,16 @@ export class NotificationsPage implements OnInit {
       return accumulator as string[];
     }, []);
 
-    let newFeatures: NotificationEventFeatures;
+    const newFeatures: NotificationEventFeatures = {
+      advances: {
+        selected: false,
+        textLabel: '',
+      },
+      expensesAndReports: {
+        selected: false,
+        textLabel: '',
+      },
+    };
     activeFeatures.forEach((featureKey: string) => {
       newFeatures[featureKey] = this.notificationEvents.features[featureKey] as {
         selected: boolean;


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9eb0513</samp>

This pull request enhances the notifications page by adding and updating unit tests, improving code quality and readability, and handling the optional advance request feature. It affects the files `notifications.page.spec.ts`, `notifications.page.ts`, and `notification-events.model.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9eb0513</samp>

> _Oh we're the coders of the sea, and we work with skill and speed_
> _We make the `NotificationEvents` optional as we need_
> _We test the `NotificationsPage` with scenarios galore_
> _And we heave away and refactor on the count of four_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9eb0513</samp>

*  Make the `advances` property optional in the `NotificationEvents` interface to handle the case of disabled advance request feature ([link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-e499d947fc603cf739489ea28e79b69ebe13d63dc33a206d6b35f88cb1f73697L19-R19))
*  Remove unused imports and reorder imports in the `notifications.page.spec.ts` file ([link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-9a90ed5661f0bc4fea1b33e636b77a68a4ba9e9c1959d9608079893753be9985L2-R12), [link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-9a90ed5661f0bc4fea1b33e636b77a68a4ba9e9c1959d9608079893753be9985L17-R23))
*  Add unit tests for the `setEvents()` method to check the assignment of `emailEvents` and `pushEvents` properties ([link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-9a90ed5661f0bc4fea1b33e636b77a68a4ba9e9c1959d9608079893753be9985R143-R149))
*  Add unit tests for the `saveNotificationSettings()` method to check the calls to the `OrgUserSettingsService` and the `navBack()` method ([link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-9a90ed5661f0bc4fea1b33e636b77a68a4ba9e9c1959d9608079893753be9985R156-R170))
*  Add unit tests for the methods that update the `notificationEvents` and `orgUserSettings` properties based on the org settings and the user input: `removeAdminUnsbscribedEvents()`, `updateAdvanceRequestFeatures()`, `updateDelegateeNotifyPreference()` and `removeDisabledFeatures()` ([link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-9a90ed5661f0bc4fea1b33e636b77a68a4ba9e9c1959d9608079893753be9985R182-R245))
*  Add unit tests for the `toggleAllSelected()` method to check the toggling of the `isAllSelected` property and the `selected` property of the form arrays ([link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-9a90ed5661f0bc4fea1b33e636b77a68a4ba9e9c1959d9608079893753be9985R256-R301))
*  Add unit tests for the `toggleEvents()` method to check the toggling of the `isAllSelected` property based on the form array values ([link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-9a90ed5661f0bc4fea1b33e636b77a68a4ba9e9c1959d9608079893753be9985R342-R359))
*  Make the `emailEvents` and `pushEvents` properties optional in the `isAllSelected` object to handle the case of calling `toggleEvents()` before `setEvents()` ([link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-32a367e9037385cdfd6b445a0a107423456bdcad37833cc3c36932aaf9ef4529L41-R42))
*  Extract the `navBack()` method from the `saveNotificationSettings()` method to improve readability and testability ([link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-32a367e9037385cdfd6b445a0a107423456bdcad37833cc3c36932aaf9ef4529L153-R160))
*  Subscribe to the `orgSettings$` observable and use the `noop` function as the callback in the `removeAdminUnsbscribedEvents()` method to avoid memory leak and follow RxJS best practices ([link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-32a367e9037385cdfd6b445a0a107423456bdcad37833cc3c36932aaf9ef4529L163-R178))
*  Initialize the `newFeatures` object with the default values of the `NotificationEventFeatures` interface in the `removeDisabledFeatures()` method to avoid accessing undefined properties ([link](https://github.com/fylein/fyle-mobile-app/pull/2470/files?diff=unified&w=0#diff-32a367e9037385cdfd6b445a0a107423456bdcad37833cc3c36932aaf9ef4529L216-R230))

## Clickup
https://app.clickup.com/t/85ztznwfy

## Code Coverage
`99.2% Statements 124/125`
`100% Branches 30/30`
`97.5% Functions 39/40`
`99.14% Lines 116/117`

## UI Preview
Please add screenshots for UI changes