### PR TITLE
fix: Fix failing tests of view team report page

### DIFF
--- a/src/app/core/mock-data/platform/v1/expense.data.ts
+++ b/src/app/core/mock-data/platform/v1/expense.data.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import { ExpenseState } from 'src/app/core/models/expense-state.enum';
 import { PlatformCategory } from 'src/app/core/models/platform/platform-category.model';
 import { MileageUnitEnum } from 'src/app/core/models/platform/platform-mileage-rates.model';
@@ -358,6 +359,30 @@ export const expenseData: Expense = {
 export const expenseResponseData = [expenseData];
 
 export const expenseResponseData2 = [expenseData, expenseData];
+
+export const expenseResponseData3: Expense[] = [
+  {
+    ...cloneDeep(expenseData),
+    amount: 89,
+    currency: 'INR',
+    foreign_currency: null,
+    foreign_amount: null,
+  },
+  {
+    ...cloneDeep(expenseData),
+    amount: 33611,
+    foreign_amount: 12,
+    currency: 'INR',
+    foreign_currency: 'CLF',
+  },
+  {
+    ...cloneDeep(expenseData),
+    amount: 15775.76,
+    foreign_amount: 178,
+    currency: 'INR',
+    foreign_currency: 'EUR',
+  },
+];
 
 export const criticalPolicyViolatedExpense: Expense = {
   ...expenseData,

--- a/src/app/core/mock-data/platform/v1/expense.data.ts
+++ b/src/app/core/mock-data/platform/v1/expense.data.ts
@@ -370,7 +370,7 @@ const mileageCategory: Category = {
   code: null,
   display_name: 'Mileage display',
   id: 267841,
-  name: 'Mileage test',
+  name: 'Mileage',
   sub_category: 'Others',
   system_category: 'Mileage',
 };
@@ -379,9 +379,14 @@ const perDiemCategory: Category = {
   code: null,
   display_name: 'Per Diem display',
   id: 267841,
-  name: 'Per Diem test',
+  name: 'Per Diem',
   sub_category: 'Others',
   system_category: 'Per Diem',
+};
+
+export const mileageExpense: Expense = {
+  ...expenseData,
+  category: mileageCategory,
 };
 
 export const mileageExpenseWithDistance: Expense = {

--- a/src/app/core/services/platform/v1/shared/expenses.service.spec.ts
+++ b/src/app/core/services/platform/v1/shared/expenses.service.spec.ts
@@ -3,6 +3,8 @@ import { ExpensesService } from './expenses.service';
 import {
   criticalPolicyViolatedExpense,
   expenseData,
+  expenseResponseData2,
+  expenseResponseData3,
   mileageExpenseWithDistance,
   mileageExpenseWithoutDistance,
   perDiemExpenseWithMultipleNumDays,
@@ -10,6 +12,8 @@ import {
 } from 'src/app/core/mock-data/platform/v1/expense.data';
 import { Expense } from 'src/app/core/models/platform/v1/expense.model';
 import { ExpenseState } from 'src/app/core/models/expense-state.enum';
+import { currencySummaryData } from 'src/app/core/mock-data/currency-summary.data';
+import { AccountType } from 'src/app/core/models/platform/v1/account.model';
 
 describe('ExpensesService', () => {
   let service: ExpensesService;
@@ -71,6 +75,232 @@ describe('ExpensesService', () => {
 
     it('should retuen vendor details for per diem expense with multiple days', () => {
       expect(service.getVendorDetails(perDiemExpenseWithMultipleNumDays)).toEqual('3 Days');
+    });
+  });
+
+  it('getPaymentModeWiseSummary(): should return the payment mode wise summary', () => {
+    // @ts-ignore
+    spyOn(service, 'getPaymentModeForExpense').and.returnValue({
+      name: 'Reimbursable',
+      key: 'reimbursable',
+    });
+
+    const paymentModes = [
+      {
+        name: 'Reimbursable',
+        key: 'reimbursable',
+      },
+      {
+        name: 'Non-Reimbursable',
+        key: 'nonReimbursable',
+      },
+      {
+        name: 'Advance',
+        key: 'advance',
+      },
+      {
+        name: 'CCC',
+        key: 'ccc',
+      },
+    ];
+
+    const summary = {
+      reimbursable: {
+        name: 'Reimbursable',
+        key: 'reimbursable',
+        amount: 207000.78,
+        count: 2,
+      },
+    };
+
+    expect(service.getPaymentModeWiseSummary(expenseResponseData2)).toEqual(summary);
+    // @ts-ignore
+    expect(service.getPaymentModeForExpense).toHaveBeenCalledWith(expenseResponseData2[0], paymentModes);
+    // @ts-ignore
+    expect(service.getPaymentModeForExpense).toHaveBeenCalledWith(expenseResponseData2[1], paymentModes);
+
+    // @ts-ignore
+    expect(service.getPaymentModeForExpense).toHaveBeenCalledTimes(2);
+  });
+
+  it('getCurrenyWiseSummary(): should return the currency wise summary', () => {
+    // @ts-ignore
+    spyOn(service, 'addExpenseToCurrencyMap').and.callThrough();
+
+    const currencyMap = {
+      INR: { name: 'INR', currency: 'INR', amount: 89, origAmount: 89, count: 1 },
+      CLF: { name: 'CLF', currency: 'CLF', amount: 33611, origAmount: 12, count: 1 },
+      EUR: { name: 'EUR', currency: 'EUR', amount: 15775.76, origAmount: 178, count: 1 },
+    };
+
+    expect(service.getCurrenyWiseSummary(expenseResponseData3)).toEqual(currencySummaryData);
+    // @ts-ignore
+    expect(service.addExpenseToCurrencyMap).toHaveBeenCalledWith(currencyMap, 'INR', 89);
+    // @ts-ignore
+    expect(service.addExpenseToCurrencyMap).toHaveBeenCalledWith(currencyMap, 'CLF', 33611, 12);
+    // @ts-ignore
+    expect(service.addExpenseToCurrencyMap).toHaveBeenCalledWith(currencyMap, 'EUR', 15775.76, 178);
+    // @ts-ignore
+    expect(service.addExpenseToCurrencyMap).toHaveBeenCalledTimes(3);
+  });
+
+  it('getPaymentModeForExpense(): should return payment mode for expense', () => {
+    spyOn(service, 'isExpenseInPaymentMode').and.returnValue(true);
+    const paymentModeList = [
+      {
+        name: 'Reimbursable',
+        key: 'reimbursable',
+      },
+      {
+        name: 'Non-Reimbursable',
+        key: 'nonReimbursable',
+      },
+      {
+        name: 'Advance',
+        key: 'advance',
+      },
+      {
+        name: 'CCC',
+        key: 'ccc',
+      },
+    ];
+    const expensePaymentMode = { name: 'Reimbursable', key: 'reimbursable' };
+    // @ts-ignore
+    expect(service.getPaymentModeForExpense(expenseData, paymentModeList)).toEqual(expensePaymentMode);
+    expect(service.isExpenseInPaymentMode).toHaveBeenCalledOnceWith(
+      !expenseData.is_reimbursable,
+      expenseData.source_account.type,
+      expensePaymentMode.key
+    );
+  });
+
+  describe('addExpenseToCurrencyMap():', () => {
+    it('should add a new currency to the map when the currencyMap does not exist', () => {
+      const currencyMap = {};
+      const expenseCurrency = 'USD';
+      const expenseAmount = 10;
+      // @ts-ignore
+      service.addExpenseToCurrencyMap(currencyMap, expenseCurrency, expenseAmount);
+
+      expect(currencyMap).toEqual({
+        USD: {
+          name: 'USD',
+          currency: 'USD',
+          amount: 10,
+          origAmount: 10,
+          count: 1,
+        },
+      });
+    });
+
+    it('should add a new currency to the map with the orig currency', () => {
+      const currencyMap = {};
+      const expenseCurrency = 'USD';
+      const expenseAmount = 10;
+      const expenseForeignAmount = 200;
+      // @ts-ignore
+      service.addExpenseToCurrencyMap(currencyMap, expenseCurrency, expenseAmount, expenseForeignAmount);
+
+      expect(currencyMap).toEqual({
+        USD: {
+          name: 'USD',
+          currency: 'USD',
+          amount: 10,
+          origAmount: 200,
+          count: 1,
+        },
+      });
+    });
+
+    it('should add the transaction amount to an existing currency in the map', () => {
+      const currencyMap = {
+        USD: {
+          name: 'USD',
+          currency: 'USD',
+          amount: 10,
+          origAmount: 10,
+          count: 1,
+        },
+      };
+      const expenseCurrency = 'USD';
+      const expenseAmount = 20;
+      // @ts-ignore
+      service.addExpenseToCurrencyMap(currencyMap, expenseCurrency, expenseAmount);
+
+      expect(currencyMap).toEqual({
+        USD: {
+          name: 'USD',
+          currency: 'USD',
+          amount: 30,
+          origAmount: 30,
+          count: 2,
+        },
+      });
+    });
+
+    it('should add the transaction amount and original amount to an existing currency in the map', () => {
+      const currencyMap = {
+        USD: {
+          name: 'USD',
+          currency: 'USD',
+          amount: 10,
+          origAmount: 10,
+          count: 1,
+        },
+      };
+      const expenseCurrency = 'USD';
+      const expenseAmount = 20;
+      const expenseForeignAmount = 30;
+      // @ts-ignore
+      service.addExpenseToCurrencyMap(currencyMap, expenseCurrency, expenseAmount, expenseForeignAmount);
+
+      expect(currencyMap).toEqual({
+        USD: {
+          name: 'USD',
+          currency: 'USD',
+          amount: 30,
+          origAmount: 40,
+          count: 2,
+        },
+      });
+    });
+  });
+
+  describe('isExpenseInPaymentMode():', () => {
+    it('should return isExpenseInPaymentMode with reimbursable payment mode', () => {
+      const expenseSkipReimbursement = false;
+      const expensePaymentMode = 'reimbursable';
+      const expenseSourceAccountType = AccountType.PERSONAL_CASH_ACCOUNT;
+      expect(
+        service.isExpenseInPaymentMode(expenseSkipReimbursement, expenseSourceAccountType, expensePaymentMode)
+      ).toBeTrue();
+    });
+
+    it('should return isExpenseInPaymentMode with non-reimbursable payment mode', () => {
+      const expenseSkipReimbursement = true;
+      const expensePaymentMode = 'nonReimbursable';
+      const expenseSourceAccountType = AccountType.PERSONAL_CASH_ACCOUNT;
+      expect(
+        service.isExpenseInPaymentMode(expenseSkipReimbursement, expenseSourceAccountType, expensePaymentMode)
+      ).toBeTrue();
+    });
+
+    it('should return isExpenseInPaymentMode with advance payment mode', () => {
+      const expenseSkipReimbursement = false;
+      const expensePaymentMode = 'advance';
+      const expenseSourceAccountType = AccountType.PERSONAL_ADVANCE_ACCOUNT;
+      expect(
+        service.isExpenseInPaymentMode(expenseSkipReimbursement, expenseSourceAccountType, expensePaymentMode)
+      ).toBeTrue();
+    });
+
+    it('should return isExpenseInPaymentMode with advance payment mode', () => {
+      const expenseSkipReimbursement = false;
+      const expensePaymentMode = 'ccc';
+      const expenseSourceAccountType = AccountType.PERSONAL_CORPORATE_CREDIT_CARD_ACCOUNT;
+      expect(
+        service.isExpenseInPaymentMode(expenseSkipReimbursement, expenseSourceAccountType, expensePaymentMode)
+      ).toBeTrue();
     });
   });
 });

--- a/src/app/core/services/platform/v1/spender/expenses.service.spec.ts
+++ b/src/app/core/services/platform/v1/spender/expenses.service.spec.ts
@@ -81,6 +81,7 @@ describe('ExpensesService', () => {
     const reportId = 'rpSGcIEwzxDd';
     const params = {
       report_id: `eq.${reportId}`,
+      order: 'spent_at.desc,id.desc',
     };
 
     service.getReportExpenses(reportId).subscribe((response) => {

--- a/src/app/core/services/platform/v1/spender/expenses.service.ts
+++ b/src/app/core/services/platform/v1/spender/expenses.service.ts
@@ -5,6 +5,8 @@ import { PlatformApiResponse } from 'src/app/core/models/platform/platform-api-r
 import { Expense } from 'src/app/core/models/platform/v1/expense.model';
 import { ExpensesQueryParams } from 'src/app/core/models/platform/v1/expenses-query-params.model';
 import { PAGINATION_SIZE } from 'src/app/constants';
+import { Cacheable } from 'ts-cacheable';
+import { expensesCacheBuster$ } from '../../../transaction.service';
 
 @Injectable({
   providedIn: 'root',
@@ -34,9 +36,13 @@ export class ExpensesService {
       .pipe(map((expenses) => expenses.data));
   }
 
+  @Cacheable({
+    cacheBusterObserver: expensesCacheBuster$,
+  })
   getReportExpenses(reportId: string): Observable<Expense[]> {
     const params = {
       report_id: `eq.${reportId}`,
+      order: 'spent_at.desc,id.desc',
     };
     return this.getExpensesCount(params).pipe(
       switchMap((expensesCount) => {

--- a/src/app/core/services/report.service.spec.ts
+++ b/src/app/core/services/report.service.spec.ts
@@ -1040,22 +1040,6 @@ describe('ReportService', () => {
     });
   });
 
-  it('getReportETxnc(): should get report transactions', (done) => {
-    apiService.get.and.returnValue(of(apiExpenseRes));
-    const reportID = 'rp1xCiq5WA1R';
-    const orgUserID = 'ouCI4UQ2G0K1';
-
-    reportService.getReportETxnc(reportID, orgUserID).subscribe((res) => {
-      expect(res).toEqual(apiExpenseRes);
-      expect(apiService.get).toHaveBeenCalledOnceWith(`/erpts/${reportID}/etxns`, {
-        params: {
-          approver_id: orgUserID,
-        },
-      });
-      done();
-    });
-  });
-
   it('addApprovers(): add approvers to reports', () => {
     const res = reportService.addApprovers(addApproverERpts, approversData1);
 

--- a/src/app/core/services/report.service.ts
+++ b/src/app/core/services/report.service.ts
@@ -5,7 +5,6 @@ import { catchError, concatMap, map, reduce, switchMap, tap } from 'rxjs/operato
 import { PAGINATION_SIZE } from 'src/app/constants';
 import { CacheBuster, Cacheable } from 'ts-cacheable';
 import { ApiV2Response } from '../models/api-v2.model';
-import { Expense } from '../models/expense.model';
 import { OrgSettings } from '../models/org-settings.model';
 import { PdfExport } from '../models/pdf-exports.model';
 import { PlatformReport } from '../models/platform/platform-report.model';
@@ -56,7 +55,7 @@ export class ReportService {
     private approverPlatformApiService: ApproverPlatformApiService,
     private datePipe: DatePipe,
     private launchDarklyService: LaunchDarklyService,
-    private permissionsService: PermissionsService,
+    private permissionsService: PermissionsService
   ) {
     reportsCacheBuster$.subscribe(() => {
       this.userEventService.clearTaskCache();
@@ -94,7 +93,7 @@ export class ReportService {
   getPaginatedERptc(
     offset: number,
     limit: number,
-    params: { state?: string[]; order?: string },
+    params: { state?: string[]; order?: string }
   ): Observable<UnflattenedReport[]> {
     const data = {
       params: {
@@ -124,7 +123,7 @@ export class ReportService {
           erpt.rp.created_at = this.dateService.getLocalDate(erpt.rp.created_at);
         }
         return erpt;
-      }),
+      })
     );
   }
 
@@ -139,7 +138,7 @@ export class ReportService {
       .pipe(
         tap(() => {
           this.clearTransactionCache();
-        }),
+        })
       );
   }
 
@@ -160,8 +159,8 @@ export class ReportService {
       switchMap((newReport: ReportV1) =>
         this.apiService
           .post<ReportV1>('/reports/' + newReport.id + '/txns', { ids: txnIds })
-          .pipe(switchMap(() => this.submit(newReport.id).pipe(map(() => newReport)))),
-      ),
+          .pipe(switchMap(() => this.submit(newReport.id).pipe(map(() => newReport))))
+      )
     );
   }
 
@@ -205,7 +204,7 @@ export class ReportService {
         comment: string;
       };
       notify: boolean;
-    },
+    }
   ): Observable<void> {
     return this.apiService.post('/reports/' + rptId + '/inquire', addStatusPayload);
   }
@@ -267,7 +266,7 @@ export class ReportService {
             res.data.next_at = dateObj;
           }
           return res;
-        }),
+        })
       );
   }
 
@@ -286,7 +285,7 @@ export class ReportService {
           return '(Automatic Submission On ' + this.datePipe.transform(nextReportAutoSubmissionDate, 'MMM d') + ')';
         }
         return null;
-      }),
+      })
     );
   }
 
@@ -339,12 +338,12 @@ export class ReportService {
           return this.apiService.get<{ count: number }>('/erpts/count', { params }).pipe(
             tap((res) => {
               this.storageService.set('erpts-count' + JSON.stringify(params), res);
-            }),
+            })
           );
         } else {
           return from(this.storageService.get<{ count: number }>('erpts-count' + JSON.stringify(params)));
         }
-      }),
+      })
     );
   }
 
@@ -358,7 +357,7 @@ export class ReportService {
       offset: 0,
       limit: 10,
       queryParams: {},
-    },
+    }
   ): Observable<ApiV2Response<ExtendedReport>> {
     return from(this.authService.getEou()).pipe(
       switchMap((eou) =>
@@ -370,7 +369,7 @@ export class ReportService {
             rp_org_user_id: 'eq.' + eou.ou.id,
             ...config.queryParams,
           },
-        }),
+        })
       ),
       map(
         (res) =>
@@ -380,12 +379,12 @@ export class ReportService {
             limit: number;
             offset: number;
             url: string;
-          },
+          }
       ),
       map((res) => ({
         ...res,
         data: res.data.map((datum) => this.dateService.fixDates(datum)),
-      })),
+      }))
     );
   }
 
@@ -402,7 +401,7 @@ export class ReportService {
       offset: 0,
       limit: 10,
       queryParams: {},
-    },
+    }
   ): Observable<ApiV2Response<ExtendedReport>> {
     return from(this.authService.getEou()).pipe(
       switchMap((eou) =>
@@ -414,7 +413,7 @@ export class ReportService {
             order: `${config.order || 'rp_created_at.desc'},rp_id.desc`,
             ...config.queryParams,
           },
-        }),
+        })
       ),
       map(
         (res) =>
@@ -424,12 +423,12 @@ export class ReportService {
             limit: number;
             offset: number;
             url: string;
-          },
+          }
       ),
       map((res) => ({
         ...res,
         data: res.data.map((datum) => this.dateService.fixDates(datum)),
-      })),
+      }))
     );
   }
 
@@ -476,7 +475,7 @@ export class ReportService {
   }
 
   getAllExtendedReports(
-    config: Partial<{ order: string; queryParams: ReportQueryParams }>,
+    config: Partial<{ order: string; queryParams: ReportQueryParams }>
   ): Observable<ExtendedReport[]> {
     return this.getMyReportsCount(config.queryParams).pipe(
       switchMap((count) => {
@@ -489,10 +488,10 @@ export class ReportService {
           limit: this.paginationSize,
           queryParams: config.queryParams,
           order: config.order,
-        }),
+        })
       ),
       map((res) => res.data),
-      reduce((acc, curr) => acc.concat(curr), [] as ExtendedReport[]),
+      reduce((acc, curr) => acc.concat(curr), [] as ExtendedReport[])
     );
   }
 
@@ -500,7 +499,7 @@ export class ReportService {
     params: {
       state?: string[];
     },
-    sortOrder?: string,
+    sortOrder?: string
   ): {
     state?: string[];
     order_by?: string;
@@ -514,7 +513,7 @@ export class ReportService {
 
   searchParamsGenerator(
     search: { state: keyof ReportStateMap; dateRange?: { from: string; to: string } },
-    sortOrder?: string,
+    sortOrder?: string
   ): Record<string, string[]> {
     let params = {};
 
@@ -532,7 +531,7 @@ export class ReportService {
         from?: string;
         to?: string;
       };
-    },
+    }
   ): Record<'state', string[]> {
     const searchParams = this.getUserReportParams(search.state);
     return Object.assign({}, params, searchParams);
@@ -550,7 +549,7 @@ export class ReportService {
     return range(0, count).pipe(
       map((page) => rptIds.slice(page * this.paginationSize, (page + 1) * this.paginationSize)),
       concatMap((rptIds) => this.apiService.get('/reports/approvers', { params: { report_ids: rptIds } })),
-      reduce((acc: Approver[], curr: Approver) => acc.concat(curr), []),
+      reduce((acc: Approver[], curr: Approver) => acc.concat(curr), [])
     );
   }
 
@@ -582,7 +581,7 @@ export class ReportService {
           },
         });
       }),
-      map((rawStatsResponse) => rawStatsResponse.data),
+      map((rawStatsResponse) => rawStatsResponse.data)
     );
   }
 
@@ -592,7 +591,7 @@ export class ReportService {
     return this.getPaginatedERptcCount(params).pipe(
       switchMap((results: { count: number }) =>
         // getting all results -> offset = 0, limit = count
-        this.getPaginatedERptc(0, results.count, params),
+        this.getPaginatedERptc(0, results.count, params)
       ),
       switchMap((erpts) => {
         const rptIds = erpts.map((erpt) => erpt.rp.id);
@@ -603,28 +602,12 @@ export class ReportService {
               (erpt) =>
                 !erpt.rp.approvals ||
                 (erpt.rp.approvals &&
-                  !(erpt.rp.approvals as Approver[]).some((approval) => approval.state === 'APPROVAL_DONE')),
-            ),
-          ),
+                  !(erpt.rp.approvals as Approver[]).some((approval) => approval.state === 'APPROVAL_DONE'))
+            )
+          )
         );
-      }),
+      })
     );
-  }
-
-  getReportETxnc(rptId: string, orgUserId: string): Observable<Expense[]> {
-    const data: {
-      params: {
-        approver_id?: string;
-      };
-    } = {
-      params: {},
-    };
-
-    if (orgUserId) {
-      data.params.approver_id = orgUserId;
-    }
-
-    return this.apiService.get('/erpts/' + rptId + '/etxns', data);
   }
 
   getReportStats(params: Partial<StatsResponse>): Observable<StatsResponse> {
@@ -635,9 +618,9 @@ export class ReportService {
             rp_org_user_id: `eq.${eou.ou.id}`,
             ...params,
           },
-        }),
+        })
       ),
-      map((rawStatsResponse: StatsResponse) => new StatsResponse(rawStatsResponse)),
+      map((rawStatsResponse: StatsResponse) => new StatsResponse(rawStatsResponse))
     );
   }
 

--- a/src/app/core/services/transaction.service.spec.ts
+++ b/src/app/core/services/transaction.service.spec.ts
@@ -37,7 +37,7 @@ import { TimezoneService } from './timezone.service';
 import { TransactionService } from './transaction.service';
 import { UserEventService } from './user-event.service';
 import { UtilityService } from './utility.service';
-import { transactionsCacheBuster$ } from './transaction.service';
+import { expensesCacheBuster$ } from './transaction.service';
 import * as dayjs from 'dayjs';
 import { eouRes2 } from '../mock-data/extended-org-user.data';
 import { txnStats } from '../mock-data/stats-response.data';
@@ -190,7 +190,7 @@ describe('TransactionService', () => {
     timezoneService = TestBed.inject(TimezoneService) as jasmine.SpyObj<TimezoneService>;
     utilityService = TestBed.inject(UtilityService) as jasmine.SpyObj<UtilityService>;
     spenderPlatformV1ApiService = TestBed.inject(
-      SpenderPlatformV1ApiService,
+      SpenderPlatformV1ApiService
     ) as jasmine.SpyObj<SpenderPlatformV1ApiService>;
     fileService = TestBed.inject(FileService) as jasmine.SpyObj<FileService>;
     userEventService = TestBed.inject(UserEventService) as jasmine.SpyObj<UserEventService>;
@@ -204,7 +204,7 @@ describe('TransactionService', () => {
   });
 
   it('clearCache(): should clear cache', (done) => {
-    const notifierSpy = spyOn(transactionsCacheBuster$, 'next').and.callThrough();
+    const notifierSpy = spyOn(expensesCacheBuster$, 'next').and.callThrough();
     transactionService.clearCache().subscribe((res) => {
       expect(notifierSpy).toHaveBeenCalledTimes(1);
       expect(res).toBeNull();
@@ -466,36 +466,6 @@ describe('TransactionService', () => {
     });
   });
 
-  it('getPaymentModeforEtxn(): should return payment mode for etxn', () => {
-    spyOn(transactionService, 'isEtxnInPaymentMode').and.returnValue(true);
-    const paymentModeList = [
-      {
-        name: 'Reimbursable',
-        key: 'reimbursable',
-      },
-      {
-        name: 'Non-Reimbursable',
-        key: 'nonReimbursable',
-      },
-      {
-        name: 'Advance',
-        key: 'advance',
-      },
-      {
-        name: 'CCC',
-        key: 'ccc',
-      },
-    ];
-    const etxnPaymentMode = { name: 'Reimbursable', key: 'reimbursable' };
-    // @ts-ignore
-    expect(transactionService.getPaymentModeForEtxn(expenseData1, paymentModeList)).toEqual(etxnPaymentMode);
-    expect(transactionService.isEtxnInPaymentMode).toHaveBeenCalledOnceWith(
-      expenseData1.tx_skip_reimbursement,
-      expenseData1.source_account_type,
-      etxnPaymentMode.key,
-    );
-  });
-
   describe('setSortParams():', () => {
     const currentParams = { pageNumber: 1 };
     const filters = { sortParam: 'tx_txn_dt', sortDir: 'desc' };
@@ -584,14 +554,14 @@ describe('TransactionService', () => {
     it('should return custom date params with start date only', () => {
       // @ts-ignore
       expect(transactionService.generateCustomDateParams(newQueryParams, filtersWithStartDateOnly)).toEqual(
-        customDateParamsWithStartDateOnly,
+        customDateParamsWithStartDateOnly
       );
     });
 
     it('should return custom date params with end date only', () => {
       // @ts-ignore
       expect(transactionService.generateCustomDateParams(newQueryParams, filtersWithEndDateOnly)).toEqual(
-        customDateParamsWithEndDateOnly,
+        customDateParamsWithEndDateOnly
       );
     });
 
@@ -972,13 +942,13 @@ describe('TransactionService', () => {
   describe('getExpenseDeletionMessage():', () => {
     it('should return expense deletion message for single', () => {
       expect(transactionService.getExpenseDeletionMessage(apiExpenseRes)).toEqual(
-        'You are about to permanently delete 1 selected expense.',
+        'You are about to permanently delete 1 selected expense.'
       );
     });
 
     it('getExpenseDeletionMessage(): should return expense deletion message for multiple expenses', () => {
       expect(transactionService.getExpenseDeletionMessage(expenseList2)).toEqual(
-        'You are about to permanently delete 2 selected expenses.',
+        'You are about to permanently delete 2 selected expenses.'
       );
     });
   });
@@ -986,19 +956,19 @@ describe('TransactionService', () => {
   describe('getCCCExpenseMessage():', () => {
     it('should return ccc expense message for single ccc expense', () => {
       expect(transactionService.getCCCExpenseMessage(apiExpenseRes, 1)).toEqual(
-        "There is 1 corporate card expense from the selection which can't be deleted. However you can delete the other expenses from the selection.",
+        "There is 1 corporate card expense from the selection which can't be deleted. However you can delete the other expenses from the selection."
       );
     });
 
     it('should return ccc expense message for multiple ccc expenses', () => {
       expect(transactionService.getCCCExpenseMessage(expenseList2, 2)).toEqual(
-        "There are 2 corporate card expenses from the selection which can't be deleted. However you can delete the other expenses from the selection.",
+        "There are 2 corporate card expenses from the selection which can't be deleted. However you can delete the other expenses from the selection."
       );
     });
 
     it('should return ccc expense message for with only ccc expenses selected', () => {
       expect(transactionService.getCCCExpenseMessage(null, 3)).toEqual(
-        "There are 3 corporate card expenses from the selection which can't be deleted. ",
+        "There are 3 corporate card expenses from the selection which can't be deleted. "
       );
     });
   });
@@ -1009,13 +979,13 @@ describe('TransactionService', () => {
         "There is 1 corporate card expense from the selection which can't be deleted. However you can delete the other expenses from the selection.";
       const deletableExpensesMessage = 'You are about to permanently delete 1 selected expense.';
       expect(
-        transactionService.getDeleteDialogBody(apiExpenseRes, 1, deletableExpensesMessage, cccExpensesMessage),
+        transactionService.getDeleteDialogBody(apiExpenseRes, 1, deletableExpensesMessage, cccExpensesMessage)
       ).toEqual(
         `<ul class="text-left">
         <li>${cccExpensesMessage}</li>
         <li>Once deleted, the action can't be reversed.</li>
         </ul>
-        <p class="confirmation-message text-left">Are you sure to <b>permanently</b> delete the selected expenses?</p>`,
+        <p class="confirmation-message text-left">Are you sure to <b>permanently</b> delete the selected expenses?</p>`
       );
     });
 
@@ -1026,7 +996,7 @@ describe('TransactionService', () => {
       <li>${deletableExpensesMessage}</li>
       <li>Once deleted, the action can't be reversed.</li>
       </ul>
-      <p class="confirmation-message text-left">Are you sure to <b>permanently</b> delete the selected expenses?</p>`,
+      <p class="confirmation-message text-left">Are you sure to <b>permanently</b> delete the selected expenses?</p>`
       );
     });
 
@@ -1036,7 +1006,7 @@ describe('TransactionService', () => {
       expect(transactionService.getDeleteDialogBody([], 1, null, cccExpensesMessage)).toEqual(
         `<ul class="text-left">
       <li>${cccExpensesMessage}</li>
-      </ul>`,
+      </ul>`
       );
     });
   });
@@ -1151,136 +1121,6 @@ describe('TransactionService', () => {
     });
   });
 
-  describe('isEtxnInPaymentMode():', () => {
-    it('should return isEtxnInPaymentMode with reimbursable payment mode', () => {
-      const txnSkipReimbursement = false;
-      const txnPaymentMode = 'reimbursable';
-      const txnSourceAccountType = AccountType.PERSONAL;
-      expect(
-        transactionService.isEtxnInPaymentMode(txnSkipReimbursement, txnSourceAccountType, txnPaymentMode),
-      ).toBeTrue();
-    });
-
-    it('should return isEtxnInPaymentMode with non-reimbursable payment mode', () => {
-      const txnSkipReimbursement = true;
-      const txnPaymentMode = 'nonReimbursable';
-      const txnSourceAccountType = AccountType.PERSONAL;
-      expect(
-        transactionService.isEtxnInPaymentMode(txnSkipReimbursement, txnSourceAccountType, txnPaymentMode),
-      ).toBeTrue();
-    });
-
-    it('should return isEtxnInPaymentMode with advance payment mode', () => {
-      const txnSkipReimbursement = false;
-      const txnPaymentMode = 'advance';
-      const txnSourceAccountType = AccountType.ADVANCE;
-      expect(
-        transactionService.isEtxnInPaymentMode(txnSkipReimbursement, txnSourceAccountType, txnPaymentMode),
-      ).toBeTrue();
-    });
-
-    it('should return isEtxnInPaymentMode with advance payment mode', () => {
-      const txnSkipReimbursement = false;
-      const txnPaymentMode = 'ccc';
-      const txnSourceAccountType = AccountType.CCC;
-      expect(
-        transactionService.isEtxnInPaymentMode(txnSkipReimbursement, txnSourceAccountType, txnPaymentMode),
-      ).toBeTrue();
-    });
-  });
-
-  describe('addEtxnToCurrencyMap():', () => {
-    it('should add a new currency to the map when the currencyMap does not exist', () => {
-      const currencyMap = {};
-      const txCurrency = 'USD';
-      const txAmount = 10;
-      // @ts-ignore
-      transactionService.addEtxnToCurrencyMap(currencyMap, txCurrency, txAmount);
-
-      expect(currencyMap).toEqual({
-        USD: {
-          name: 'USD',
-          currency: 'USD',
-          amount: 10,
-          origAmount: 10,
-          count: 1,
-        },
-      });
-    });
-
-    it('should add a new currency to the map with the orig currency', () => {
-      const currencyMap = {};
-      const txCurrency = 'USD';
-      const txAmount = 10;
-      const txOrigAmount = 200;
-      // @ts-ignore
-      transactionService.addEtxnToCurrencyMap(currencyMap, txCurrency, txAmount, txOrigAmount);
-
-      expect(currencyMap).toEqual({
-        USD: {
-          name: 'USD',
-          currency: 'USD',
-          amount: 10,
-          origAmount: 200,
-          count: 1,
-        },
-      });
-    });
-
-    it('should add the transaction amount to an existing currency in the map', () => {
-      const currencyMap = {
-        USD: {
-          name: 'USD',
-          currency: 'USD',
-          amount: 10,
-          origAmount: 10,
-          count: 1,
-        },
-      };
-      const txCurrency = 'USD';
-      const txAmount = 20;
-      // @ts-ignore
-      transactionService.addEtxnToCurrencyMap(currencyMap, txCurrency, txAmount);
-
-      expect(currencyMap).toEqual({
-        USD: {
-          name: 'USD',
-          currency: 'USD',
-          amount: 30,
-          origAmount: 30,
-          count: 2,
-        },
-      });
-    });
-
-    it('should add the transaction amount and original amount to an existing currency in the map', () => {
-      const currencyMap = {
-        USD: {
-          name: 'USD',
-          currency: 'USD',
-          amount: 10,
-          origAmount: 10,
-          count: 1,
-        },
-      };
-      const txCurrency = 'USD';
-      const txAmount = 20;
-      const txOrigAmount = 30;
-      // @ts-ignore
-      transactionService.addEtxnToCurrencyMap(currencyMap, txCurrency, txAmount, txOrigAmount);
-
-      expect(currencyMap).toEqual({
-        USD: {
-          name: 'USD',
-          currency: 'USD',
-          amount: 30,
-          origAmount: 40,
-          count: 2,
-        },
-      });
-    });
-  });
-
   it('getTxnAccount(): should get the default txn account', (done) => {
     orgSettingsService.get.and.returnValue(of(orgSettingsData));
     accountsService.getEMyAccounts.and.returnValue(of(accountsData));
@@ -1298,7 +1138,7 @@ describe('TransactionService', () => {
       expect(paymentModesService.getDefaultAccount).toHaveBeenCalledOnceWith(
         orgSettingsData,
         accountsData,
-        orgUserSettingsData,
+        orgUserSettingsData
       );
       expect(orgSettingsService.get).toHaveBeenCalledTimes(1);
       expect(accountsService.getEMyAccounts).toHaveBeenCalledTimes(1);
@@ -1332,73 +1172,6 @@ describe('TransactionService', () => {
     expect(transactionService.getReportableExpenses(apiExpenseRes)).toEqual([apiExpenseRes[0]]);
     expect(transactionService.getIsCriticalPolicyViolated).toHaveBeenCalledOnceWith(apiExpenseRes[0]);
     expect(transactionService.getIsDraft).toHaveBeenCalledOnceWith(apiExpenseRes[0]);
-  });
-
-  it('getCurrenyWiseSummary(): should return the currency wise summary', () => {
-    // @ts-ignore
-    spyOn(transactionService, 'addEtxnToCurrencyMap').and.callThrough();
-
-    const currencyMap = {
-      INR: { name: 'INR', currency: 'INR', amount: 89, origAmount: 89, count: 1 },
-      CLF: { name: 'CLF', currency: 'CLF', amount: 33611, origAmount: 12, count: 1 },
-      EUR: { name: 'EUR', currency: 'EUR', amount: 15775.76, origAmount: 178, count: 1 },
-    };
-
-    expect(transactionService.getCurrenyWiseSummary(expenseList4)).toEqual(currencySummaryData);
-    // @ts-ignore
-    expect(transactionService.addEtxnToCurrencyMap).toHaveBeenCalledWith(currencyMap, 'INR', 89);
-    // @ts-ignore
-    expect(transactionService.addEtxnToCurrencyMap).toHaveBeenCalledWith(currencyMap, 'CLF', 33611, 12);
-    // @ts-ignore
-    expect(transactionService.addEtxnToCurrencyMap).toHaveBeenCalledWith(currencyMap, 'EUR', 15775.76, 178);
-    // @ts-ignore
-    expect(transactionService.addEtxnToCurrencyMap).toHaveBeenCalledTimes(3);
-  });
-
-  it('getPaymentModeWiseSummary(): should return the payment mode wise summary', () => {
-    // @ts-ignore
-    spyOn(transactionService, 'getPaymentModeForEtxn').and.returnValue({
-      name: 'Reimbursable',
-      key: 'reimbursable',
-    });
-
-    const paymentModes = [
-      {
-        name: 'Reimbursable',
-        key: 'reimbursable',
-      },
-      {
-        name: 'Non-Reimbursable',
-        key: 'nonReimbursable',
-      },
-      {
-        name: 'Advance',
-        key: 'advance',
-      },
-      {
-        name: 'CCC',
-        key: 'ccc',
-      },
-    ];
-
-    const summary = {
-      reimbursable: {
-        name: 'Reimbursable',
-        key: 'reimbursable',
-        amount: 49475.76,
-        count: 3,
-      },
-    };
-
-    expect(transactionService.getPaymentModeWiseSummary(expenseList4)).toEqual(summary);
-    // @ts-ignore
-    expect(transactionService.getPaymentModeForEtxn).toHaveBeenCalledWith(expenseList4[0], paymentModes);
-    // @ts-ignore
-    expect(transactionService.getPaymentModeForEtxn).toHaveBeenCalledWith(expenseList4[1], paymentModes);
-    // @ts-ignore
-    expect(transactionService.getPaymentModeForEtxn).toHaveBeenCalledWith(expenseList4[2], paymentModes);
-    // @ts-ignore
-    expect(transactionService.getPaymentModeForEtxn).toHaveBeenCalledTimes(3);
   });
 
   it('matchCCCExpense(): should match ccc expense', (done) => {

--- a/src/app/core/services/transaction.service.ts
+++ b/src/app/core/services/transaction.service.ts
@@ -16,7 +16,6 @@ import { Expense } from '../models/expense.model';
 import { Cacheable, CacheBuster } from 'ts-cacheable';
 import { UserEventService } from './user-event.service';
 import { UndoMerge } from '../models/undo-merge.model';
-import { AccountType } from '../enums/account-type.enum';
 import { cloneDeep } from 'lodash';
 import { DateFilters } from 'src/app/shared/components/fy-filters/date-filters.enum';
 import { ExpenseFilters } from 'src/app/fyle/my-expenses/expense-filters.model';
@@ -48,7 +47,7 @@ enum FilterState {
   DRAFT = 'DRAFT',
 }
 
-export const transactionsCacheBuster$ = new Subject<void>();
+export const expensesCacheBuster$ = new Subject<void>();
 
 type PaymentMode = {
   name: string;
@@ -78,7 +77,7 @@ export class TransactionService {
     private orgSettingsService: OrgSettingsService,
     private accountsService: AccountsService
   ) {
-    transactionsCacheBuster$.subscribe(() => {
+    expensesCacheBuster$.subscribe(() => {
       this.userEventService.clearTaskCache();
     });
   }
@@ -89,7 +88,7 @@ export class TransactionService {
     Ref: https://www.npmjs.com/package/ts-cacheable#:~:text=need%20to%20set-,isInstant%3A%20true,-on%20CacheBuster%20configuration
   */
   @CacheBuster({
-    cacheBusterNotifier: transactionsCacheBuster$,
+    cacheBusterNotifier: expensesCacheBuster$,
     isInstant: true,
   })
   clearCache(): Observable<null> {
@@ -97,7 +96,7 @@ export class TransactionService {
   }
 
   @Cacheable({
-    cacheBusterObserver: transactionsCacheBuster$,
+    cacheBusterObserver: expensesCacheBuster$,
   })
   getEtxn(txnId: string): Observable<Expense> {
     // TODO api v2
@@ -118,21 +117,21 @@ export class TransactionService {
   }
 
   @CacheBuster({
-    cacheBusterNotifier: transactionsCacheBuster$,
+    cacheBusterNotifier: expensesCacheBuster$,
   })
   manualFlag(txnId: string): Observable<Expense> {
     return this.apiService.post('/transactions/' + txnId + '/manual_flag');
   }
 
   @CacheBuster({
-    cacheBusterNotifier: transactionsCacheBuster$,
+    cacheBusterNotifier: expensesCacheBuster$,
   })
   manualUnflag(txnId: string): Observable<Expense> {
     return this.apiService.post('/transactions/' + txnId + '/manual_unflag');
   }
 
   @Cacheable({
-    cacheBusterObserver: transactionsCacheBuster$,
+    cacheBusterObserver: expensesCacheBuster$,
   })
   getAllETxnc(params: EtxnParams): Observable<Expense[]> {
     return this.getETxnCount(params).pipe(
@@ -146,7 +145,7 @@ export class TransactionService {
   }
 
   @Cacheable({
-    cacheBusterObserver: transactionsCacheBuster$,
+    cacheBusterObserver: expensesCacheBuster$,
   })
   getMyExpenses(
     config: Partial<{ offset: number; limit: number; order: string; queryParams: EtxnParams }> = {
@@ -185,7 +184,7 @@ export class TransactionService {
   }
 
   @Cacheable({
-    cacheBusterObserver: transactionsCacheBuster$,
+    cacheBusterObserver: expensesCacheBuster$,
   })
   getAllExpenses(config: Partial<{ order: string; queryParams: EtxnParams }>): Observable<Expense[]> {
     return this.getMyExpensesCount(config.queryParams).pipe(
@@ -207,7 +206,7 @@ export class TransactionService {
   }
 
   @Cacheable({
-    cacheBusterObserver: transactionsCacheBuster$,
+    cacheBusterObserver: expensesCacheBuster$,
   })
   // TODO: Remove `any` type once the stats response implementation is fixed
   getTransactionStats(aggregates: string, queryParams: EtxnParams): Observable<Datum[]> {
@@ -226,14 +225,14 @@ export class TransactionService {
   }
 
   @CacheBuster({
-    cacheBusterNotifier: transactionsCacheBuster$,
+    cacheBusterNotifier: expensesCacheBuster$,
   })
   delete(txnId: string): Observable<Expense> {
     return this.apiService.delete<Expense>('/transactions/' + txnId);
   }
 
   @CacheBuster({
-    cacheBusterNotifier: transactionsCacheBuster$,
+    cacheBusterNotifier: expensesCacheBuster$,
   })
   deleteBulk(txnIds: string[]): Observable<Transaction[]> {
     const chunkSize = 10;
@@ -250,7 +249,7 @@ export class TransactionService {
   }
 
   @CacheBuster({
-    cacheBusterNotifier: transactionsCacheBuster$,
+    cacheBusterNotifier: expensesCacheBuster$,
   })
   upsert(transaction: Partial<Transaction>): Observable<Partial<Transaction>> {
     /** Only these fields will be of type text & custom fields */
@@ -316,7 +315,7 @@ export class TransactionService {
   }
 
   @CacheBuster({
-    cacheBusterNotifier: transactionsCacheBuster$,
+    cacheBusterNotifier: expensesCacheBuster$,
   })
   createTxnWithFiles(
     txn: Partial<Transaction>,
@@ -530,64 +529,6 @@ export class TransactionService {
     return expense.tx_state && expense.tx_state === 'DRAFT';
   }
 
-  getPaymentModeWiseSummary(etxns: Expense[]): PaymentModeSummary {
-    const paymentModes = [
-      {
-        name: 'Reimbursable',
-        key: 'reimbursable',
-      },
-      {
-        name: 'Non-Reimbursable',
-        key: 'nonReimbursable',
-      },
-      {
-        name: 'Advance',
-        key: 'advance',
-      },
-      {
-        name: 'CCC',
-        key: 'ccc',
-      },
-    ];
-
-    return etxns
-      .map((etxn) => ({
-        ...etxn,
-        paymentMode: this.getPaymentModeForEtxn(etxn, paymentModes),
-      }))
-      .reduce((paymentMap: PaymentModeSummary, etxnData) => {
-        if (paymentMap.hasOwnProperty(etxnData.paymentMode.key)) {
-          paymentMap[etxnData.paymentMode.key].name = etxnData.paymentMode.name;
-          paymentMap[etxnData.paymentMode.key].key = etxnData.paymentMode.key;
-          paymentMap[etxnData.paymentMode.key].amount += etxnData.tx_amount;
-          paymentMap[etxnData.paymentMode.key].count++;
-        } else {
-          paymentMap[etxnData.paymentMode.key] = {
-            name: etxnData.paymentMode.name,
-            key: etxnData.paymentMode.key,
-            amount: etxnData.tx_amount,
-            count: 1,
-          };
-        }
-        return paymentMap;
-      }, {});
-  }
-
-  getCurrenyWiseSummary(etxns: Expense[]): CurrencySummary[] {
-    const currencyMap: Record<string, CurrencySummary> = {};
-    etxns.forEach((etxn) => {
-      if (!(etxn.tx_orig_currency && etxn.tx_orig_amount)) {
-        this.addEtxnToCurrencyMap(currencyMap, etxn.tx_currency, etxn.tx_amount);
-      } else {
-        this.addEtxnToCurrencyMap(currencyMap, etxn.tx_orig_currency, etxn.tx_amount, etxn.tx_orig_amount);
-      }
-    });
-
-    return Object.keys(currencyMap)
-      .map((currency) => currencyMap[currency])
-      .sort((a, b) => (a.amount < b.amount ? 1 : -1));
-  }
-
   excludeCCCExpenses(expenses: Partial<Expense>[]): Partial<Expense>[] {
     return expenses.filter((expense) => expense && !expense.tx_corporate_credit_card_expense_group_id);
   }
@@ -790,26 +731,6 @@ export class TransactionService {
     return currentParamsCopy;
   }
 
-  isEtxnInPaymentMode(txnSkipReimbursement: boolean, txnSourceAccountType: string, paymentMode: string): boolean {
-    let etxnInPaymentMode = false;
-    const isAdvanceOrCCCEtxn = txnSourceAccountType === AccountType.ADVANCE || txnSourceAccountType === AccountType.CCC;
-
-    if (paymentMode === 'reimbursable') {
-      //Paid by Employee: reimbursable
-      etxnInPaymentMode = !txnSkipReimbursement && !isAdvanceOrCCCEtxn;
-    } else if (paymentMode === 'nonReimbursable') {
-      //Paid by Company: not reimbursable
-      etxnInPaymentMode = txnSkipReimbursement && !isAdvanceOrCCCEtxn;
-    } else if (paymentMode === 'advance') {
-      //Paid from Advance account: not reimbursable
-      etxnInPaymentMode = txnSourceAccountType === AccountType.ADVANCE;
-    } else if (paymentMode === 'ccc') {
-      //Paid from CCC: not reimbursable
-      etxnInPaymentMode = txnSourceAccountType === AccountType.CCC;
-    }
-    return etxnInPaymentMode;
-  }
-
   private getTxnAccount(): Observable<{ source_account_id: string; skip_reimbursement: boolean }> {
     return forkJoin({
       orgSettings: this.orgSettingsService.get(),
@@ -849,35 +770,6 @@ export class TransactionService {
 
     data.tx_updated_at = new Date(data.tx_updated_at);
     return data;
-  }
-
-  private getPaymentModeForEtxn(etxn: Expense, paymentModes: PaymentMode[]): PaymentMode {
-    const txnSkipReimbursement = etxn.tx_skip_reimbursement;
-    const txnSourceAccountType = etxn.source_account_type;
-    return paymentModes.find((paymentMode) =>
-      this.isEtxnInPaymentMode(txnSkipReimbursement, txnSourceAccountType, paymentMode.key)
-    );
-  }
-
-  private addEtxnToCurrencyMap(
-    currencyMap: Record<string, CurrencySummary>,
-    txCurrency: string,
-    txAmount: number,
-    txOrigAmount: number = null
-  ): void {
-    if (currencyMap.hasOwnProperty(txCurrency)) {
-      currencyMap[txCurrency].origAmount += txOrigAmount ? txOrigAmount : txAmount;
-      currencyMap[txCurrency].amount += txAmount;
-      currencyMap[txCurrency].count++;
-    } else {
-      currencyMap[txCurrency] = {
-        name: txCurrency,
-        currency: txCurrency,
-        amount: txAmount,
-        origAmount: txOrigAmount ? txOrigAmount : txAmount,
-        count: 1,
-      };
-    }
   }
 
   private generateStateOrFilter(filters: Partial<ExpenseFilters>, newQueryParamsCopy: FilterQueryParams): string[] {

--- a/src/app/fyle/my-view-report/my-view-report.page.html
+++ b/src/app/fyle/my-view-report/my-view-report.page.html
@@ -159,17 +159,17 @@
           <div *ngIf="!isExpensesLoading && erpt.rp_num_transactions > 0">
             <div class="view-reports--divider"></div>
             <div class="view-reports--expenses-card-block">
-              <div *ngFor="let etxn of etxns$|async as list; let i = index;">
-                <app-expense-card
-                  [expense]="etxn"
-                  [etxnIndex]="i"
-                  [previousExpenseTxnDate]="list[i-1]?.tx_txn_dt"
-                  [previousExpenseCreatedAt]="list[i-1]?.tx_created_at"
+              <div *ngFor="let expense of expenses$|async as list; let i = index;">
+                <app-expense-card-v2
+                  [expense]="expense"
+                  [expenseIndex]="i"
+                  [previousExpenseTxnDate]="list[i-1]?.spent_at"
+                  [previousExpenseCreatedAt]="list[i-1]?.created_at"
                   (goToTransaction)="goToTransaction($event)"
                   [isFromReports]="true"
                   [isFromViewReports]="true"
                 >
-                </app-expense-card>
+                </app-expense-card-v2>
               </div>
             </div>
             <ng-template #ExpensesLoader>

--- a/src/app/fyle/my-view-report/my-view-report.page.spec.ts
+++ b/src/app/fyle/my-view-report/my-view-report.page.spec.ts
@@ -291,25 +291,6 @@ describe('MyViewReportPage', () => {
     });
   });
 
-  describe('getShowViolation():', () => {
-    it('should show expense violation', () => {
-      const result = component.getShowViolation(expenseData2);
-
-      expect(result).toBeFalse();
-    });
-
-    it('should show the policy flag in expense', () => {
-      const result = component.getShowViolation({
-        ...expenseData2,
-        tx_policy_flag: true,
-        tx_manual_flag: false,
-        tx_policy_amount: 1000,
-      });
-
-      expect(result).toBeTrue();
-    });
-  });
-
   describe('getSimplifyReportSettings():', () => {
     it('should return simplify report settings', () => {
       const result = component.getSimplifyReportSettings({

--- a/src/app/fyle/my-view-report/my-view-report.page.ts
+++ b/src/app/fyle/my-view-report/my-view-report.page.ts
@@ -26,12 +26,15 @@ import { AddExpensesToReportComponent } from './add-expenses-to-report/add-expen
 import { cloneDeep } from 'lodash';
 import { RefinerService } from 'src/app/core/services/refiner.service';
 import { Expense } from 'src/app/core/models/expense.model';
+import { Expense as PlatformExpense } from 'src/app/core/models/platform/v1/expense.model';
 import { ExpenseView } from 'src/app/core/models/expense-view.enum';
 import { OrgSettingsService } from 'src/app/core/services/org-settings.service';
 import { ReportPageSegment } from 'src/app/core/enums/report-page-segment.enum';
 import { OrgSettings } from 'src/app/core/models/org-settings.model';
 import { Approver } from 'src/app/core/models/v1/approver.model';
 import { ExtendedOrgUser } from 'src/app/core/models/extended-org-user.model';
+import { ExpensesService } from 'src/app/core/services/platform/v1/spender/expenses.service';
+import { ExpenseState } from 'src/app/core/models/expense-state.enum';
 @Component({
   selector: 'app-my-view-report',
   templateUrl: './my-view-report.page.html',
@@ -44,7 +47,7 @@ export class MyViewReportPage {
 
   erpt$: Observable<ExtendedReport>;
 
-  etxns$: Observable<Expense[]>;
+  expenses$: Observable<PlatformExpense[]>;
 
   reportApprovals$: Observable<Approver[]>;
 
@@ -84,7 +87,7 @@ export class MyViewReportPage {
 
   unReportedEtxns: Expense[];
 
-  reportEtxnIds: string[];
+  reportExpenseIds: string[];
 
   isExpensesLoading: boolean;
 
@@ -110,6 +113,7 @@ export class MyViewReportPage {
     private activatedRoute: ActivatedRoute,
     private reportService: ReportService,
     private transactionService: TransactionService,
+    private expensesService: ExpensesService,
     private authService: AuthService,
     private loaderService: LoaderService,
     private router: Router,
@@ -161,14 +165,6 @@ export class MyViewReportPage {
     }
 
     return vendorName;
-  }
-
-  getShowViolation(etxn: Expense): boolean {
-    return (
-      etxn.tx_id &&
-      (etxn.tx_manual_flag || etxn.tx_policy_flag) &&
-      !(typeof etxn.tx_policy_amount === 'number' && etxn.tx_policy_amount < 0.0001)
-    );
   }
 
   getSimplifyReportSettings(orgSettings: OrgSettings): boolean {
@@ -251,24 +247,10 @@ export class MyViewReportPage {
       .getApproversByReportId(this.reportId)
       .pipe(map((reportApprovals) => reportApprovals));
 
-    this.etxns$ = this.loadReportTxns$.pipe(
+    this.expenses$ = this.loadReportTxns$.pipe(
       tap(() => (this.isExpensesLoading = true)),
-      switchMap(() => this.authService.getEou()),
-      switchMap((eou) =>
-        this.transactionService
-          .getAllETxnc({
-            tx_org_user_id: 'eq.' + eou.ou.id,
-            tx_report_id: 'eq.' + this.reportId,
-            order: 'tx_txn_dt.desc,tx_id.desc',
-          })
-          .pipe(finalize(() => (this.isExpensesLoading = false)))
-      ),
-      map((etxns) =>
-        etxns.map((etxn) => {
-          etxn.vendor = this.getVendorName(etxn);
-          etxn.violation = this.getShowViolation(etxn);
-          return etxn;
-        })
+      switchMap(() =>
+        this.expensesService.getReportExpenses(this.reportId).pipe(finalize(() => (this.isExpensesLoading = false)))
       ),
       shareReplay(1)
     );
@@ -279,7 +261,7 @@ export class MyViewReportPage {
     this.canDelete$ = actions$.pipe(map((actions) => actions.can_delete));
     this.canResubmitReport$ = actions$.pipe(map((actions) => actions.can_resubmit));
 
-    this.etxns$.subscribe((etxns) => (this.reportEtxnIds = etxns.map((etxn) => etxn.tx_id)));
+    this.expenses$.subscribe((expenses) => (this.reportExpenseIds = expenses.map((expense) => expense.id)));
 
     const queryParams = {
       tx_report_id: 'is.null',
@@ -444,12 +426,12 @@ export class MyViewReportPage {
     });
   }
 
-  goToTransaction({ etxn, etxnIndex }: { etxn: Expense; etxnIndex: number }): void {
-    const canEdit = this.canEditTxn(etxn.tx_state);
+  goToTransaction({ expense, expenseIndex }: { expense: PlatformExpense; expenseIndex: number }): void {
+    const canEdit = this.canEditExpense(expense.state);
     let category: string;
 
-    if (etxn.tx_org_category) {
-      category = etxn.tx_org_category.toLowerCase();
+    if (expense.category) {
+      category = expense.category.name?.toLowerCase();
     }
 
     let route: string;
@@ -475,7 +457,7 @@ export class MyViewReportPage {
         this.router.navigate([
           route,
           {
-            id: etxn.tx_id,
+            id: expense.id,
             navigate_back: true,
             remove_from_report: erpt.rp_num_transactions > 1,
           },
@@ -486,9 +468,9 @@ export class MyViewReportPage {
       this.router.navigate([
         route,
         {
-          id: etxn.tx_id,
-          txnIds: JSON.stringify(this.reportEtxnIds),
-          activeIndex: etxnIndex,
+          id: expense.id,
+          txnIds: JSON.stringify(this.reportExpenseIds),
+          activeIndex: expenseIndex,
           view: ExpenseView.individual,
         },
       ]);
@@ -530,7 +512,7 @@ export class MyViewReportPage {
       component: FyViewReportInfoComponent,
       componentProps: {
         erpt$: this.erpt$,
-        etxns$: this.etxns$,
+        expenses$: this.expenses$,
         view: ExpenseView.individual,
       },
       ...this.modalProperties.getModalDefaultProperties(),
@@ -542,8 +524,8 @@ export class MyViewReportPage {
     this.trackingService.clickViewReportInfo({ view: ExpenseView.individual });
   }
 
-  canEditTxn(txState: string): boolean {
-    return this.canEdit$ && ['DRAFT', 'DRAFT_INQUIRY', 'COMPLETE', 'APPROVER_PENDING'].indexOf(txState) > -1;
+  canEditExpense(expenseState: ExpenseState): boolean {
+    return this.canEdit$ && ['DRAFT', 'DRAFT_INQUIRY', 'COMPLETE', 'APPROVER_PENDING'].indexOf(expenseState) > -1;
   }
 
   segmentChanged(event: SegmentCustomEvent): void {

--- a/src/app/fyle/view-team-report/view-team-report.page.spec.ts
+++ b/src/app/fyle/view-team-report/view-team-report.page.spec.ts
@@ -49,14 +49,18 @@ import { platformReportData } from 'src/app/core/mock-data/platform-report.data'
 import {
   expenseData,
   expenseResponseData,
+  expenseResponseData2,
+  mileageExpense,
   perDiemExpenseWithSingleNumDays,
 } from 'src/app/core/mock-data/platform/v1/expense.data';
+import { ExpensesService as ApproverExpensesService } from 'src/app/core/services/platform/v1/approver/expenses.service';
 
-describe('ViewTeamReportPage', () => {
+fdescribe('ViewTeamReportPage', () => {
   let component: ViewTeamReportPage;
   let fixture: ComponentFixture<ViewTeamReportPage>;
   let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
   let reportService: jasmine.SpyObj<ReportService>;
+  let approverExpensesService: jasmine.SpyObj<ApproverExpensesService>;
   let authService: jasmine.SpyObj<AuthService>;
   let loaderService: jasmine.SpyObj<LoaderService>;
   let router: jasmine.SpyObj<Router>;
@@ -74,12 +78,16 @@ describe('ViewTeamReportPage', () => {
   let orgSettingsService: jasmine.SpyObj<OrgSettingsService>;
 
   beforeEach(waitForAsync(() => {
+    const approverExpensesServiceSpy = jasmine.createSpyObj('ApproverExpensesService', [
+      'getReportExpenses',
+      'getExpenses',
+      'getExpensesCount',
+    ]);
     const reportServiceSpy = jasmine.createSpyObj('ReportService', [
       'getReport',
       'getTeamReport',
       'getExports',
       'getApproversByReportId',
-      'getReportETxnc',
       'actions',
       'delete',
       'approve',
@@ -128,6 +136,10 @@ describe('ViewTeamReportPage', () => {
         {
           provide: ReportService,
           useValue: reportServiceSpy,
+        },
+        {
+          provide: ApproverExpensesService,
+          useValue: approverExpensesServiceSpy,
         },
         {
           provide: AuthService,
@@ -197,6 +209,7 @@ describe('ViewTeamReportPage', () => {
 
     activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
     reportService = TestBed.inject(ReportService) as jasmine.SpyObj<ReportService>;
+    approverExpensesService = TestBed.inject(ApproverExpensesService) as jasmine.SpyObj<ApproverExpensesService>;
     authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
     loaderService = TestBed.inject(LoaderService) as jasmine.SpyObj<LoaderService>;
     router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
@@ -306,7 +319,7 @@ describe('ViewTeamReportPage', () => {
         })
       );
       reportService.getApproversByReportId.and.returnValue(of(approversData1));
-      reportService.getReportETxnc.and.returnValue(of(etxncListData.data));
+      approverExpensesService.getReportExpenses.and.returnValue(of(expenseResponseData2));
       reportService.actions.and.returnValue(of(apiReportActions));
 
       component.ionViewWillEnter();
@@ -319,7 +332,7 @@ describe('ViewTeamReportPage', () => {
       expect(loaderService.showLoader).toHaveBeenCalledTimes(1);
       expect(component.setupNetworkWatcher).toHaveBeenCalledTimes(1);
       expect(component.loadReports).toHaveBeenCalledTimes(1);
-      expect(authService.getEou).toHaveBeenCalledTimes(2);
+      expect(authService.getEou).toHaveBeenCalledTimes(1);
       expect(statusService.find).toHaveBeenCalledOnceWith(component.objectType, component.objectId);
       expect(orgSettingsService.get).toHaveBeenCalledTimes(2);
 
@@ -357,10 +370,10 @@ describe('ViewTeamReportPage', () => {
       expect(reportService.getExports).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id);
       expect(reportService.getApproversByReportId).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id);
 
-      expect(reportService.getReportETxnc).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id, apiEouRes.ou.id);
+      expect(approverExpensesService.getReportExpenses).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id);
 
       component.expensesAmountSum$.subscribe((res) => {
-        expect(res).toEqual(310.65);
+        expect(res).toEqual(207000.78);
       });
 
       component.sharedWith$.subscribe((res) => {
@@ -391,7 +404,7 @@ describe('ViewTeamReportPage', () => {
       expect(component.getApprovalSettings).toHaveBeenCalledOnceWith(orgSettingsData);
       expect(component.isUserActiveInCurrentSeqApprovalQueue).toHaveBeenCalledOnceWith(apiEouRes, [approversData1[0]]);
 
-      expect(component.reportExpensesIds).toEqual(['txZ1nfsXb5Xs', 'txnYF8lUl3Sr']);
+      expect(component.reportExpensesIds).toEqual(['txe0bYaJlRJf', 'txe0bYaJlRJf']);
       expect(component.isSequentialApprovalEnabled).toBeTrue();
       expect(component.canApprove).toBeNull();
       expect(component.canShowTooltip).toBeTrue();
@@ -417,7 +430,7 @@ describe('ViewTeamReportPage', () => {
         })
       );
       reportService.getApproversByReportId.and.returnValue(of(approversData1));
-      reportService.getReportETxnc.and.returnValue(of(etxncListData.data));
+      approverExpensesService.getReportExpenses.and.returnValue(of(expenseResponseData2));
       reportService.actions.and.returnValue(of(apiReportActions));
       fixture.detectChanges();
 
@@ -431,7 +444,7 @@ describe('ViewTeamReportPage', () => {
       expect(loaderService.showLoader).toHaveBeenCalledTimes(1);
       expect(component.setupNetworkWatcher).toHaveBeenCalledTimes(1);
       expect(component.loadReports).toHaveBeenCalledTimes(1);
-      expect(authService.getEou).toHaveBeenCalledTimes(2);
+      expect(authService.getEou).toHaveBeenCalledTimes(1);
       expect(statusService.find).toHaveBeenCalledOnceWith(component.objectType, component.objectId);
       expect(orgSettingsService.get).toHaveBeenCalledTimes(2);
 
@@ -467,10 +480,10 @@ describe('ViewTeamReportPage', () => {
       expect(reportService.getExports).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id);
       expect(reportService.getApproversByReportId).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id);
 
-      expect(reportService.getReportETxnc).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id, apiEouRes.ou.id);
+      expect(approverExpensesService.getReportExpenses).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id);
 
       component.expensesAmountSum$.subscribe((res) => {
-        expect(res).toEqual(310.65);
+        expect(res).toEqual(207000.78);
       });
 
       component.sharedWith$.subscribe((res) => {
@@ -500,7 +513,7 @@ describe('ViewTeamReportPage', () => {
       expect(reportService.actions).toHaveBeenCalledOnceWith(activatedRoute.snapshot.params.id);
       expect(component.getApprovalSettings).toHaveBeenCalledOnceWith(orgSettingsData);
 
-      expect(component.reportExpensesIds).toEqual(['txZ1nfsXb5Xs', 'txnYF8lUl3Sr']);
+      expect(component.reportExpensesIds).toEqual(['txe0bYaJlRJf', 'txe0bYaJlRJf']);
       expect(component.isSequentialApprovalEnabled).toBeFalse();
       expect(component.canApprove).toBeTrue();
       expect(component.canShowTooltip).toBeTrue();
@@ -609,9 +622,9 @@ describe('ViewTeamReportPage', () => {
 
       expect(popoverController.create).toHaveBeenCalledOnceWith({
         componentProps: {
-          expenses: expenseResponseData,
           title: 'Approve Report',
           message: '3 expenses of amount undefined will be approved',
+          numIssues: 0,
           primaryCta: {
             text: 'Approve',
             action: 'approve',
@@ -665,12 +678,12 @@ describe('ViewTeamReportPage', () => {
 
       expect(trackingService.viewExpenseClicked).toHaveBeenCalledOnceWith({
         view: ExpenseView.team,
-        category: 'groceries',
+        category: 'entertainment',
       });
       expect(router.navigate).toHaveBeenCalledOnceWith([
         route,
         {
-          id: expenseData1.tx_id,
+          id: expenseData.id,
           txnIds: JSON.stringify(component.reportExpensesIds),
           activeIndex: 0,
           view: ExpenseView.team,
@@ -683,7 +696,7 @@ describe('ViewTeamReportPage', () => {
       fixture.detectChanges();
 
       component.goToTransaction({
-        expense: expenseData,
+        expense: mileageExpense,
         expenseIndex: 0,
       });
 
@@ -696,7 +709,7 @@ describe('ViewTeamReportPage', () => {
       expect(router.navigate).toHaveBeenCalledOnceWith([
         route,
         {
-          id: etxncListData.data[0].tx_id,
+          id: mileageExpense.id,
           txnIds: JSON.stringify(component.reportExpensesIds),
           activeIndex: 0,
           view: ExpenseView.team,

--- a/src/app/fyle/view-team-report/view-team-report.page.spec.ts
+++ b/src/app/fyle/view-team-report/view-team-report.page.spec.ts
@@ -55,7 +55,7 @@ import {
 } from 'src/app/core/mock-data/platform/v1/expense.data';
 import { ExpensesService as ApproverExpensesService } from 'src/app/core/services/platform/v1/approver/expenses.service';
 
-fdescribe('ViewTeamReportPage', () => {
+describe('ViewTeamReportPage', () => {
   let component: ViewTeamReportPage;
   let fixture: ComponentFixture<ViewTeamReportPage>;
   let activatedRoute: jasmine.SpyObj<ActivatedRoute>;


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f7eb4ad</samp>

Updated mock data and test cases for expense features. Changed the mock data file `expense.data.ts` to include mileage expenses and correct category names. Modified the test file `view-team-report.page.spec.ts` to use the new service and data, and to test mileage and sequential approval features.
https://app.clickup.com/t/86ctx56rq
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f7eb4ad</samp>

> _Mock data renamed_
> _`ApproverExpensesService` tested_
> _Mileage in autumn_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f7eb4ad</samp>

*  Update mock data for mileage and per diem categories and add a new mileage expense object ([link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-24d88c263ca5d224aa35b783df4640316640e6db32915015b6cce6ff83b7a05bL373-R373), [link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-24d88c263ca5d224aa35b783df4640316640e6db32915015b6cce6ff83b7a05bL382-R391))
*  Rename `ExpensesService` to `ApproverExpensesService` and update import statement in view team report page spec file ([link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL52-R63))
*  Create a spy object for `ApproverExpensesService` with mocked methods and remove `getReportETxnc` method from `ReportService` spy object ([link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bR81-R85), [link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL82))
*  Add `ApproverExpensesService` as a provider in the test module using the spy object ([link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bR141-R144))
*  Assign `ApproverExpensesService` to a variable using `TestBed.inject` and cast it as a spy object ([link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bR212))
*  Replace `getReportETxnc` method with `getReportExpenses` method from `ApproverExpensesService` and call `getEou` method only once in `loadReports` method ([link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL309-R322), [link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL322-R335))
*  Replace `getReportETxnc` method with `getReportExpenses` method and update expected values for `expensesAmountSum$` observable and `reportExpensesIds` array in test cases for `loadReports` method ([link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL360-R376), [link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL394-R407), [link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL420-R433), [link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL434-R447), [link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL470-R486), [link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL503-R516))
*  Add `numIssues` property to component props for popover controller create method in test case for `openApproveReportPopover` method ([link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL612-R627))
*  Update expected values for tracking service and router navigate methods and use `mileageExpense` mock object in test cases for `goToTransaction` method ([link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL668-R686), [link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL686-R699), [link](https://github.com/fylein/fyle-mobile-app/pull/2560/files?diff=unified&w=0#diff-f9e80783b99def8ad456e4198384f47f1cf09702205aa82574c31d70a0dcae2bL699-R712))

## Clickup
Please add link here

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes