### PR TITLE
test: removing unnecessary optionals and increasing branch cov - 4

### DIFF
--- a/src/app/core/services/merge-expenses.service.spec.ts
+++ b/src/app/core/services/merge-expenses.service.spec.ts
@@ -911,17 +911,16 @@ describe('MergeExpensesService', () => {
 
     it('formatTaxGroupOption(): should return the formatted tax group option with label as undefined if id does not matches with options', (done) => {
       taxGroupService.get.and.returnValue(of(taxGroupData));
+      const mockOptions = { ...optionsData11.options[0], value: 'tgp6JA6tgoZ1' };
       // @ts-ignore
-      mergeExpensesService
-        .formatTaxGroupOption({ ...optionsData11.options[0], value: 'tgp6JA6tgoZ1' })
-        .subscribe((res) => {
-          expect(res).toEqual({
-            label: undefined,
-            value: 'tgp6JA6tgoZ1',
-          });
-          expect(taxGroupService.get).toHaveBeenCalledTimes(1);
-          done();
+      mergeExpensesService.formatTaxGroupOption(mockOptions).subscribe((res) => {
+        expect(res).toEqual({
+          label: undefined,
+          value: 'tgp6JA6tgoZ1',
         });
+        expect(taxGroupService.get).toHaveBeenCalledTimes(1);
+        done();
+      });
     });
   });
 

--- a/src/app/core/services/merge-expenses.service.spec.ts
+++ b/src/app/core/services/merge-expenses.service.spec.ts
@@ -94,7 +94,7 @@ import { projectsV1Data } from '../test-data/projects.spec.data';
 import { corporateCardExpenseData } from '../mock-data/corporate-card-expense.data';
 import { customInputData } from '../test-data/custom-inputs.spec.data';
 import * as dayjs from 'dayjs';
-import { orgCategoryData1 } from '../mock-data/org-category.data';
+import { expectedOrgCategoryByName2, orgCategoryData1 } from '../mock-data/org-category.data';
 import { taxGroupData } from '../mock-data/tax-group.data';
 
 describe('MergeExpensesService', () => {
@@ -412,6 +412,15 @@ describe('MergeExpensesService', () => {
       });
     });
 
+    it('should return the project options with label as project name if id matches with option', (done) => {
+      projectService.getAllActive.and.returnValue(of(projectsV1Data));
+      // @ts-ignore
+      mergeExpensesService.formatProjectOptions({ ...projectOptionsData, value: 257528 }).subscribe((res) => {
+        expect(res).toEqual({ label: 'Customer Mapped Project', value: 257528 });
+        done();
+      });
+    });
+
     it('should return the project options when project is not present', (done) => {
       projectService.getAllActive.and.returnValue(of([]));
       // @ts-ignore
@@ -447,7 +456,7 @@ describe('MergeExpensesService', () => {
   });
 
   describe('getCorporateCardTransactions(): ', () => {
-    it('should return the corportate card transactions', (done) => {
+    it('should return the corporate card transactions', (done) => {
       const params = {
         queryParams: {
           group_id: ['in.(,)'],
@@ -462,6 +471,29 @@ describe('MergeExpensesService', () => {
         .and.returnValue(of(corporateCardExpenseData));
 
       mergeExpensesService.getCorporateCardTransactions(expensesDataWithCC).subscribe((res) => {
+        expect(res).toEqual(corporateCardExpenseData.data);
+        expect(corporateCreditCardExpenseService.getv2CardTransactions).toHaveBeenCalledOnceWith(params);
+        expect(customInputsService.getAll).toHaveBeenCalledOnceWith(true);
+        done();
+      });
+    });
+
+    it('should return the corporate card transactions if expenses are undefined', (done) => {
+      const params = {
+        queryParams: {
+          group_id: ['in.(,)'],
+        },
+        offset: 0,
+        limit: 1,
+      };
+
+      customInputsService.getAll.withArgs(true).and.returnValue(of(customInputData));
+      corporateCreditCardExpenseService.getv2CardTransactions
+        .withArgs(params)
+        .and.returnValue(of(corporateCardExpenseData));
+
+      const mockExpense = [undefined, undefined];
+      mergeExpensesService.getCorporateCardTransactions(mockExpense).subscribe((res) => {
         expect(res).toEqual(corporateCardExpenseData.data);
         expect(corporateCreditCardExpenseService.getv2CardTransactions).toHaveBeenCalledOnceWith(params);
         expect(customInputsService.getAll).toHaveBeenCalledOnceWith(true);
@@ -669,6 +701,16 @@ describe('MergeExpensesService', () => {
     it('should return null when options are not passed', () => {
       expect(mergeExpensesService.getFieldValue(optionsData13)).toBeNull();
     });
+
+    it('should return null when optionsData is null', () => {
+      expect(mergeExpensesService.getFieldValue(null)).toBeNull();
+    });
+
+    it('should return undefined if option is empty array', () => {
+      expect(
+        mergeExpensesService.getFieldValue({ ...optionsData13, areSameValues: true, options: [] })
+      ).toBeUndefined();
+    });
   });
 
   it('generateLocationOptions(): should return the location options', (done) => {
@@ -782,12 +824,32 @@ describe('MergeExpensesService', () => {
     });
   });
 
-  it('getCategoryName(): should return the category name', () => {
-    categoriesService.getAll.and.returnValue(of(orgCategoryData1));
-    const categoryId = '201952';
-    mergeExpensesService.getCategoryName(categoryId).subscribe((res) => {
-      expect(res).toEqual('Food');
-      expect(categoriesService.getAll).toHaveBeenCalledTimes(1);
+  describe('getCategoryName():', () => {
+    it('should return the category name', () => {
+      categoriesService.getAll.and.returnValue(of(orgCategoryData1));
+      const categoryId = '201952';
+      mergeExpensesService.getCategoryName(categoryId).subscribe((res) => {
+        expect(res).toEqual('Food');
+        expect(categoriesService.getAll).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should return undefined if category id does not match with params', () => {
+      categoriesService.getAll.and.returnValue(of(orgCategoryData1));
+      const categoryId = '201951';
+      mergeExpensesService.getCategoryName(categoryId).subscribe((res) => {
+        expect(res).toEqual(undefined);
+        expect(categoriesService.getAll).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should return undefined if category id is undefined', () => {
+      categoriesService.getAll.and.returnValue(of([expectedOrgCategoryByName2]));
+      const categoryId = '201951';
+      mergeExpensesService.getCategoryName(categoryId).subscribe((res) => {
+        expect(res).toEqual(undefined);
+        expect(categoriesService.getAll).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
@@ -815,6 +877,16 @@ describe('MergeExpensesService', () => {
       expect(res).toEqual(mergeExpensesOptionData4[0].value);
     });
 
+    it('should return the field value on change when value is untouched and optionsData is undefined', () => {
+      const res = mergeExpensesService.getFieldValueOnChange(
+        undefined,
+        null,
+        mergeExpensesOptionData4[0].value,
+        mergeExpensesOptionData4[0].value
+      );
+      expect(res).toEqual(mergeExpensesOptionData4[0].value);
+    });
+
     it('should return the field value on change when value is touched', () => {
       const res = mergeExpensesService.getFieldValueOnChange(
         mergeExpensesOptionData4[0],
@@ -826,13 +898,30 @@ describe('MergeExpensesService', () => {
     });
   });
 
-  it('formatTaxGroupOption(): should return the formatted tax group option', (done) => {
-    taxGroupService.get.and.returnValue(of(taxGroupData));
-    // @ts-ignore
-    mergeExpensesService.formatTaxGroupOption(optionsData11.options[0]).subscribe((res) => {
-      expect(res).toEqual(mergeExpensesOptionData5[0]);
-      expect(taxGroupService.get).toHaveBeenCalledTimes(1);
-      done();
+  describe('formatTaxGroupOption():', () => {
+    it('formatTaxGroupOption(): should return the formatted tax group option', (done) => {
+      taxGroupService.get.and.returnValue(of(taxGroupData));
+      // @ts-ignore
+      mergeExpensesService.formatTaxGroupOption(optionsData11.options[0]).subscribe((res) => {
+        expect(res).toEqual(mergeExpensesOptionData5[0]);
+        expect(taxGroupService.get).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+
+    it('formatTaxGroupOption(): should return the formatted tax group option with label as undefined if id does not matches with options', (done) => {
+      taxGroupService.get.and.returnValue(of(taxGroupData));
+      // @ts-ignore
+      mergeExpensesService
+        .formatTaxGroupOption({ ...optionsData11.options[0], value: 'tgp6JA6tgoZ1' })
+        .subscribe((res) => {
+          expect(res).toEqual({
+            label: undefined,
+            value: 'tgp6JA6tgoZ1',
+          });
+          expect(taxGroupService.get).toHaveBeenCalledTimes(1);
+          done();
+        });
     });
   });
 
@@ -911,5 +1000,35 @@ describe('MergeExpensesService', () => {
   it('setformattedDate(): should return formatted date', () => {
     const mockDate = '2021-03-10T05:31:00.000Z';
     expect(mergeExpensesService.setFormattedDate(mockDate)).toEqual(dayjs(mockDate).format('MMM DD, YYYY'));
+  });
+
+  describe('formatCategoryOption():', () => {
+    beforeEach(() => {
+      categoriesService.getAll.and.returnValue(of(orgCategoryData1));
+      categoriesService.filterRequired.and.returnValue(orgCategoryData1);
+    });
+
+    it('should return the formatted category option', (done) => {
+      // @ts-ignore
+      mergeExpensesService.formatCategoryOption(mergeExpensesOptionData4[0]).subscribe((res) => {
+        expect(res).toEqual(mergeExpensesOptionData4[0]);
+        expect(categoriesService.getAll).toHaveBeenCalledTimes(1);
+        expect(categoriesService.filterRequired).toHaveBeenCalledOnceWith(orgCategoryData1);
+        done();
+      });
+    });
+
+    it('should return the formatted category option with label as Unspecified if id does not matches with options', (done) => {
+      // @ts-ignore
+      mergeExpensesService.formatCategoryOption({ ...mergeExpensesOptionData4[0], value: 201951 }).subscribe((res) => {
+        expect(res).toEqual({
+          label: 'Unspecified',
+          value: 201951,
+        });
+        expect(categoriesService.getAll).toHaveBeenCalledTimes(1);
+        expect(categoriesService.filterRequired).toHaveBeenCalledOnceWith(orgCategoryData1);
+        done();
+      });
+    });
   });
 });

--- a/src/app/core/services/merge-expenses.service.ts
+++ b/src/app/core/services/merge-expenses.service.ts
@@ -135,7 +135,7 @@ export class MergeExpensesService {
       switchMap(() => {
         const CCCGroupIds = expenses.map((expense) => expense?.tx_corporate_credit_card_expense_group_id);
 
-        if (CCCGroupIds?.length > 0) {
+        if (CCCGroupIds.length > 0) {
           const queryParams = {
             group_id: ['in.(' + CCCGroupIds + ')'],
           };
@@ -297,7 +297,7 @@ export class MergeExpensesService {
     return from(expenses).pipe(
       filter((expense) => !!expense.tx_project_id),
       map((expense) => ({
-        label: expense.tx_project_id?.toString(),
+        label: expense.tx_project_id.toString(),
         value: expense.tx_project_id,
       })),
       mergeMap((option) => this.formatProjectOptions(option)),
@@ -395,7 +395,7 @@ export class MergeExpensesService {
     return from(expenses).pipe(
       filter((expense) => !!expense.tx_locations[locationIndex]),
       map((expense) => ({
-        label: expense.tx_locations[locationIndex]?.formatted_address,
+        label: expense.tx_locations[locationIndex].formatted_address,
         value: expense.tx_locations[locationIndex],
       })),
       reduce((acc: MergeExpensesOption<Location>[], curr) => {
@@ -562,7 +562,7 @@ export class MergeExpensesService {
   getCategoryName(categoryId: string): Observable<string> {
     return this.categoriesService.getAll().pipe(
       map((categories) => {
-        const category = categories.find((category) => category?.id?.toString() === categoryId);
+        const category = categories.find((category) => category.id?.toString() === categoryId);
         return category?.name;
       })
     );
@@ -641,7 +641,7 @@ export class MergeExpensesService {
 
   getFieldValue<T>(optionsData: MergeExpensesOptionsData<T>): T {
     if (optionsData?.areSameValues) {
-      return optionsData?.options[0]?.value;
+      return optionsData.options[0]?.value;
     } else {
       return null;
     }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d54a87a</samp>

This pull request improves the testing and code quality of the `MergeExpensesService` class, which handles the logic for merging expenses in the app. It adds and updates test cases for different methods and scenarios in `src/app/core/services/merge-expenses.service.spec.ts`. It also removes unnecessary optional chaining operators from various properties in `src/app/core/services/merge-expenses.service.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d54a87a</samp>

> _`MergeExpensesService`_
> _Tests and code refined - no more_
> _Optional chaining_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d54a87a</samp>

*  Remove unnecessary optional chaining operators from various properties in `merge-expenses.service.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L138-R138), [link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L300-R300), [link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L398-R398), [link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L565-R565), [link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L644-R644))
*  Add new test cases for `getCategoryName()`, `formatProjectOptions()`, `getCorporateCardTransactions()`, `getFieldValue()`, `getFieldValueOnChange()`, `formatTaxGroupOption()`, and `formatCategoryOption()` methods in `merge-expenses.service.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-499d27b2b9ff1320e3207bd1413b47d449450c768a433995af14e85f5944f39bR415-R423), [link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-499d27b2b9ff1320e3207bd1413b47d449450c768a433995af14e85f5944f39bR480-R502), [link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-499d27b2b9ff1320e3207bd1413b47d449450c768a433995af14e85f5944f39bR704-R713), [link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-499d27b2b9ff1320e3207bd1413b47d449450c768a433995af14e85f5944f39bL785-R853), [link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-499d27b2b9ff1320e3207bd1413b47d449450c768a433995af14e85f5944f39bR880-R889), [link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-499d27b2b9ff1320e3207bd1413b47d449450c768a433995af14e85f5944f39bL829-R925), [link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-499d27b2b9ff1320e3207bd1413b47d449450c768a433995af14e85f5944f39bR1004-R1033))
*  Import mock data for `expectedOrgCategoryByName2` from `org-category.data` file in `merge-expenses.service.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-499d27b2b9ff1320e3207bd1413b47d449450c768a433995af14e85f5944f39bL97-R97))
*  Fix typo in test suite description for `getCorporateCardTransactions()` method in `merge-expenses.service.spec.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2506/files?diff=unified&w=0#diff-499d27b2b9ff1320e3207bd1413b47d449450c768a433995af14e85f5944f39bL450-R459))

## Clickup
app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes