### PR TITLE
fix: Add card CTA usability issue

### DIFF
--- a/src/app/shared/components/add-card/add-card.component.html
+++ b/src/app/shared/components/add-card/add-card.component.html
@@ -1,9 +1,9 @@
-<div class="add-card-container">
+<div class="add-card-container" (click)="addCardClick.emit($event)" ata-testid="add-card-container">
   <img class="add-card-container__img" src="../../../../assets/images/cards.svg" />
   <span *ngIf="showZeroStateMessage" data-testid="zero-state-message">No card added yet!</span>
 
-  <button class="add-card-container__cta" (click)="addCardClick.emit($event)" data-testid="add-card-button">
+  <div class="add-card-container__cta">
     <ion-icon class="add-card-container__cta-icon" src="../../../../assets/svg/plus.svg"></ion-icon>
     <span>Add Corporate Card</span>
-  </button>
+  </div>
 </div>

--- a/src/app/shared/components/add-card/add-card.component.html
+++ b/src/app/shared/components/add-card/add-card.component.html
@@ -1,4 +1,4 @@
-<div class="add-card-container" (click)="addCardClick.emit($event)" ata-testid="add-card-container">
+<div class="add-card-container" (click)="addCardClick.emit($event)" data-testid="add-card-container">
   <img class="add-card-container__img" src="../../../../assets/images/cards.svg" />
   <span *ngIf="showZeroStateMessage" data-testid="zero-state-message">No card added yet!</span>
 

--- a/src/app/shared/components/add-card/add-card.component.spec.ts
+++ b/src/app/shared/components/add-card/add-card.component.spec.ts
@@ -42,11 +42,11 @@ describe('AddCardComponent', () => {
     expect(zeroStateMessageElement).toBeNull();
   });
 
-  it('should raise an event addCardClick when the add card button is clicked', () => {
+  it('should raise an event addCardClick when the add card container is clicked', () => {
     spyOn(component.addCardClick, 'emit');
 
-    const addCardButton = getElementRef(fixture, '[data-testid="add-card-button"]');
-    addCardButton.nativeElement.click();
+    const addCardContainer = getElementRef(fixture, '[data-testid="add-card-container"]');
+    addCardContainer.nativeElement.click();
 
     expect(component.addCardClick.emit).toHaveBeenCalled();
   });

--- a/src/app/shared/components/spent-cards/spent-cards.component.html
+++ b/src/app/shared/components/spent-cards/spent-cards.component.html
@@ -6,6 +6,7 @@
     [slidesPerView]="1.1"
     [spaceBetween]="16"
     [pagination]="pagination"
+    [centeredSlides]="cardDetails.length === 1 && !showAddCardSlide"
   >
     <ng-template *ngFor="let cardDetail of cardDetails" swiperSlide>
       <app-card-detail [cardDetail]="cardDetail" [homeCurrency]="homeCurrency" [currencySymbol]="currencySymbol">


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1hvRVEXkvBqmiLIFHPeQeAymRKavE8Dc%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=Xi5wMEK)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f0dd9b</samp>

Improved the UI and UX of the add card component by making the whole container clickable. Updated the unit test to match the new HTML structure.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3f0dd9b</samp>

> _`addCard` container_
> _clickable for better UX_
> _autumn leaves falling_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f0dd9b</samp>

* Make the add card container clickable instead of the button inside it ([link](https://github.com/fylein/fyle-mobile-app/pull/2497/files?diff=unified&w=0#diff-f9e2659014c7cb2b02a16174e456a776b4765d2278ce91e38b858dc7bc39eacdL1-R8), [link](https://github.com/fylein/fyle-mobile-app/pull/2497/files?diff=unified&w=0#diff-ae3550de5730e363e5a41cba3d785756a29348edf5ffa1e339de66b90b52da67L45-R49))

## Clickup
https://app.clickup.com

Made the entire add card container clickable instead of only the text