### PR TITLE
test: some branches in route selector component

### DIFF
--- a/src/app/shared/components/route-selector/route-selector.component.spec.ts
+++ b/src/app/shared/components/route-selector/route-selector.component.spec.ts
@@ -15,7 +15,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { click, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
 import { By } from '@angular/platform-browser';
 
-describe('RouteSelectorComponent', () => {
+fdescribe('RouteSelectorComponent', () => {
   let component: RouteSelectorComponent;
   let fixture: ComponentFixture<RouteSelectorComponent>;
   let fb: jasmine.SpyObj<FormBuilder>;
@@ -133,39 +133,67 @@ describe('RouteSelectorComponent', () => {
     });
   });
 
-  it('openModal(): should open the modal', async () => {
-    modalController.create.and.returnValue(
-      new Promise((resolve) => {
-        const selectionModalSpy = jasmine.createSpyObj('selectionModal', ['present', 'onWillDismiss']);
+  describe('openModal():', () => {
+    let selectionModalSpy: jasmine.SpyObj<HTMLIonModalElement>;
+    beforeEach(() => {
+      selectionModalSpy = jasmine.createSpyObj('selectionModal', ['present', 'onWillDismiss']);
+      selectionModalSpy.onWillDismiss.and.returnValue(
+        new Promise((resInt) => {
+          resInt({
+            data: {
+              mileageLocations: mileageLocationData1,
+              distance: 20,
+            },
+          });
+        })
+      );
+      modalController.create.and.resolveTo(selectionModalSpy);
+    });
 
-        selectionModalSpy.onWillDismiss.and.returnValue(
-          new Promise((resInt) => {
-            resInt({
-              data: {
-                mileageLocations: mileageLocationData1,
-                distance: 20,
-              },
-            });
-          })
-        );
-        resolve(selectionModalSpy);
-      })
-    );
+    it('should open the modal', async () => {
+      fixture.detectChanges();
 
-    fixture.detectChanges();
+      component.openModal();
+      expect(modalController.create).toHaveBeenCalledOnceWith({
+        component: RouteSelectorModalComponent,
+        componentProps: {
+          unit: component.unit,
+          mileageConfig: component.mileageConfig,
+          isDistanceMandatory: component.isDistanceMandatory,
+          isAmountDisabled: component.isAmountDisabled,
+          txnFields: component.txnFields,
+          value: component.form.value,
+          recentlyUsedMileageLocations: component.recentlyUsedMileageLocations,
+        },
+      });
+    });
 
-    component.openModal();
-    expect(modalController.create).toHaveBeenCalledOnceWith({
-      component: RouteSelectorModalComponent,
-      componentProps: {
-        unit: component.unit,
-        mileageConfig: component.mileageConfig,
-        isDistanceMandatory: component.isDistanceMandatory,
-        isAmountDisabled: component.isAmountDisabled,
-        txnFields: component.txnFields,
-        value: component.form.value,
-        recentlyUsedMileageLocations: component.recentlyUsedMileageLocations,
-      },
+    it('should open modal and should not update mileageLocations if "data.mileageLocations" is null', async () => {
+      selectionModalSpy.onWillDismiss.and.returnValue(
+        new Promise((resInt) => {
+          resInt({
+            data: {
+              mileageLocations: null,
+              distance: 20,
+            },
+          });
+        })
+      );
+      modalController.create.and.resolveTo(selectionModalSpy);
+
+      component.openModal();
+      expect(modalController.create).toHaveBeenCalledOnceWith({
+        component: RouteSelectorModalComponent,
+        componentProps: {
+          unit: component.unit,
+          mileageConfig: component.mileageConfig,
+          isDistanceMandatory: component.isDistanceMandatory,
+          isAmountDisabled: component.isAmountDisabled,
+          txnFields: component.txnFields,
+          value: component.form.value,
+          recentlyUsedMileageLocations: component.recentlyUsedMileageLocations,
+        },
+      });
     });
   });
 
@@ -224,13 +252,33 @@ describe('RouteSelectorComponent', () => {
     });
   });
 
-  it('onTxnFieldsChange():', () => {
-    spyOn(component, 'ngOnChanges');
-    component.txnFields = expenseFieldsMapResponse3;
-    component.onTxnFieldsChange();
+  describe('onTxnFieldsChange():', () => {
+    beforeEach(() => {
+      spyOn(component, 'ngOnChanges');
+      component.txnFields = expenseFieldsMapResponse3;
+    });
 
-    expect(component.form.controls.distance.hasValidator(Validators.required)).toBeFalse();
-    expect(component.form.controls.mileageLocations.hasValidator(Validators.required)).toBeFalse();
+    it('should update form validators', () => {
+      component.onTxnFieldsChange();
+      expect(component.form.controls.distance.hasValidator(Validators.required)).toBeFalse();
+      expect(component.form.controls.mileageLocations.hasValidator(Validators.required)).toBeFalse();
+    });
+
+    it('should update distance field validator if it distance is mandatory', () => {
+      spyOn(component.form, 'updateValueAndValidity');
+      spyOn(component.form.controls.distance, 'updateValueAndValidity');
+      component.isConnected = true;
+      component.txnFields.distance.is_mandatory = true;
+      component.onTxnFieldsChange();
+      expect(component.form.controls.distance.validator).toBeDefined();
+    });
+
+    it('should update distance field validator as null if it is mandatory but isConnected is false', () => {
+      component.txnFields.distance.is_mandatory = true;
+      component.onTxnFieldsChange();
+      expect(component.form.controls.mileageLocations.hasValidator(Validators.required)).toBeFalse();
+      expect(component.form.controls.distance.validator).toBeNull();
+    });
   });
 
   it('should show mandatory symbol if location is required', () => {

--- a/src/app/shared/components/route-selector/route-selector.component.spec.ts
+++ b/src/app/shared/components/route-selector/route-selector.component.spec.ts
@@ -15,7 +15,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { click, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
 import { By } from '@angular/platform-browser';
 
-fdescribe('RouteSelectorComponent', () => {
+describe('RouteSelectorComponent', () => {
   let component: RouteSelectorComponent;
   let fixture: ComponentFixture<RouteSelectorComponent>;
   let fb: jasmine.SpyObj<FormBuilder>;

--- a/src/app/shared/components/route-selector/route-selector.component.ts
+++ b/src/app/shared/components/route-selector/route-selector.component.ts
@@ -222,7 +222,7 @@ export class RouteSelectorComponent implements OnInit, ControlValueAccessor, OnD
         emitEvent: false,
       });
 
-      data?.mileageLocations?.forEach((mileageLocation) => {
+      data.mileageLocations?.forEach((mileageLocation) => {
         this.mileageLocations.push(
           new FormControl(mileageLocation, this.mileageConfig.location_mandatory && Validators.required)
         );


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1S7tLZhW6Wxr5LKSQS93SrS71zAnEDqE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=mqrVrYV)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6060aa4</samp>

This pull request enhances the testing and readability of the `RouteSelectorComponent` in the Fyle mobile app. It reorganizes the test suite into more meaningful blocks and adds new test cases. It also removes unnecessary optional chaining operators from the component code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6060aa4</samp>

> _We're testing the `RouteSelectorComponent` today_
> _We'll make it more robust and clear along the way_
> _We'll remove the `?.` operator from the `data` parameter_
> _And we'll heave away on the count of three, heave away!_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6060aa4</samp>

* Focus the test suite for `RouteSelectorComponent` using `fdescribe` ([link](https://github.com/fylein/fyle-mobile-app/pull/2523/files?diff=unified&w=0#diff-7a330205eec059c2438881d216ca68664411b2bcf883394ab9991910c7faa007L18-R18))
* Refactor and expand the test for `openModal` method to use `describe` and `it` blocks and cover null modal data scenario ([link](https://github.com/fylein/fyle-mobile-app/pull/2523/files?diff=unified&w=0#diff-7a330205eec059c2438881d216ca68664411b2bcf883394ab9991910c7faa007L136-R196))
* Refactor and expand the test for `onTxnFieldsChange` method to use `describe` and `it` blocks and cover different distance validator scenarios ([link](https://github.com/fylein/fyle-mobile-app/pull/2523/files?diff=unified&w=0#diff-7a330205eec059c2438881d216ca68664411b2bcf883394ab9991910c7faa007L227-R281))
* Remove unnecessary optional chaining operator from `data` parameter in `setMileageLocations` method in `route-selector.component.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2523/files?diff=unified&w=0#diff-f4cd3a095f3da561cbfa36bbbc85c254d749df2160f94c8ae4b3310857a63f34L225-R225))

## Clickup
app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes