### PR TITLE
fix: edited platform expense fields columnm mapping for per_diem_num_days

### DIFF
--- a/src/app/core/services/expense-fields.service.spec.ts
+++ b/src/app/core/services/expense-fields.service.spec.ts
@@ -94,8 +94,17 @@ describe('ExpenseFieldsService', () => {
 
   it('should return correct mapping for column name', () => {
     expect(expenseFieldsService.getColumnName('spent_at')).toBe('txn_dt');
+    expect(expenseFieldsService.getColumnName('category_id')).toBe('org_category_id');
+    expect(expenseFieldsService.getColumnName('merchant')).toBe('vendor_id');
+    expect(expenseFieldsService.getColumnName('is_billable')).toBe('billable');
+    expect(expenseFieldsService.getColumnName('started_at')).toBe('from_dt');
+    expect(expenseFieldsService.getColumnName('ended_at')).toBe('to_dt');
+    expect(expenseFieldsService.getColumnName('per_diem_num_days')).toBe('num_days');
     expect(expenseFieldsService.getColumnName('locations[0]')).toBe('location1');
+    expect(expenseFieldsService.getColumnName('locations[1]')).toBe('location2');
+    expect(expenseFieldsService.getColumnName('travel_classes[0]', 1)).toBe('flight_journey_travel_class');
     expect(expenseFieldsService.getColumnName('travel_classes[0]', 2)).toBe('bus_travel_class');
+    expect(expenseFieldsService.getColumnName('travel_classes[0]', 3)).toBe('train_travel_class');
     expect(expenseFieldsService.getColumnName('travel_classes[1]', 1)).toBe('flight_return_travel_class');
 
     //For other fields, the column_name should remain the same

--- a/src/app/core/services/expense-fields.service.ts
+++ b/src/app/core/services/expense-fields.service.ts
@@ -20,7 +20,7 @@ export class ExpenseFieldsService {
   constructor(
     private spenderPlatformV1ApiService: SpenderPlatformV1ApiService,
     private authService: AuthService,
-    private dateService: DateService,
+    private dateService: DateService
   ) {}
 
   @Cacheable()
@@ -33,10 +33,10 @@ export class ExpenseFieldsService {
             is_enabled: 'eq.true',
             is_custom: 'eq.false',
           },
-        }),
+        })
       ),
       map((res) => this.transformFrom(res.data)),
-      map((res) => this.dateService.fixDates(res)),
+      map((res) => this.dateService.fixDates(res))
     );
   }
 
@@ -48,6 +48,7 @@ export class ExpenseFieldsService {
       merchant: 'vendor_id',
       is_billable: 'billable',
       started_at: 'from_dt',
+      per_diem_num_days: 'num_days',
       ended_at: 'to_dt',
       'locations[0]': 'location1',
       'locations[1]': 'location2',
@@ -131,14 +132,14 @@ export class ExpenseFieldsService {
           expenseFieldMap[expenseField.column_name] = expenseFieldsList;
         });
         return expenseFieldMap;
-      }),
+      })
     );
   }
 
   filterByOrgCategoryId(
     tfcMap: Partial<ExpenseFieldsMap>,
     fields: string[],
-    orgCategory: OrgCategory,
+    orgCategory: OrgCategory
   ): Observable<Partial<ExpenseFieldsObj>> {
     const orgCategoryId = orgCategory && orgCategory.id;
     return of(fields).pipe(
@@ -171,7 +172,7 @@ export class ExpenseFieldsService {
             }
             return filteredField;
           })
-          .filter((filteredField) => !!filteredField),
+          .filter((filteredField) => !!filteredField)
       ),
       switchMap((fields) => from(fields)),
       map((field) => ({
@@ -180,7 +181,7 @@ export class ExpenseFieldsService {
       reduce((acc, curr) => {
         acc[curr.field] = curr;
         return acc;
-      }, {}),
+      }, {})
     );
   }
 
@@ -194,7 +195,7 @@ export class ExpenseFieldsService {
       To handle both case added this, it can take the type based on use case, but, ideally, we should have a single type of response
   */
   getDefaultTxnFieldValues(
-    txnFields: Partial<ExpenseFieldsMap> | Partial<ExpenseFieldsObj>,
+    txnFields: Partial<ExpenseFieldsMap> | Partial<ExpenseFieldsObj>
   ): Partial<DefaultTxnFieldValues> {
     const defaultValues = {};
     for (const configurationColumn in txnFields) {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4414616</samp>

Fix syntax errors and add per diem feature in `expense-fields.service.ts`. This allows the app to handle the number of days for per diem expenses from the API.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4414616</samp>

> _From the ashes of syntax errors we rise_
> _We claim our rightful per diem prize_
> _We map the fields of our expense reports_
> _We defy the API and its cohorts_

## Clickup
https://app.clickup.com/t/86791a5cz
