### PR TITLE
feat: Remove unified card enrollment flow LD flag

### DIFF
--- a/src/app/fyle/dashboard/card-stats/card-stats.component.spec.ts
+++ b/src/app/fyle/dashboard/card-stats/card-stats.component.spec.ts
@@ -23,7 +23,6 @@ import { By } from '@angular/platform-browser';
 import { cardDetailsRes } from 'src/app/core/mock-data/platform-corporate-card-detail-data';
 import { AddCorporateCardComponent } from '../../manage-corporate-cards/add-corporate-card/add-corporate-card.component';
 import { CardAddedComponent } from '../../manage-corporate-cards/card-added/card-added.component';
-import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 
 @Component({
   selector: 'app-spent-cards',
@@ -62,7 +61,6 @@ describe('CardStatsComponent', () => {
   let orgUserSettingsService: jasmine.SpyObj<OrgUserSettingsService>;
   let corporateCreditCardExpenseService: jasmine.SpyObj<CorporateCreditCardExpenseService>;
   let popoverController: jasmine.SpyObj<PopoverController>;
-  let launchDarklyService: jasmine.SpyObj<LaunchDarklyService>;
 
   beforeEach(waitForAsync(() => {
     const currencyServiceSpy = jasmine.createSpyObj('CurrencyService', ['getHomeCurrency']);
@@ -76,7 +74,6 @@ describe('CardStatsComponent', () => {
       'clearCache',
     ]);
     const popoverControllerSpy = jasmine.createSpyObj('PopoverController', ['create']);
-    const launchDarklyServiceSpy = jasmine.createSpyObj('LaunchDarklyService', ['getVariation']);
 
     TestBed.configureTestingModule({
       declarations: [CardStatsComponent, MockSpentCardsComponent, MockAddCardComponent],
@@ -110,10 +107,6 @@ describe('CardStatsComponent', () => {
           provide: PopoverController,
           useValue: popoverControllerSpy,
         },
-        {
-          provide: LaunchDarklyService,
-          useValue: launchDarklyServiceSpy,
-        },
       ],
     }).compileComponents();
 
@@ -126,10 +119,9 @@ describe('CardStatsComponent', () => {
     networkService = TestBed.inject(NetworkService) as jasmine.SpyObj<NetworkService>;
     orgUserSettingsService = TestBed.inject(OrgUserSettingsService) as jasmine.SpyObj<OrgUserSettingsService>;
     corporateCreditCardExpenseService = TestBed.inject(
-      CorporateCreditCardExpenseService,
+      CorporateCreditCardExpenseService
     ) as jasmine.SpyObj<CorporateCreditCardExpenseService>;
     popoverController = TestBed.inject(PopoverController) as jasmine.SpyObj<PopoverController>;
-    launchDarklyService = TestBed.inject(LaunchDarklyService) as jasmine.SpyObj<LaunchDarklyService>;
 
     // Default return values
     currencyService.getHomeCurrency.and.returnValue(of('USD'));
@@ -140,7 +132,6 @@ describe('CardStatsComponent', () => {
     corporateCreditCardExpenseService.getPlatformCorporateCardDetails.and.returnValue(cardDetails);
     networkService.isOnline.and.returnValue(of(true));
     corporateCreditCardExpenseService.clearCache.and.returnValue(of(null));
-    launchDarklyService.getVariation.and.returnValue(of(true));
 
     spyOn(component.loadCardDetails$, 'next').and.callThrough();
 
@@ -192,7 +183,7 @@ describe('CardStatsComponent', () => {
       expect(corporateCreditCardExpenseService.getCorporateCards).toHaveBeenCalledTimes(1);
       expect(corporateCreditCardExpenseService.getPlatformCorporateCardDetails).toHaveBeenCalledOnceWith(
         cards,
-        cardStats.cardDetails,
+        cardStats.cardDetails
       );
     });
 
@@ -245,7 +236,7 @@ describe('CardStatsComponent', () => {
 
       popoverController.create.and.returnValues(
         Promise.resolve(addCardPopoverSpy),
-        Promise.resolve(cardAddedPopoverSpy),
+        Promise.resolve(cardAddedPopoverSpy)
       );
 
       corporateCreditCardExpenseService.getCorporateCards.and.returnValue(of([]));
@@ -310,7 +301,7 @@ describe('CardStatsComponent', () => {
 
       popoverController.create.and.returnValues(
         Promise.resolve(addCardPopoverSpy),
-        Promise.resolve(cardAddedPopoverSpy),
+        Promise.resolve(cardAddedPopoverSpy)
       );
 
       component.ngOnInit();

--- a/src/app/fyle/dashboard/card-stats/card-stats.component.ts
+++ b/src/app/fyle/dashboard/card-stats/card-stats.component.ts
@@ -12,7 +12,6 @@ import { AddCorporateCardComponent } from '../../manage-corporate-cards/add-corp
 import { OverlayResponse } from 'src/app/core/models/overlay-response.modal';
 import { CardAddedComponent } from '../../manage-corporate-cards/card-added/card-added.component';
 import { NetworkService } from 'src/app/core/services/network.service';
-import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 
 @Component({
   selector: 'app-card-stats',
@@ -47,8 +46,7 @@ export class CardStatsComponent implements OnInit {
     private networkService: NetworkService,
     private orgUserSettingsService: OrgUserSettingsService,
     private corporateCreditCardExpenseService: CorporateCreditCardExpenseService,
-    private popoverController: PopoverController,
-    private launchDarklyService: LaunchDarklyService
+    private popoverController: PopoverController
   ) {}
 
   ngOnInit(): void {
@@ -98,20 +96,8 @@ export class CardStatsComponent implements OnInit {
       )
     );
 
-    const isUnifiedCardEnrollmentFlowEnabled$ = this.launchDarklyService.getVariation(
-      'unified_card_enrollment_flow_enabled',
-      false
-    );
-
-    this.canAddCorporateCards$ = forkJoin([
-      isUnifiedCardEnrollmentFlowEnabled$,
-      this.isVisaRTFEnabled$,
-      this.isMastercardRTFEnabled$,
-    ]).pipe(
-      map(
-        ([isUnifiedCardEnrollmentFlowEnabled, isVisaRTFEnabled, isMastercardRTFEnabled]) =>
-          isUnifiedCardEnrollmentFlowEnabled && (isVisaRTFEnabled || isMastercardRTFEnabled)
-      )
+    this.canAddCorporateCards$ = forkJoin([this.isVisaRTFEnabled$, this.isMastercardRTFEnabled$]).pipe(
+      map(([isVisaRTFEnabled, isMastercardRTFEnabled]) => isVisaRTFEnabled || isMastercardRTFEnabled)
     );
 
     this.cardDetails$ = this.loadCardDetails$.pipe(

--- a/src/app/fyle/my-profile/my-profile.page.html
+++ b/src/app/fyle/my-profile/my-profile.page.html
@@ -46,9 +46,7 @@
         ></ion-icon>
       </div>
 
-      <ng-container
-        *ngIf="isCCCEnabled && isUnifiedCardEnrollmentFlowEnabled && (isVisaRTFEnabled || isMastercardRTFEnabled)"
-      >
+      <ng-container *ngIf="isCCCEnabled && (isVisaRTFEnabled || isMastercardRTFEnabled)">
         <div class="my-profile__section-header">Corporate Cards</div>
         <div class="my-profile__card" [routerLink]="[ '/', 'enterprise', 'manage_corporate_cards' ]" matRipple>
           <div class="my-profile__card__title">Manage Corporate Cards</div>

--- a/src/app/fyle/my-profile/my-profile.page.spec.ts
+++ b/src/app/fyle/my-profile/my-profile.page.spec.ts
@@ -31,7 +31,6 @@ import { MyProfilePage } from './my-profile.page';
 import { UpdateMobileNumberComponent } from './update-mobile-number/update-mobile-number.component';
 import { VerifyNumberPopoverComponent } from './verify-number-popover/verify-number-popover.component';
 import { orgData1 } from 'src/app/core/mock-data/org.data';
-import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 
 describe('MyProfilePage', () => {
   let component: MyProfilePage;
@@ -52,7 +51,6 @@ describe('MyProfilePage', () => {
   let matSnackBar: jasmine.SpyObj<MatSnackBar>;
   let snackbarProperties: jasmine.SpyObj<SnackbarPropertiesService>;
   let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
-  let launchDarklyService: jasmine.SpyObj<LaunchDarklyService>;
 
   beforeEach(waitForAsync(() => {
     const authServiceSpy = jasmine.createSpyObj('AuthService', ['getEou', 'logout', 'refreshEou']);
@@ -76,7 +74,6 @@ describe('MyProfilePage', () => {
     const popoverControllerSpy = jasmine.createSpyObj('PopoverController', ['create']);
     const matSnackBarSpy = jasmine.createSpyObj('MatSnackBar', ['openFromComponent']);
     const snackbarPropertiesSpy = jasmine.createSpyObj('SnackbarPropertiesService', ['setSnackbarProperties']);
-    const launchDarklyServiceSpy = jasmine.createSpyObj('LaunchDarklyService', ['getVariation']);
 
     TestBed.configureTestingModule({
       declarations: [MyProfilePage],
@@ -156,10 +153,6 @@ describe('MyProfilePage', () => {
           provide: SnackbarPropertiesService,
           useValue: snackbarPropertiesSpy,
         },
-        {
-          provide: LaunchDarklyService,
-          useValue: launchDarklyServiceSpy,
-        },
       ],
     }).compileComponents();
 
@@ -183,9 +176,7 @@ describe('MyProfilePage', () => {
     matSnackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
     snackbarProperties = TestBed.inject(SnackbarPropertiesService) as jasmine.SpyObj<SnackbarPropertiesService>;
     activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
-    launchDarklyService = TestBed.inject(LaunchDarklyService) as jasmine.SpyObj<LaunchDarklyService>;
 
-    launchDarklyService.getVariation.and.returnValue(of(true));
     component.loadEou$ = new BehaviorSubject(null);
     component.eou$ = of(apiEouRes);
 

--- a/src/app/fyle/my-profile/my-profile.page.ts
+++ b/src/app/fyle/my-profile/my-profile.page.ts
@@ -32,7 +32,6 @@ import { OverlayResponse } from 'src/app/core/models/overlay-response.modal';
 import { EventData } from 'src/app/core/models/event-data.model';
 import { PreferenceSetting } from 'src/app/core/models/preference-setting.model';
 import { CopyCardDetails } from 'src/app/core/models/copy-card-details.model';
-import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 
 @Component({
   selector: 'app-my-profile',
@@ -74,10 +73,6 @@ export class MyProfilePage {
 
   isMastercardRTFEnabled: boolean;
 
-  isYodleeEnabled: boolean;
-
-  isUnifiedCardEnrollmentFlowEnabled: boolean;
-
   constructor(
     private authService: AuthService,
     private orgUserSettingsService: OrgUserSettingsService,
@@ -94,8 +89,7 @@ export class MyProfilePage {
     private popoverController: PopoverController,
     private matSnackBar: MatSnackBar,
     private snackbarProperties: SnackbarPropertiesService,
-    private activatedRoute: ActivatedRoute,
-    private launchDarklyService: LaunchDarklyService
+    private activatedRoute: ActivatedRoute
   ) {}
 
   setupNetworkWatcher(): void {
@@ -187,10 +181,6 @@ export class MyProfilePage {
           forkJoin({
             orgUserSettings: orgUserSettings$,
             orgSettings: orgSettings$,
-            isUnifiedCardEnrollmentFlowEnabled: this.launchDarklyService.getVariation(
-              'unified_card_enrollment_flow_enabled',
-              false
-            ),
           })
         ),
         finalize(() => from(this.loaderService.hideLoader()))
@@ -198,7 +188,6 @@ export class MyProfilePage {
       .subscribe(async (res) => {
         this.orgUserSettings = res.orgUserSettings;
         this.orgSettings = res.orgSettings;
-        this.isUnifiedCardEnrollmentFlowEnabled = res.isUnifiedCardEnrollmentFlowEnabled;
 
         this.setCCCFlags();
         this.setPreferenceSettings();


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19xVTD5JYkJ3WaH4fHga3lpZRq5NA2610%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=8Otmu2L)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d36b934</samp>

Removed unused code and simplified logic related to the feature flag `unified_card_enrollment_flow_enabled` in the `CardStatsComponent` and the `MyProfilePage` component and their test files. This feature flag was no longer needed as the unified card enrollment flow was enabled for all users.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d36b934</samp>

> _`LaunchDarklyService`_
> _Gone with the autumn feature_
> _Code is simplified_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d36b934</samp>

*  Remove the usage of `LaunchDarklyService` and the feature flag `unified_card_enrollment_flow_enabled` from the components `CardStatsComponent` and `MyProfilePage` and their respective test files ([link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-fcc80bf83d226889337842b0e4ab887285aa2d2383c75f304b5d1b6640345fa9L15), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-fcc80bf83d226889337842b0e4ab887285aa2d2383c75f304b5d1b6640345fa9L50-R49), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-fcc80bf83d226889337842b0e4ab887285aa2d2383c75f304b5d1b6640345fa9L101-R102), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-d2134e07df0df71330169a496945a65330a3aaa352a6caebdd329c831611307fL49-R49), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-2c63a619cd79823c07aec7f42fb6ef1e07a5a3f9068ed72c121826ceed7996f5L35), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-2c63a619cd79823c07aec7f42fb6ef1e07a5a3f9068ed72c121826ceed7996f5L77-L80), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-2c63a619cd79823c07aec7f42fb6ef1e07a5a3f9068ed72c121826ceed7996f5L97-R92), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-2c63a619cd79823c07aec7f42fb6ef1e07a5a3f9068ed72c121826ceed7996f5L190-L193), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-2c63a619cd79823c07aec7f42fb6ef1e07a5a3f9068ed72c121826ceed7996f5L201))
* Simplify the observables `canAddCorporateCards$` and `loadEou$` to depend only on the feature flags `isCCCEnabled`, `isVisaRTFEnabled`, and `isMastercardRTFEnabled` in the component files `card-stats.component.ts` and `my-profile.page.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-fcc80bf83d226889337842b0e4ab887285aa2d2383c75f304b5d1b6640345fa9L101-R102), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-d2134e07df0df71330169a496945a65330a3aaa352a6caebdd329c831611307fL49-R49), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-2c63a619cd79823c07aec7f42fb6ef1e07a5a3f9068ed72c121826ceed7996f5L190-L193))
* Remove the import, declaration, creation, provider, and assignment of `launchDarklyService` as a spy object from the test files `card-stats.component.spec.ts` and `my-profile.page.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-f2f460301fee446fd9e4821d9219f50a4c228d7b9fcea747c5da68bd53aee490L26), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-f2f460301fee446fd9e4821d9219f50a4c228d7b9fcea747c5da68bd53aee490L65), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-f2f460301fee446fd9e4821d9219f50a4c228d7b9fcea747c5da68bd53aee490L79), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-f2f460301fee446fd9e4821d9219f50a4c228d7b9fcea747c5da68bd53aee490L113-L116), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-f2f460301fee446fd9e4821d9219f50a4c228d7b9fcea747c5da68bd53aee490L129-R124), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-f2f460301fee446fd9e4821d9219f50a4c228d7b9fcea747c5da68bd53aee490L143), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L34), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L55), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L79), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L159-L162), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-e185ae8ca57df8b05ecc79a2509e4913674fb3c789f5304e09bca7970e879fc5L186-R179))
* Remove the trailing commas from the arguments and return values of some functions in the test file `card-stats.component.spec.ts` to follow the code style ([link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-f2f460301fee446fd9e4821d9219f50a4c228d7b9fcea747c5da68bd53aee490L195-R186), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-f2f460301fee446fd9e4821d9219f50a4c228d7b9fcea747c5da68bd53aee490L248-R239), [link](https://github.com/fylein/fyle-mobile-app/pull/2473/files?diff=unified&w=0#diff-f2f460301fee446fd9e4821d9219f50a4c228d7b9fcea747c5da68bd53aee490L313-R304))

## Clickup
https://app.clickup.com