### PR TITLE
test: Move My Create To Platform: Fixing Tests

### DIFF
--- a/src/app/core/mock-data/platform/v1/expense.data.ts
+++ b/src/app/core/mock-data/platform/v1/expense.data.ts
@@ -421,7 +421,7 @@ export const readyToReportExpensesData: Expense[] = [
   },
 ];
 
-export const nonReImbursableExpense: Expense = {
+export const nonReimbursableExpense: Expense = {
   ...expenseData,
   is_reimbursable: false,
 };

--- a/src/app/core/mock-data/platform/v1/expense.data.ts
+++ b/src/app/core/mock-data/platform/v1/expense.data.ts
@@ -407,3 +407,21 @@ export const perDiemExpenseWithMultipleNumDays: Expense = {
   category: perDiemCategory,
   per_diem_num_days: 3,
 };
+
+export const readyToReportExpensesData: Expense[] = [
+  {
+    ...expenseData,
+    amount: 50,
+    id: 'tx3rb9ZcrTRn',
+  },
+  {
+    ...expenseData,
+    amount: 100,
+    id: 'txWjW9qT2Vf1',
+  },
+];
+
+export const nonReImbursableExpense: Expense = {
+  ...expenseData,
+  is_reimbursable: false,
+};

--- a/src/app/fyle/my-create-report/my-create-report.page.spec.ts
+++ b/src/app/fyle/my-create-report/my-create-report.page.spec.ts
@@ -151,7 +151,7 @@ describe('MyCreateReportPage', () => {
 
   describe('cancel():', () => {
     it('should navigate to my expenses if there are any selected txns', () => {
-      component.selectedTxnIds = ['txfCdl3TEZ7K'];
+      component.selectedExpenseIDs = ['txfCdl3TEZ7K'];
       fixture.detectChanges();
 
       component.cancel();
@@ -159,7 +159,7 @@ describe('MyCreateReportPage', () => {
     });
 
     it('should navigate to my reports if there are no selected txns', () => {
-      component.selectedTxnIds = [];
+      component.selectedExpenseIDs = [];
       fixture.detectChanges();
 
       component.cancel();
@@ -170,7 +170,7 @@ describe('MyCreateReportPage', () => {
   it('sendFirstReportCreated(): should set a new report if first report not created', fakeAsync(() => {
     storageService.get.and.resolveTo(false);
     reportService.getMyReportsCount.and.returnValue(of(0));
-    component.readyToReportEtxns = cloneDeep(selectedExpenses);
+    component.readyToReportExpenses = cloneDeep(selectedExpenses);
     fixture.detectChanges();
 
     component.sendFirstReportCreated();
@@ -241,7 +241,7 @@ describe('MyCreateReportPage', () => {
           purpose: component.reportTitle,
           source: 'MOBILE',
         },
-        [selectedExpenses[0].tx_id, selectedExpenses[1].tx_id],
+        [selectedExpenses[0].tx_id, selectedExpenses[1].tx_id]
       );
       expect(trackingService.createReport).toHaveBeenCalledOnceWith({
         Expense_Count: 2,
@@ -273,7 +273,7 @@ describe('MyCreateReportPage', () => {
     beforeEach(() => {
       spyOn(component, 'getReportTitle');
       component.selectedElements = cloneDeep(selectedExpenses);
-      component.readyToReportEtxns = [];
+      component.readyToReportExpenses = [];
     });
 
     it('should add the expense in selected list', () => {
@@ -295,7 +295,7 @@ describe('MyCreateReportPage', () => {
 
   describe('toggleSelectAll():', () => {
     beforeEach(() => {
-      component.readyToReportEtxns = cloneDeep(apiExpenseRes);
+      component.readyToReportExpenses = cloneDeep(apiExpenseRes);
       spyOn(component, 'getReportTitle');
       fixture.detectChanges();
     });
@@ -312,20 +312,6 @@ describe('MyCreateReportPage', () => {
 
       expect(component.selectedElements).toEqual([]);
       expect(component.getReportTitle).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('getVendorDetails():', () => {
-    it('should return distance with units if expense is of type mileage', () => {
-      const result = component.getVendorDetails(etxncListData.data[0]);
-
-      expect(result).toEqual('13.17 KM');
-    });
-
-    it('should return number of days if expense is of type per diem', () => {
-      const result = component.getVendorDetails(perDiemExpenseSingleNumDays);
-
-      expect(result).toEqual('1 Days');
     });
   });
 
@@ -367,7 +353,7 @@ describe('MyCreateReportPage', () => {
 
       component.checkTxnIds();
 
-      expect(component.selectedTxnIds).toEqual([selectedExpenses[0].tx_id, null]);
+      expect(component.selectedExpenseIDs).toEqual([selectedExpenses[0].tx_id, null]);
     });
 
     it('should set selected txn IDs as empty array if not found in route', () => {
@@ -376,7 +362,7 @@ describe('MyCreateReportPage', () => {
 
       component.checkTxnIds();
 
-      expect(component.selectedTxnIds).toEqual([]);
+      expect(component.selectedExpenseIDs).toEqual([]);
     });
   });
 
@@ -384,10 +370,9 @@ describe('MyCreateReportPage', () => {
     loaderService.showLoader.and.resolveTo();
     loaderService.hideLoader.and.resolveTo();
     transactionService.getAllExpenses.and.returnValue(of(cloneDeep(selectedExpenses)));
-    spyOn(component, 'getVendorDetails').and.returnValue('vendor');
     spyOn(component, 'getReportTitle').and.returnValue(null);
     spyOn(component, 'checkTxnIds');
-    component.selectedTxnIds = [selectedExpenses[0].tx_id];
+    component.selectedExpenseIDs = [selectedExpenses[0].tx_id];
     fixture.detectChanges();
 
     component.ionViewWillEnter();
@@ -403,7 +388,7 @@ describe('MyCreateReportPage', () => {
     });
     expect(loaderService.showLoader).toHaveBeenCalledTimes(1);
     expect(component.getReportTitle).toHaveBeenCalledTimes(1);
-    expect(component.getVendorDetails).toHaveBeenCalledTimes(2);
+
     expect(component.checkTxnIds).toHaveBeenCalledTimes(1);
   }));
 });

--- a/src/app/fyle/my-create-report/my-create-report.page.spec.ts
+++ b/src/app/fyle/my-create-report/my-create-report.page.spec.ts
@@ -28,7 +28,7 @@ import { TrackingService } from '../../core/services/tracking.service';
 import { MyCreateReportPage } from './my-create-report.page';
 import { ExpensesService } from 'src/app/core/services/platform/v1/spender/expenses.service';
 
-fdescribe('MyCreateReportPage', () => {
+describe('MyCreateReportPage', () => {
   let component: MyCreateReportPage;
   let fixture: ComponentFixture<MyCreateReportPage>;
   let transactionService: jasmine.SpyObj<TransactionService>;

--- a/src/app/fyle/my-create-report/my-create-report.page.spec.ts
+++ b/src/app/fyle/my-create-report/my-create-report.page.spec.ts
@@ -12,7 +12,7 @@ import { getElementBySelector } from 'src/app/core/dom-helpers';
 import { selectedExpense1, selectedExpenses } from 'src/app/core/mock-data/expense.data';
 import {
   expenseData,
-  nonReImbursableExpense,
+  nonReimbursableExpense,
   readyToReportExpensesData,
 } from 'src/app/core/mock-data/platform/v1/expense.data';
 import { reportUnflattenedData } from 'src/app/core/mock-data/report-v1.data';
@@ -416,7 +416,7 @@ describe('MyCreateReportPage', () => {
     });
 
     it('should return 0 if there are no re imbursable expenses', () => {
-      expect(component.getTotalSelectedExpensesAmount([nonReImbursableExpense])).toEqual(0);
+      expect(component.getTotalSelectedExpensesAmount([nonReimbursableExpense])).toEqual(0);
     });
   });
 });

--- a/src/app/fyle/my-create-report/my-create-report.page.ts
+++ b/src/app/fyle/my-create-report/my-create-report.page.ts
@@ -86,9 +86,9 @@ export class MyCreateReportPage implements OnInit {
     if (!isFirstReportCreated) {
       this.reportService.getMyReportsCount({}).subscribe(async (allReportsCount) => {
         if (allReportsCount === 0) {
-          const expenses = this.readyToReportExpenses?.filter((etxn) => this.selectedElements.includes(etxn));
+          const expenses = this.readyToReportExpenses.filter((expense) => this.selectedElements.includes(expense));
           const expenesIDs = expenses.map((expense) => expense.id);
-          const selectedTotalAmount = expenses.reduce((acc, obj) => acc + (!obj.is_reimbursable ? 0 : obj.amount), 0);
+          const selectedTotalAmount = this.getTotalSelectedExpensesAmount(expenses);
           this.trackingService.createFirstReport({
             Expense_Count: expenesIDs.length,
             Report_Value: selectedTotalAmount,
@@ -114,7 +114,8 @@ export class MyCreateReportPage implements OnInit {
 
       this.sendFirstReportCreated();
 
-      const expenseIDs = this.selectedElements?.map((expense) => expense.id);
+      let expenseIDs: string[] = [];
+      expenseIDs = this.selectedElements?.map((expense) => expense.id);
 
       if (reportActionType === 'create_draft_report') {
         this.saveDraftReportLoading = true;
@@ -123,12 +124,12 @@ export class MyCreateReportPage implements OnInit {
           .pipe(
             tap(() =>
               this.trackingService.createReport({
-                Expense_Count: expenseIDs.length,
+                Expense_Count: expenseIDs?.length,
                 Report_Value: this.selectedTotalAmount,
               })
             ),
             switchMap((report: ReportV1) => {
-              if (expenseIDs.length > 0) {
+              if (expenseIDs?.length > 0) {
                 return this.reportService.addTransactions(report.id, expenseIDs).pipe(map(() => report));
               } else {
                 return of(report);
@@ -185,10 +186,7 @@ export class MyCreateReportPage implements OnInit {
 
   getReportTitle(): Subscription {
     const expenseIDs = this.selectedElements.map((ele) => ele.id);
-    this.selectedTotalAmount = this.selectedElements.reduce(
-      (acc, obj) => acc + (!obj.is_reimbursable ? 0 : obj.amount),
-      0
-    );
+    this.selectedTotalAmount = this.getTotalSelectedExpensesAmount(this.selectedElements);
 
     if (this.reportTitleInput && !this.reportTitleInput.dirty) {
       return this.reportService.getReportPurpose({ ids: expenseIDs }).subscribe((res) => {
@@ -209,6 +207,7 @@ export class MyCreateReportPage implements OnInit {
 
   ionViewWillEnter(): void {
     this.isSelectedAll = true;
+    this.selectedElements = [];
 
     this.checkTxnIds();
 
@@ -223,15 +222,16 @@ export class MyCreateReportPage implements OnInit {
       .pipe(
         switchMap(() =>
           this.expensesService.getAllExpenses({ queryParams }).pipe(
-            map((etxns) => {
-              etxns.forEach((etxn) => {
+            map((expenses) => {
+              this.selectedElements = expenses;
+              expenses.forEach((expense) => {
                 if (this.selectedExpenseIDs.length > 0) {
-                  if (this.selectedExpenseIDs.indexOf(etxn.id) === -1) {
-                    this.selectedElements.filter((element) => element.id !== etxn.id);
+                  if (this.selectedExpenseIDs.indexOf(expense.id) === -1) {
+                    this.selectedElements.filter((element) => element.id !== expense.id);
                   }
                 }
               });
-              return etxns;
+              return expenses;
             })
           )
         ),
@@ -240,7 +240,6 @@ export class MyCreateReportPage implements OnInit {
       )
       .subscribe((res) => {
         this.readyToReportExpenses = res;
-        this.selectedElements = this.readyToReportExpenses;
         this.getReportTitle();
       });
 
@@ -249,7 +248,7 @@ export class MyCreateReportPage implements OnInit {
 
   checkShowDt(expense: PlatformExpense, i: number): boolean {
     const spentAtDt = expense.spent_at;
-    const prevExpenseSpentAtDt = this.readyToReportExpenses[i - 1].spent_at;
+    const prevExpenseSpentAtDt = this.readyToReportExpenses[i - 1]?.spent_at;
     if (
       i > 0 &&
       spentAtDt &&
@@ -265,5 +264,9 @@ export class MyCreateReportPage implements OnInit {
     this.currencyService.getHomeCurrency().subscribe((homeCurrency) => {
       this.homeCurrency = homeCurrency;
     });
+  }
+
+  getTotalSelectedExpensesAmount(expenses: PlatformExpense[]): number {
+    return expenses.reduce((acc, obj) => acc + (!obj.is_reimbursable ? 0 : obj.amount), 0);
   }
 }

--- a/src/app/fyle/my-create-report/my-create-report.page.ts
+++ b/src/app/fyle/my-create-report/my-create-report.page.ts
@@ -165,9 +165,9 @@ export class MyCreateReportPage implements OnInit {
   }
 
   selectExpense(expense: PlatformExpense): void {
-    const isSelectedElementsIncludesExpense = this.selectedElements.some((expense) => expense.id === expense.id);
+    const isSelectedElementsIncludesExpense = this.selectedElements.some((exp) => exp.id === expense.id);
     if (isSelectedElementsIncludesExpense) {
-      this.selectedElements = this.selectedElements.filter((expense) => expense.id !== expense.id);
+      this.selectedElements = this.selectedElements.filter((exp) => exp.id !== expense.id);
     } else {
       this.selectedElements.push(expense);
     }

--- a/src/app/fyle/my-create-report/my-create-report.page.ts
+++ b/src/app/fyle/my-create-report/my-create-report.page.ts
@@ -129,7 +129,7 @@ export class MyCreateReportPage implements OnInit {
               })
             ),
             switchMap((report: ReportV1) => {
-              if (expenseIDs?.length > 0) {
+              if (expenseIDs?.length) {
                 return this.reportService.addTransactions(report.id, expenseIDs).pipe(map(() => report));
               } else {
                 return of(report);


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3396dd3</samp>

This pull request improves the functionality and testing of the `MyCreateReportPage` component, which allows users to create reports from selected expenses. It uses the new platform model and service methods for expenses, handles edge cases, and avoids array mutation. It also adds mock data for different types of expenses.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3396dd3</samp>

> _To test `MyCreateReportPage`_
> _We added some mock data on stage_
> _We refactored the code_
> _To handle each mode_
> _And used new methods to gauge_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3396dd3</samp>

*  Add mock data for ready to report and non-reimbursable expenses ([link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-24d88c263ca5d224aa35b783df4640316640e6db32915015b6cce6ff83b7a05bR410-R427))
  - Import `ExpensesService` from the platform module and declare a spy object for it ([link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L12-R17), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L30-R31), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03R43), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03R60), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03R110-R113), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03R129))
  - Rename `selectedTxnIds` to `selectedExpenseIDs` and use optional chaining for `expenseIDs` ([link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L154-R161), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L162-R169), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L370-R373), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L379-R382), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e33a2b899a6e74f70b44155fb78ebb6e7719bfe5ff09a9a23561038648ac3794L117-R118), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e33a2b899a6e74f70b44155fb78ebb6e7719bfe5ff09a9a23561038648ac3794L126-R132))
  - Update the methods for sending the first report created event, getting the report title, and creating a report or draft to use the new method for getting the total amount of selected expenses ([link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L173-R193), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L192-R207), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L203-R222), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L318-R335), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L349-R354), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e33a2b899a6e74f70b44155fb78ebb6e7719bfe5ff09a9a23561038648ac3794L89-R91), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e33a2b899a6e74f70b44155fb78ebb6e7719bfe5ff09a9a23561038648ac3794L188-R189))
  - Remove the unused method and import of `getVendorDetails` and the related test cases and spies ([link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L12-R17), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L275-R303), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L298-R313), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L387-R393))
  - Add a new method for getting the total amount of selected expenses that are reimbursable and the related test cases ([link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L275-R303), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e33a2b899a6e74f70b44155fb78ebb6e7719bfe5ff09a9a23561038648ac3794R268-R271))
  - Update the method for getting all expenses to use the new service method, assign the expenses to `selectedElements`, and filter out the expenses that are not in `selectedExpenseIDs` ([link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e33a2b899a6e74f70b44155fb78ebb6e7719bfe5ff09a9a23561038648ac3794L226-R234), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e33a2b899a6e74f70b44155fb78ebb6e7719bfe5ff09a9a23561038648ac3794L243))
  - Reset the `selectedElements` array to an empty array when the report title input is changed ([link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e33a2b899a6e74f70b44155fb78ebb6e7719bfe5ff09a9a23561038648ac3794R210))
  - Add optional chaining to the previous expense spent at date to handle the case when it is undefined ([link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e33a2b899a6e74f70b44155fb78ebb6e7719bfe5ff09a9a23561038648ac3794L252-R251))
  - Update the test cases for `selectExpense`, `toggleSelectAll`, and `ngOnInit` to use the new mock data and service method ([link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L306-R321), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L318-R335), [link](https://github.com/fylein/fyle-mobile-app/pull/2577/files?diff=unified&w=0#diff-e99cd7c1b24fdd0e0242661ffed035227ad84a86d656e6c34dd5e3429a700a03L387-R393))

## Clickup
https://app.clickup.com/t/86ctv3kkf

## Code Coverage
`100% Statements 114/114`
`92.72% Branches 51/55`
`100% Functions 37/37`
`100% Lines 103/103`

## UI Preview
Please add screenshots for UI changes