### PR TITLE
fix: failing tests on v2 of expenses card component

### DIFF
--- a/src/app/core/mock-data/platform/v1/expense.data.ts
+++ b/src/app/core/mock-data/platform/v1/expense.data.ts
@@ -1,4 +1,6 @@
 import { ExpenseState } from 'src/app/core/models/expense-state.enum';
+import { PlatformCategory } from 'src/app/core/models/platform/platform-category.model';
+import { MileageUnitEnum } from 'src/app/core/models/platform/platform-mileage-rates.model';
 import { ApprovalState } from 'src/app/core/models/platform/report-approvals.model';
 import { AccountType } from 'src/app/core/models/platform/v1/account.model';
 import { Expense } from 'src/app/core/models/platform/v1/expense.model';
@@ -354,3 +356,54 @@ export const expenseData: Expense = {
 };
 
 export const expenseResponseData = [expenseData];
+
+export const criticalPolicyViolatedExpense: Expense = {
+  ...expenseData,
+  policy_amount: 0.00009,
+};
+
+type Category = Pick<PlatformCategory, 'code' | 'id' | 'display_name' | 'name' | 'sub_category' | 'system_category'>;
+
+const mileageCategory: Category = {
+  code: null,
+  display_name: 'Mileage display',
+  id: 267841,
+  name: 'Mileage test',
+  sub_category: 'Others',
+  system_category: 'Mileage',
+};
+
+const perDiemCategory: Category = {
+  code: null,
+  display_name: 'Per Diem display',
+  id: 267841,
+  name: 'Per Diem test',
+  sub_category: 'Others',
+  system_category: 'Per Diem',
+};
+
+export const mileageExpenseWithDistance: Expense = {
+  ...expenseData,
+  distance: 25,
+  distance_unit: MileageUnitEnum.KM,
+  category: mileageCategory,
+};
+
+export const mileageExpenseWithoutDistance: Expense = {
+  ...expenseData,
+  distance: 0,
+  distance_unit: MileageUnitEnum.KM,
+  category: mileageCategory,
+};
+
+export const perDiemExpenseWithSingleNumDays: Expense = {
+  ...expenseData,
+  category: perDiemCategory,
+  per_diem_num_days: 1,
+};
+
+export const perDiemExpenseWithMultipleNumDays: Expense = {
+  ...expenseData,
+  category: perDiemCategory,
+  per_diem_num_days: 3,
+};

--- a/src/app/core/mock-data/platform/v1/expense.data.ts
+++ b/src/app/core/mock-data/platform/v1/expense.data.ts
@@ -352,3 +352,5 @@ export const expenseData: Expense = {
   user_id: 'us29O6z3jnd3',
   verifier_comments: [],
 };
+
+export const expenseResponseData = [expenseData];

--- a/src/app/core/services/platform/v1/shared/expense.service.spec.ts
+++ b/src/app/core/services/platform/v1/shared/expense.service.spec.ts
@@ -1,8 +1,17 @@
 import { TestBed } from '@angular/core/testing';
-
 import { ExpenseService } from './expense.service';
+import {
+  criticalPolicyViolatedExpense,
+  expenseData,
+  mileageExpenseWithDistance,
+  mileageExpenseWithoutDistance,
+  perDiemExpenseWithMultipleNumDays,
+  perDiemExpenseWithSingleNumDays,
+} from 'src/app/core/mock-data/platform/v1/expense.data';
+import { Expense } from 'src/app/core/models/platform/v1/expense.model';
+import { ExpenseState } from 'src/app/core/models/expense-state.enum';
 
-xdescribe('ExpenseService', () => {
+describe('ExpenseService', () => {
   let service: ExpenseService;
 
   beforeEach(() => {
@@ -12,5 +21,56 @@ xdescribe('ExpenseService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('getIsCriticalPolicyViolated():', () => {
+    it('should return false if critical policy is not violated', () => {
+      expect(service.getIsCriticalPolicyViolated(expenseData)).toBeFalse();
+    });
+
+    it('should return true if critical policy is violated', () => {
+      expect(service.getIsCriticalPolicyViolated(criticalPolicyViolatedExpense)).toBeTrue();
+    });
+  });
+
+  describe('getIsDraft():', () => {
+    it('should return true if transaction is draft', () => {
+      expect(service.getIsDraft(expenseData)).toBeTrue();
+    });
+
+    it('should return false if transaction is not draft', () => {
+      const expense: Expense = {
+        ...expenseData,
+        state: ExpenseState.COMPLETE,
+      };
+      expect(service.getIsDraft(expense)).toBeFalse();
+    });
+  });
+
+  describe('getVendorDetails():', () => {
+    it('should return vendor details for normal expense', () => {
+      const merchant = 'UberTest';
+      const expense: Expense = {
+        ...expenseData,
+        merchant,
+      };
+      expect(service.getVendorDetails(expense)).toEqual(merchant);
+    });
+
+    it('should return vendor details for mileage expense with distance', () => {
+      expect(service.getVendorDetails(mileageExpenseWithDistance)).toEqual('25 KM');
+    });
+
+    it('should return vendor details for mileage expense without distance', () => {
+      expect(service.getVendorDetails(mileageExpenseWithoutDistance)).toEqual('0 KM');
+    });
+
+    it('should retuen vendor details for per diem expense with 1 day', () => {
+      expect(service.getVendorDetails(perDiemExpenseWithSingleNumDays)).toEqual('1 Day');
+    });
+
+    it('should retuen vendor details for per diem expense with multiple days', () => {
+      expect(service.getVendorDetails(perDiemExpenseWithMultipleNumDays)).toEqual('3 Days');
+    });
   });
 });

--- a/src/app/shared/components/expenses-card-v2/expenses-card.component.spec.ts
+++ b/src/app/shared/components/expenses-card-v2/expenses-card.component.spec.ts
@@ -37,7 +37,7 @@ import { DebugElement, EventEmitter } from '@angular/core';
 import { expenseData, expenseResponseData } from 'src/app/core/mock-data/platform/v1/expense.data';
 import { AccountType } from 'src/app/core/models/platform/v1/account.model';
 
-fdescribe('ExpensesCardComponent', () => {
+describe('ExpensesCardComponent', () => {
   let component: ExpensesCardComponent;
   let fixture: ComponentFixture<ExpensesCardComponent>;
   let transactionService: jasmine.SpyObj<TransactionService>;
@@ -520,7 +520,8 @@ fdescribe('ExpensesCardComponent', () => {
         id: 'tx12341',
         spent_at: null,
       };
-      (component.expense.category.name = 'mileage'), component.ngOnInit();
+      component.expense.category.name = 'mileage';
+      component.ngOnInit();
       expect(component.isMileageExpense).toBeTrue();
     });
 
@@ -530,7 +531,8 @@ fdescribe('ExpensesCardComponent', () => {
         id: 'tx12341',
         spent_at: null,
       };
-      (component.expense.category.name = 'per diem'), component.ngOnInit();
+      component.expense.category.name = 'per diem';
+      component.ngOnInit();
       expect(component.isPerDiem).toBeTrue();
     });
 

--- a/src/app/shared/components/expenses-card-v2/expenses-card.component.spec.ts
+++ b/src/app/shared/components/expenses-card-v2/expenses-card.component.spec.ts
@@ -38,7 +38,7 @@ import { expenseData, expenseResponseData } from 'src/app/core/mock-data/platfor
 import { AccountType } from 'src/app/core/models/platform/v1/account.model';
 import { ExpenseService as SharedExpenseService } from 'src/app/core/services/platform/v1/shared/expense.service';
 
-fdescribe('ExpensesCardComponent', () => {
+describe('ExpensesCardComponent', () => {
   let component: ExpensesCardComponent;
   let fixture: ComponentFixture<ExpensesCardComponent>;
   let transactionService: jasmine.SpyObj<TransactionService>;

--- a/src/app/shared/components/expenses-card-v2/expenses-card.component.spec.ts
+++ b/src/app/shared/components/expenses-card-v2/expenses-card.component.spec.ts
@@ -36,11 +36,13 @@ import { ToastMessageComponent } from '../toast-message/toast-message.component'
 import { DebugElement, EventEmitter } from '@angular/core';
 import { expenseData, expenseResponseData } from 'src/app/core/mock-data/platform/v1/expense.data';
 import { AccountType } from 'src/app/core/models/platform/v1/account.model';
+import { ExpenseService as SharedExpenseService } from 'src/app/core/services/platform/v1/shared/expense.service';
 
-describe('ExpensesCardComponent', () => {
+fdescribe('ExpensesCardComponent', () => {
   let component: ExpensesCardComponent;
   let fixture: ComponentFixture<ExpensesCardComponent>;
   let transactionService: jasmine.SpyObj<TransactionService>;
+  let sharedExpenseService: jasmine.SpyObj<SharedExpenseService>;
   let orgUserSettingsService: jasmine.SpyObj<OrgUserSettingsService>;
   let fileService: jasmine.SpyObj<FileService>;
   let popoverController: jasmine.SpyObj<PopoverController>;
@@ -57,8 +59,8 @@ describe('ExpensesCardComponent', () => {
   let componentElement: DebugElement;
 
   beforeEach(waitForAsync(() => {
-    const transactionServiceSpy = jasmine.createSpyObj('TransactionService', [
-      'getETxnUnflattened',
+    const transactionServiceSpy = jasmine.createSpyObj('TransactionService', ['getETxnUnflattened']);
+    const sharedExpenseServiceSpy = jasmine.createSpyObj('SharedExpenseService', [
       'getIsDraft',
       'getIsCriticalPolicyViolated',
       'getVendorDetails',
@@ -98,6 +100,7 @@ describe('ExpensesCardComponent', () => {
       imports: [IonicModule.forRoot(), MatIconModule, MatIconTestingModule, MatCheckboxModule, FormsModule],
       providers: [
         { provide: TransactionService, useValue: transactionServiceSpy },
+        { provide: SharedExpenseService, useValue: sharedExpenseServiceSpy },
         { provide: OrgUserSettingsService, useValue: orgUserSettingsServiceSpy },
         { provide: FileService, useValue: fileServiceSpy },
         { provide: PopoverController, useValue: popoverControllerSpy },
@@ -131,19 +134,20 @@ describe('ExpensesCardComponent', () => {
     expenseFieldsService = TestBed.inject(ExpenseFieldsService) as jasmine.SpyObj<ExpenseFieldsService>;
     orgSettingsService = TestBed.inject(OrgSettingsService) as jasmine.SpyObj<OrgSettingsService>;
     transactionService = TestBed.inject(TransactionService) as jasmine.SpyObj<TransactionService>;
+    sharedExpenseService = TestBed.inject(SharedExpenseService) as jasmine.SpyObj<SharedExpenseService>;
 
     orgSettingsService.get.and.returnValue(of(orgSettingsGetData));
     transactionsOutboxService.isSyncInProgress.and.returnValue(true);
     expenseFieldsService.getAllMap.and.returnValue(of(expenseFieldsMapResponse2));
-    transactionService.getVendorDetails.and.returnValue('asd');
+    sharedExpenseService.getVendorDetails.and.returnValue('asd');
     currencyService.getHomeCurrency.and.returnValue(of(orgData1[0].currency));
-    transactionService.getIsCriticalPolicyViolated.and.returnValue(false);
+    sharedExpenseService.getIsCriticalPolicyViolated.and.returnValue(false);
     platform.is.and.returnValue(true);
     fileService.getReceiptDetails.and.returnValue(fileObjectAdv[0].type);
     transactionsOutboxService.isDataExtractionPending.and.returnValue(true);
     transactionService.getETxnUnflattened.and.returnValue(of(unflattenedTxnData));
     networkService.isOnline.and.returnValue(of(true));
-    transactionService.getIsDraft.and.returnValue(true);
+    sharedExpenseService.getIsDraft.and.returnValue(true);
 
     networkService.connectivityWatcher.and.returnValue(new EventEmitter());
     fixture = TestBed.createComponent(ExpensesCardComponent);

--- a/src/app/shared/components/expenses-card-v2/expenses-card.component.ts
+++ b/src/app/shared/components/expenses-card-v2/expenses-card.component.ts
@@ -348,7 +348,12 @@ export class ExpensesCardComponent implements OnInit {
   canAddAttachment(): boolean {
     return (
       !this.isFromViewReports &&
-      !(this.isMileageExpense || this.isPerDiem || this.expense.file_ids || this.isFromPotentialDuplicates) &&
+      !(
+        this.isMileageExpense ||
+        this.isPerDiem ||
+        this.expense.file_ids?.length > 0 ||
+        this.isFromPotentialDuplicates
+      ) &&
       !this.isSelectionModeEnabled
     );
   }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 617a851</samp>

This pull request updates the tests and mock data for the expense card component. It uses the new data and properties from the `platform/v1` folder and fixes some minor issues.
https://app.clickup.com/t/8679027wa

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 617a851</samp>

> _Sing, O Muse, of the valiant coder who dared to test the expense card_
> _With mock data of `expenseResponseData`, array of objects rich and hard_
> _He updated the spec file with skill and care, using the platform's new names_
> _And cloned the data deep, avoiding mutation, like Hephaestus forging flames_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 617a851</samp>

*  Export mock data for expense card component testing ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-24d88c263ca5d224aa35b783df4640316640e6db32915015b6cce6ff83b7a05bR355-R356))
*  Remove old mock data imports and add new mock data imports in expense card component spec file ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL23-L24), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL39-R40))
  - Replace apiExpenseRes with expenseResponseData and expenseData1 with expenseData in beforeEach block ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL154-R155))
  - Replace tx_id with id and apiExpenseRes with expenseResponseData in isSelected getter tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL171-R174), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL180-R183))
  - Replace etxn with expense and etxnIndex with expenseIndex in onGoToTransaction test ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL194-R195))
  - Replace tx_org_category with category.name and expenseData1 with cloneDeep(expenseData) in getReceipt tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL209-R210), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL219-R218), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL230-R227), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL242-R239))
  - Replace tx_amount with amount, tx_user_amount with claim_amount, tx_extracted_data with extracted_data, and vendor with vendor_name in checkIfScanIsCompleted tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL254-R253), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL266-R265), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL278-R282))
  - Replace tx_created_at with created_at and expenseData1 with expenseData in checkIfScanIsExpired test ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL297-R298))
  - Fix typo in handleScanStatus test ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL340-R336))
  - Add id property to expense object in handleScanStatus tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dR353), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dR387))
  - Replace tx_id with id, tx_extracted_data with extracted_data, and expenseData1 with expenseData in handleScanStatus tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL375-R375), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL409-R407))
  - Replace tx_skip_reimbursement with is_reimbursable and expenseData1 with expenseData in canShowPaymentModeIcon tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL439-R438), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL449-R448), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL459-R462))
  - Replace source_account_type with source_account.type in canShowPaymentModeIcon test ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL459-R462))
  - Replace tx_id with id and expenseData1 with expenseData in setShowDt tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL482-R484), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL492-R495), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL506-R508))
  - Replace tx_org_category with category.name and expenseData1 with cloneDeep(expenseData) in ngOnInit tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL518-R523), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL529-R533))
  - Replace source_account_type with source_account.type, tx_corporate_credit_card_expense_group_id with matched_corporate_card_transaction_ids, and expenseData1 with cloneDeep(expenseData) in setOtherData tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL556-R558), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL566-R567), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dR575-R579), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL585-R588))
  - Replace tx_file_ids with file_ids, tx_id with id, and fileObjectData with fileObjectData in matchReceiptWithEtxn test ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL610-R614))
  - Replace tx_file_ids with file_ids and expenseData1 with expenseData in canShowAddReceiptIcon tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL619-R621), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL629-R631))
  - Replace tx_amount with amount, tx_user_amount with claim_amount, tx_org_category with category.name, and expenseData1 with cloneDeep(expenseData) in isZeroAmountPerDiem tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL843-R848), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL853-R859), [link](https://github.com/fylein/fyle-mobile-app/pull/2555/files?diff=unified&w=0#diff-45d78c099f66f78170dc6aa70cacea0b6f946301eb14e3703e1358c1f5c3c10dL863-R866))

## Clickup
Please add link here

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes