### PR TITLE
test: some branches in view per diem page

### DIFF
--- a/src/app/fyle/view-per-diem/view-per-diem.page.spec.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.spec.ts
@@ -201,7 +201,7 @@ describe('ViewPerDiemPage', () => {
     it('should get policy details for team expenses', () => {
       component.view = ExpenseView.team;
       policyService.getApproverExpensePolicyViolations.and.returnValue(
-        of(ApproverExpensePolicyStatesData.data[0].individual_desired_states),
+        of(ApproverExpensePolicyStatesData.data[0].individual_desired_states)
       );
       component.getPolicyDetails('txRNWeQRXhso');
       expect(policyService.getApproverExpensePolicyViolations).toHaveBeenCalledOnceWith('txRNWeQRXhso');
@@ -211,7 +211,7 @@ describe('ViewPerDiemPage', () => {
     it('should get policy details for individual expenses', () => {
       component.view = ExpenseView.individual;
       policyService.getSpenderExpensePolicyViolations.and.returnValue(
-        of(expensePolicyStatesData.data[0].individual_desired_states),
+        of(expensePolicyStatesData.data[0].individual_desired_states)
       );
       component.getPolicyDetails('txVTmNOp5JEa');
       expect(policyService.getSpenderExpensePolicyViolations).toHaveBeenCalledOnceWith('txVTmNOp5JEa');
@@ -297,7 +297,7 @@ describe('ViewPerDiemPage', () => {
         .pipe(
           finalize(() => {
             expect(loaderService.hideLoader).toHaveBeenCalledTimes(1);
-          }),
+          })
         )
         .subscribe((extendedPerDiem) => {
           expect(transactionService.getExpenseV2).toHaveBeenCalledOnceWith('tx3qwe4ty');
@@ -326,6 +326,48 @@ describe('ViewPerDiemPage', () => {
         done();
       });
     });
+
+    it('should call dependentFieldsService.getDependentFieldValuesForBaseField with undefined if "txnFields.project_id" and "txnFields.cost_center_id" is array containing undefined', fakeAsync(() => {
+      expenseFieldsService.getAllMap.and.returnValue(
+        of({ ...expenseFieldsMapResponse4, project_id: [undefined], cost_center_id: [undefined] })
+      );
+      component.ionViewWillEnter();
+      tick(100);
+
+      component.projectDependentCustomProperties$.subscribe((projectDependentCustomProperties) => {
+        expect(dependentFieldsService.getDependentFieldValuesForBaseField).toHaveBeenCalledOnceWith(
+          expenseData1.tx_custom_properties,
+          undefined
+        );
+        expect(projectDependentCustomProperties).toEqual(customInputData1);
+      });
+
+      component.costCenterDependentCustomProperties$.subscribe((costCenterDependentCustomProperties) => {
+        expect(dependentFieldsService.getDependentFieldValuesForBaseField).not.toHaveBeenCalledOnceWith(
+          expenseData1.tx_custom_properties,
+          undefined
+        );
+        expect(costCenterDependentCustomProperties).toEqual(customInputData1);
+      });
+    }));
+
+    it('should set projectDependentCustomProperties$ and costCenterDependentCustomProperties$ to undefined if "txnFields.project_id" and "txnFields.cost_center_id" is undefined', fakeAsync(() => {
+      expenseFieldsService.getAllMap.and.returnValue(
+        of({ ...expenseFieldsMapResponse4, project_id: undefined, cost_center_id: undefined })
+      );
+      component.ionViewWillEnter();
+      tick(100);
+
+      component.projectDependentCustomProperties$.subscribe((projectDependentCustomProperties) => {
+        expect(dependentFieldsService.getDependentFieldValuesForBaseField).not.toHaveBeenCalled();
+        expect(projectDependentCustomProperties).toEqual(undefined);
+      });
+
+      component.costCenterDependentCustomProperties$.subscribe((costCenterDependentCustomProperties) => {
+        expect(dependentFieldsService.getDependentFieldValuesForBaseField).not.toHaveBeenCalled();
+        expect(costCenterDependentCustomProperties).toEqual(undefined);
+      });
+    }));
 
     it('should set paymentMode and paymentMode icon correctly if account type is ADVANCE', fakeAsync(() => {
       const mockExpense = cloneDeep(expenseData1);
@@ -373,6 +415,13 @@ describe('ViewPerDiemPage', () => {
       expect(component.isProjectShown).toBeFalse();
     }));
 
+    it('should set isProjectShown to undefined if orgSettings is undefined', fakeAsync(() => {
+      orgSettingsService.get.and.returnValue(of(undefined));
+      component.ionViewWillEnter();
+      tick(100);
+      expect(component.isProjectShown).toBeUndefined();
+    }));
+
     it('should set orgSettings and isNewReportsFlowEnabled', fakeAsync(() => {
       component.ionViewWillEnter();
       tick(100);
@@ -391,7 +440,7 @@ describe('ViewPerDiemPage', () => {
         expect(customInputsService.fillCustomProperties).toHaveBeenCalledOnceWith(
           expenseData1.tx_org_category_id,
           expenseData1.tx_custom_properties,
-          true,
+          true
         );
         // Called twice because of the two custom fields
         expect(customInputsService.getCustomPropertyDisplayValue).toHaveBeenCalledTimes(2);

--- a/src/app/fyle/view-per-diem/view-per-diem.page.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.ts
@@ -109,7 +109,7 @@ export class ViewPerDiemPage {
     private trackingService: TrackingService,
     private expenseFieldsService: ExpenseFieldsService,
     private orgSettingsService: OrgSettingsService,
-    private dependentFieldsService: DependentFieldsService,
+    private dependentFieldsService: DependentFieldsService
   ) {}
 
   get ExpenseView(): typeof ExpenseView {
@@ -172,10 +172,10 @@ export class ViewPerDiemPage {
 
     this.extendedPerDiem$ = this.updateFlag$.pipe(
       switchMap(() =>
-        from(this.loaderService.showLoader()).pipe(switchMap(() => this.transactionService.getExpenseV2(id))),
+        from(this.loaderService.showLoader()).pipe(switchMap(() => this.transactionService.getExpenseV2(id)))
       ),
       finalize(() => from(this.loaderService.hideLoader())),
-      shareReplay(1),
+      shareReplay(1)
     );
 
     this.txnFields$ = this.expenseFieldsService.getAllMap().pipe(shareReplay(1));
@@ -185,14 +185,14 @@ export class ViewPerDiemPage {
       txnFields: this.txnFields$.pipe(take(1)),
     }).pipe(
       filter(
-        ({ extendedPerDiem, txnFields }) => extendedPerDiem.tx_custom_properties && txnFields.project_id?.length > 0,
+        ({ extendedPerDiem, txnFields }) => extendedPerDiem.tx_custom_properties && txnFields.project_id?.length > 0
       ),
       switchMap(({ extendedPerDiem, txnFields }) =>
         this.dependentFieldsService.getDependentFieldValuesForBaseField(
           extendedPerDiem.tx_custom_properties,
-          txnFields.project_id[0]?.id,
-        ),
-      ),
+          txnFields.project_id[0]?.id
+        )
+      )
     );
 
     this.costCenterDependentCustomProperties$ = forkJoin({
@@ -200,16 +200,15 @@ export class ViewPerDiemPage {
       txnFields: this.txnFields$.pipe(take(1)),
     }).pipe(
       filter(
-        ({ extendedPerDiem, txnFields }) =>
-          extendedPerDiem.tx_custom_properties && txnFields.cost_center_id?.length > 0,
+        ({ extendedPerDiem, txnFields }) => extendedPerDiem.tx_custom_properties && txnFields.cost_center_id?.length > 0
       ),
       switchMap(({ extendedPerDiem, txnFields }) =>
         this.dependentFieldsService.getDependentFieldValuesForBaseField(
           extendedPerDiem.tx_custom_properties,
-          txnFields.cost_center_id[0]?.id,
-        ),
+          txnFields.cost_center_id[0]?.id
+        )
       ),
-      shareReplay(1),
+      shareReplay(1)
     );
 
     this.extendedPerDiem$.subscribe((extendedPerDiem) => {
@@ -232,11 +231,11 @@ export class ViewPerDiemPage {
     forkJoin([this.txnFields$, this.extendedPerDiem$.pipe(take(1))])
       .pipe(
         map(([expenseFieldsMap, extendedPerDiem]) => {
-          this.projectFieldName = expenseFieldsMap?.project_id && expenseFieldsMap?.project_id[0]?.field_name;
-          const isProjectMandatory = expenseFieldsMap?.project_id && expenseFieldsMap?.project_id[0]?.is_mandatory;
+          this.projectFieldName = expenseFieldsMap?.project_id && expenseFieldsMap.project_id[0]?.field_name;
+          const isProjectMandatory = expenseFieldsMap?.project_id && expenseFieldsMap.project_id[0]?.is_mandatory;
           this.isProjectShown =
             this.orgSettings?.projects?.enabled && (!!extendedPerDiem.tx_project_name || isProjectMandatory);
-        }),
+        })
       )
       .subscribe(noop);
 
@@ -250,21 +249,21 @@ export class ViewPerDiemPage {
 
     this.perDiemCustomFields$ = this.extendedPerDiem$.pipe(
       switchMap((res) =>
-        this.customInputsService.fillCustomProperties(res.tx_org_category_id, res.tx_custom_properties, true),
+        this.customInputsService.fillCustomProperties(res.tx_org_category_id, res.tx_custom_properties, true)
       ),
       map((res) =>
         res.map((customProperties) => {
           customProperties.displayValue = this.customInputsService.getCustomPropertyDisplayValue(customProperties);
           return customProperties;
-        }),
-      ),
+        })
+      )
     );
 
     this.perDiemRate$ = this.extendedPerDiem$.pipe(
       switchMap((res) => {
         const perDiemRateId = parseInt(res.tx_per_diem_rate_id, 10);
         return this.perDiemService.getRate(perDiemRateId);
-      }),
+      })
     );
 
     this.view = this.activatedRoute.snapshot.params.view as ExpenseView;
@@ -273,22 +272,21 @@ export class ViewPerDiemPage {
       filter(() => this.view === ExpenseView.team),
       map(
         (etxn) =>
-          ['COMPLETE', 'POLICY_APPROVED', 'APPROVER_PENDING', 'APPROVED', 'PAYMENT_PENDING'].indexOf(etxn.tx_state) >
-          -1,
-      ),
+          ['COMPLETE', 'POLICY_APPROVED', 'APPROVER_PENDING', 'APPROVED', 'PAYMENT_PENDING'].indexOf(etxn.tx_state) > -1
+      )
     );
 
     this.canDelete$ = this.extendedPerDiem$.pipe(
       filter(() => this.view === ExpenseView.team),
       switchMap((etxn) =>
-        this.reportService.getTeamReport(etxn.tx_report_id).pipe(map((report) => ({ report, etxn }))),
+        this.reportService.getTeamReport(etxn.tx_report_id).pipe(map((report) => ({ report, etxn })))
       ),
       map(({ report, etxn }) => {
         if (report.rp_num_transactions === 1) {
           return false;
         }
         return ['PAYMENT_PENDING', 'PAYMENT_PROCESSING', 'PAID'].indexOf(etxn.tx_state) < 0;
-      }),
+      })
     );
 
     if (id) {
@@ -303,13 +301,13 @@ export class ViewPerDiemPage {
     this.comments$ = this.statusService.find('transactions', id);
 
     this.isCriticalPolicyViolated$ = this.extendedPerDiem$.pipe(
-      map((res) => this.isNumber(res.tx_policy_amount) && res.tx_policy_amount < 0.0001),
+      map((res) => this.isNumber(res.tx_policy_amount) && res.tx_policy_amount < 0.0001)
     );
 
     this.getPolicyDetails(id);
 
     this.isAmountCapped$ = this.extendedPerDiem$.pipe(
-      map((res) => this.isNumber(res.tx_admin_amount) || this.isNumber(res.tx_policy_amount)),
+      map((res) => this.isNumber(res.tx_admin_amount) || this.isNumber(res.tx_policy_amount))
     );
 
     this.extendedPerDiem$.subscribe((etxn) => {
@@ -384,12 +382,12 @@ export class ViewPerDiemPage {
           concatMap(() =>
             etxn.tx_manual_flag
               ? this.transactionService.manualUnflag(etxn.tx_id)
-              : this.transactionService.manualFlag(etxn.tx_id),
+              : this.transactionService.manualFlag(etxn.tx_id)
           ),
           finalize(() => {
             this.updateFlag$.next(null);
             this.loaderService.hideLoader();
-          }),
+          })
         )
         .subscribe(noop);
     }

--- a/src/app/fyle/view-per-diem/view-per-diem.page.ts
+++ b/src/app/fyle/view-per-diem/view-per-diem.page.ts
@@ -270,9 +270,8 @@ export class ViewPerDiemPage {
 
     this.canFlagOrUnflag$ = this.extendedPerDiem$.pipe(
       filter(() => this.view === ExpenseView.team),
-      map(
-        (etxn) =>
-          ['COMPLETE', 'POLICY_APPROVED', 'APPROVER_PENDING', 'APPROVED', 'PAYMENT_PENDING'].indexOf(etxn.tx_state) > -1
+      map((etxn) =>
+        ['COMPLETE', 'POLICY_APPROVED', 'APPROVER_PENDING', 'APPROVED', 'PAYMENT_PENDING'].includes(etxn.tx_state)
       )
     );
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18cJjGo2HVZqkeScUcGQf3T92xCGeBtsRc%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=-bAq6uF)
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5774a73</samp>

This pull request enhances the `ViewPerDiemPage` component by improving its code style, readability, and test coverage. It removes unnecessary commas and uses the `includes` method for array checks in `view-per-diem.page.ts`. It also adds new tests for the `ionViewWillEnter` method and its dependencies in `view-per-diem.page.spec.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5774a73</samp>

> _Oh we're the coders of the sea, and we work with skill and glee_
> _We tidy up our code and make it shine_
> _We remove the extra commas from our `ViewPerDiemPage`_
> _And we test our `ionViewWillEnter` fine_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5774a73</samp>

*  Remove unnecessary commas at the end of function calls for code style consistency and readability ([link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-aa7434f7715887f5188bf634482b759f816a20bd7f5d51ef219f9754ec71a057L204-R204), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-aa7434f7715887f5188bf634482b759f816a20bd7f5d51ef219f9754ec71a057L214-R214), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-aa7434f7715887f5188bf634482b759f816a20bd7f5d51ef219f9754ec71a057L300-R300), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-aa7434f7715887f5188bf634482b759f816a20bd7f5d51ef219f9754ec71a057L394-R443), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L112-R112), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L175-R178), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L188-R195), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L203-R211), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L235-R238), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L253-R252), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L259-R259), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L267-R266), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L284-R281), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L291-R288), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L306-R303), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L312-R309), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L387-R389))
*  Replace `indexOf` with `includes` for checking array membership for code readability and conciseness ([link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-b66c53e7e9d2eaf1447540624a0e92ad7ea25c5299edf4e5720110afb75cec90L274-R275))
*  Add test cases for `ionViewWillEnter` method of `ViewPerDiemPage` class to increase test coverage and ensure correctness of logic ([link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-aa7434f7715887f5188bf634482b759f816a20bd7f5d51ef219f9754ec71a057R330-R371), [link](https://github.com/fylein/fyle-mobile-app/pull/2524/files?diff=unified&w=0#diff-aa7434f7715887f5188bf634482b759f816a20bd7f5d51ef219f9754ec71a057R418-R424))

## Clickup
app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes