### PR TITLE
test: Fixing add card component flaky tests

### DIFF
--- a/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
+++ b/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flush, tick, waitForAsync } from '@angular/core/testing';
 import { IonicModule, PopoverController } from '@ionic/angular';
 
 import { AddCorporateCardComponent } from './add-corporate-card.component';
@@ -167,7 +167,7 @@ describe('AddCorporateCardComponent', () => {
     });
   });
 
-  describe('card number validation errors', () => {
+  fdescribe('card number validation errors', () => {
     it('should show an error message when the user has entered an invalid card number', fakeAsync(() => {
       realTimeFeedService.isCardNumberValid.and.returnValue(false);
       realTimeFeedService.getCardTypeFromNumber.and.returnValue(CardNetworkType.OTHERS);
@@ -181,7 +181,7 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
-      tick(500);
+      flush();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
       expect(errorMessage.innerText).toBe('Please enter a valid card number.');
@@ -204,7 +204,7 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
-      tick(500);
+      flush();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 
@@ -230,7 +230,7 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
-      tick(500);
+      flush();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 
@@ -256,7 +256,7 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
-      tick(500);
+      flush();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
       expect(errorMessage.innerText).toBe(
@@ -335,7 +335,7 @@ describe('AddCorporateCardComponent', () => {
       addCorporateCardBtn.click();
 
       fixture.detectChanges();
-      tick(500);
+      flush();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 
@@ -363,7 +363,7 @@ describe('AddCorporateCardComponent', () => {
       addCorporateCardBtn.click();
 
       fixture.detectChanges();
-      tick(500);
+      flush();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 

--- a/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
+++ b/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { IonicModule, PopoverController } from '@ionic/angular';
 
 import { AddCorporateCardComponent } from './add-corporate-card.component';
@@ -168,7 +168,7 @@ describe('AddCorporateCardComponent', () => {
   });
 
   describe('card number validation errors', () => {
-    it('should show an error message when the user has entered an invalid card number', () => {
+    it('should show an error message when the user has entered an invalid card number', fakeAsync(() => {
       realTimeFeedService.isCardNumberValid.and.returnValue(false);
       realTimeFeedService.getCardTypeFromNumber.and.returnValue(CardNetworkType.OTHERS);
 
@@ -181,13 +181,13 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
+      tick(500);
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
-
       expect(errorMessage.innerText).toBe('Please enter a valid card number.');
-    });
+    }));
 
-    it('should show an error message if only mastercard rtf is enabled but the user has entered a non-mastercard number', () => {
+    it('should show an error message if only mastercard rtf is enabled but the user has entered a non-mastercard number', fakeAsync(() => {
       component.isMastercardRTFEnabled = true;
       component.isVisaRTFEnabled = false;
       component.isYodleeEnabled = false;
@@ -204,15 +204,16 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
+      tick(500);
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 
       expect(errorMessage.innerText).toBe(
         'Enter a valid Mastercard number. If you have other cards, please contact your admin.'
       );
-    });
+    }));
 
-    it('should show an error message if only visa rtf is enabled but the user has entered a non-visa number', () => {
+    it('should show an error message if only visa rtf is enabled but the user has entered a non-visa number', fakeAsync(() => {
       component.isVisaRTFEnabled = true;
       component.isMastercardRTFEnabled = false;
       component.isYodleeEnabled = false;
@@ -229,15 +230,16 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
+      tick(500);
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 
       expect(errorMessage.innerText).toBe(
         'Enter a valid Visa number. If you have other cards, please contact your admin.'
       );
-    });
+    }));
 
-    it('should show an error message if user has entered a non visa/mastercard card number and yodlee is disabled in the org', () => {
+    it('should show an error message if user has entered a non visa/mastercard card number and yodlee is disabled in the org', fakeAsync(() => {
       component.isVisaRTFEnabled = true;
       component.isMastercardRTFEnabled = true;
       component.isYodleeEnabled = false;
@@ -254,12 +256,13 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
+      tick(500);
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
       expect(errorMessage.innerText).toBe(
         'Enter a valid Visa or Mastercard number. If you have other cards, please contact your admin.'
       );
-    });
+    }));
   });
 
   describe('card enrollment flow', () => {

--- a/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
+++ b/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
@@ -316,7 +316,7 @@ describe('AddCorporateCardComponent', () => {
       expect(trackingService.cardEnrolled).toHaveBeenCalledOnceWith(cardEnrolledProperties2);
     });
 
-    it('should show the error message received from backend when we face api errors while enrolling the card', () => {
+    it('should show the error message received from backend when we face api errors while enrolling the card', fakeAsync(() => {
       realTimeFeedService.isCardNumberValid.and.returnValue(true);
       realTimeFeedService.getCardTypeFromNumber.and.returnValue(CardNetworkType.VISA);
       realTimeFeedService.enroll.and.returnValue(throwError(() => new Error('This card already exists in the system')));
@@ -335,15 +335,16 @@ describe('AddCorporateCardComponent', () => {
       addCorporateCardBtn.click();
 
       fixture.detectChanges();
+      tick(500);
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 
       expect(realTimeFeedService.enroll).toHaveBeenCalledOnceWith('4555555555555555', null);
       expect(errorMessage.innerText).toBe('This card already exists in the system');
       expect(trackingService.cardEnrollmentErrors).toHaveBeenCalledWith(cardEnrollmentErrorsProperties1);
-    });
+    }));
 
-    it('should show a default error message when we face api errors from backend but we dont have the error message', () => {
+    it('should show a default error message when we face api errors from backend but we dont have the error message', fakeAsync(() => {
       realTimeFeedService.isCardNumberValid.and.returnValue(true);
       realTimeFeedService.getCardTypeFromNumber.and.returnValue(CardNetworkType.VISA);
       realTimeFeedService.enroll.and.returnValue(throwError(() => new Error()));
@@ -362,13 +363,14 @@ describe('AddCorporateCardComponent', () => {
       addCorporateCardBtn.click();
 
       fixture.detectChanges();
+      tick(500);
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 
       expect(realTimeFeedService.enroll).toHaveBeenCalledOnceWith('4555555555555555', null);
       expect(errorMessage.innerText).toBe('Something went wrong. Please try after some time.');
       expect(trackingService.cardEnrollmentErrors).toHaveBeenCalledOnceWith(cardEnrollmentErrorsProperties2);
-    });
+    }));
 
     it('should disallow card enrollment if the entered card number is invalid', () => {
       realTimeFeedService.isCardNumberValid.and.returnValue(false);

--- a/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
+++ b/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, flush, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { IonicModule, PopoverController } from '@ionic/angular';
 
 import { AddCorporateCardComponent } from './add-corporate-card.component';
@@ -181,7 +181,7 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
-      flush();
+      tick(500);
       fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
@@ -205,7 +205,7 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
-      flush();
+      tick(500);
       fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
@@ -232,7 +232,7 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
-      flush();
+      tick(500);
       fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
@@ -259,7 +259,7 @@ describe('AddCorporateCardComponent', () => {
       cardNumberInput.dispatchEvent(new Event('blur'));
 
       fixture.detectChanges();
-      flush();
+      tick(500);
       fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
@@ -339,7 +339,7 @@ describe('AddCorporateCardComponent', () => {
       addCorporateCardBtn.click();
 
       fixture.detectChanges();
-      flush();
+      tick(500);
       fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
@@ -368,7 +368,7 @@ describe('AddCorporateCardComponent', () => {
       addCorporateCardBtn.click();
 
       fixture.detectChanges();
-      flush();
+      tick(500);
       fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;

--- a/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
+++ b/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, flush, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flush, waitForAsync } from '@angular/core/testing';
 import { IonicModule, PopoverController } from '@ionic/angular';
 
 import { AddCorporateCardComponent } from './add-corporate-card.component';
@@ -182,6 +182,7 @@ describe('AddCorporateCardComponent', () => {
 
       fixture.detectChanges();
       flush();
+      fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
       expect(errorMessage.innerText).toBe('Please enter a valid card number.');
@@ -205,6 +206,7 @@ describe('AddCorporateCardComponent', () => {
 
       fixture.detectChanges();
       flush();
+      fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 
@@ -231,6 +233,7 @@ describe('AddCorporateCardComponent', () => {
 
       fixture.detectChanges();
       flush();
+      fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 
@@ -257,6 +260,7 @@ describe('AddCorporateCardComponent', () => {
 
       fixture.detectChanges();
       flush();
+      fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
       expect(errorMessage.innerText).toBe(
@@ -336,6 +340,7 @@ describe('AddCorporateCardComponent', () => {
 
       fixture.detectChanges();
       flush();
+      fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 
@@ -364,6 +369,7 @@ describe('AddCorporateCardComponent', () => {
 
       fixture.detectChanges();
       flush();
+      fixture.detectChanges();
 
       const errorMessage = getElementBySelector(fixture, '[data-testid="error-message"]') as HTMLElement;
 

--- a/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
+++ b/src/app/fyle/manage-corporate-cards/add-corporate-card/add-corporate-card.component.spec.ts
@@ -167,7 +167,7 @@ describe('AddCorporateCardComponent', () => {
     });
   });
 
-  fdescribe('card number validation errors', () => {
+  describe('card number validation errors', () => {
     it('should show an error message when the user has entered an invalid card number', fakeAsync(() => {
       realTimeFeedService.isCardNumberValid.and.returnValue(false);
       realTimeFeedService.getCardTypeFromNumber.and.returnValue(CardNetworkType.OTHERS);


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19HyEhEvNCmWLrSKbYOSv1ot5S3BIQMA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=u3OxPp2)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55275de</samp>

The pull request improves the unit testing of the `AddCorporateCardComponent` by using `fakeAsync` and `tick` to simulate the validation process. This helps verify the error handling of different card numbers and yodlee settings.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 55275de</samp>

> _In the shadows of the yodlee beast_
> _We test the logic of the card_
> _With `fakeAsync` and `tick` we unleash_
> _The validation of the dark_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55275de</samp>

* Imported `fakeAsync` and `tick` functions to enable testing of asynchronous code with timers ([link](https://github.com/fylein/fyle-mobile-app/pull/2474/files?diff=unified&w=0#diff-c5548f8968bea9df856f1bf7ad8b68d9b7eee71d7181ef5cf14b83c59904b45dL1-R1))
* Wrapped `it` blocks with `fakeAsync` and added `tick(500)` statements to trigger the `debounceTime` operator and the validation logic for the card number input in different scenarios ([link](https://github.com/fylein/fyle-mobile-app/pull/2474/files?diff=unified&w=0#diff-c5548f8968bea9df856f1bf7ad8b68d9b7eee71d7181ef5cf14b83c59904b45dL171-R171), [link](https://github.com/fylein/fyle-mobile-app/pull/2474/files?diff=unified&w=0#diff-c5548f8968bea9df856f1bf7ad8b68d9b7eee71d7181ef5cf14b83c59904b45dL184-R190), [link](https://github.com/fylein/fyle-mobile-app/pull/2474/files?diff=unified&w=0#diff-c5548f8968bea9df856f1bf7ad8b68d9b7eee71d7181ef5cf14b83c59904b45dR207), [link](https://github.com/fylein/fyle-mobile-app/pull/2474/files?diff=unified&w=0#diff-c5548f8968bea9df856f1bf7ad8b68d9b7eee71d7181ef5cf14b83c59904b45dL213-R216), [link](https://github.com/fylein/fyle-mobile-app/pull/2474/files?diff=unified&w=0#diff-c5548f8968bea9df856f1bf7ad8b68d9b7eee71d7181ef5cf14b83c59904b45dR233), [link](https://github.com/fylein/fyle-mobile-app/pull/2474/files?diff=unified&w=0#diff-c5548f8968bea9df856f1bf7ad8b68d9b7eee71d7181ef5cf14b83c59904b45dL238-R242), [link](https://github.com/fylein/fyle-mobile-app/pull/2474/files?diff=unified&w=0#diff-c5548f8968bea9df856f1bf7ad8b68d9b7eee71d7181ef5cf14b83c59904b45dR259), [link](https://github.com/fylein/fyle-mobile-app/pull/2474/files?diff=unified&w=0#diff-c5548f8968bea9df856f1bf7ad8b68d9b7eee71d7181ef5cf14b83c59904b45dL262-R265))

## Clickup
https://app.clickup.com