### PR TITLE
test: 100% coverage of view-team-adv-request page

### DIFF
--- a/src/app/core/mock-data/modal-controller.data.ts
+++ b/src/app/core/mock-data/modal-controller.data.ts
@@ -17,8 +17,9 @@ import { FyInputPopoverComponent } from 'src/app/shared/components/fy-input-popo
 import { PolicyViolationDialogComponent } from 'src/app/fyle/add-edit-advance-request/policy-violation-dialog/policy-violation-dialog.component';
 import { CaptureReceiptComponent } from 'src/app/shared/components/capture-receipt/capture-receipt.component';
 import { FyViewAttachmentComponent } from 'src/app/shared/components/fy-view-attachment/fy-view-attachment.component';
-import { advanceRequestFileUrlData2 } from './file-object.data';
+import { advanceRequestFileUrlData2, fileObject4 } from './file-object.data';
 import { ViewCommentComponent } from 'src/app/shared/components/comments-history/view-comment/view-comment.component';
+import { FyPopoverComponent } from 'src/app/shared/components/fy-popover/fy-popover.component';
 
 export const modalControllerParams = {
   component: FyFiltersComponent,
@@ -460,4 +461,55 @@ export const popoverControllerParams5 = {
       action: 'cancel',
     },
   },
+};
+
+export const popoverControllerParams6 = {
+  component: FyPopoverComponent,
+  cssClass: 'fy-dialog-popover',
+  componentProps: {
+    title: 'Send Back',
+    formLabel: 'Reason For Sending Back Advance',
+  },
+};
+
+export const popoverControllerParams7 = {
+  component: FyPopoverComponent,
+  cssClass: 'fy-dialog-popover',
+  componentProps: {
+    title: 'Reject',
+    formLabel: 'Please mention the reason for rejecting the advance request',
+  },
+};
+
+export const modalControllerParams6 = {
+  component: ViewCommentComponent,
+  componentProps: {
+    objectType: 'advance_requests',
+    objectId: 'areqR1cyLgXdND',
+  },
+  cssClass: 'fy-modal',
+  showBackdrop: true,
+  canDismiss: true,
+  backdropDismiss: true,
+  animated: true,
+  initialBreakpoint: 1,
+  breakpoints: [0, 1],
+  handle: false,
+};
+
+export const modalControllerParams7 = {
+  component: FyViewAttachmentComponent,
+  componentProps: {
+    attachments: fileObject4[0],
+  },
+  mode: 'ios' as Mode,
+  presentingElement: undefined,
+  cssClass: 'fy-modal',
+  showBackdrop: true,
+  canDismiss: true,
+  backdropDismiss: true,
+  animated: true,
+  initialBreakpoint: 1,
+  breakpoints: [0, 1],
+  handle: false,
 };


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 275c4ef</samp>

Added mock data and unit tests for modals and popovers in `ViewTeamAdvanceRequestPage` component. This pull request enhances the test coverage and functionality of the component that displays team advance requests.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 275c4ef</samp>

> _Mock data for tests_
> _`ViewTeamAdvanceRequestPage`_
> _Has modal, popover_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 275c4ef</samp>

*  Import mock data and component for attachment modal and popover ([link](https://github.com/fylein/fyle-mobile-app/pull/2494/files?diff=unified&w=0#diff-32f470962ca37f24fcdc6eaf809fb30dc2ce6a9e003b41b20b34908107e83805L20-R22))
* Add mock data for modal and popover controller parameters for different scenarios in view team advance request page ([link](https://github.com/fylein/fyle-mobile-app/pull/2494/files?diff=unified&w=0#diff-32f470962ca37f24fcdc6eaf809fb30dc2ce6a9e003b41b20b34908107e83805R465-R515))
* Import mock data for modal and popover controller parameters and properties in view team advance request page spec file ([link](https://github.com/fylein/fyle-mobile-app/pull/2494/files?diff=unified&w=0#diff-207a312b9a332e35779d4ad67cb5c45fa712eac9aef5b6537d366d5c27189780L32-R39))
* Add unit tests for `showSendBackAdvanceSummaryPopover`, `showRejectAdvanceSummaryPopup`, `openCommentsModal`, `viewAttachments`, and `goToTeamAdvances` methods in `ViewTeamAdvanceRequestPage` component ([link](https://github.com/fylein/fyle-mobile-app/pull/2494/files?diff=unified&w=0#diff-207a312b9a332e35779d4ad67cb5c45fa712eac9aef5b6537d366d5c27189780R391-R485))
* Use mock data, services, and fakeAsync to create and present modals and popovers, simulate API calls, and verify analytics events in unit tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2494/files?diff=unified&w=0#diff-207a312b9a332e35779d4ad67cb5c45fa712eac9aef5b6537d366d5c27189780R391-R485))

## Clickup
https://app.clickup.com/t/85zu314xk

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes