### PR TITLE
test: Transaction status changes remaining branches

### DIFF
--- a/src/app/core/mock-data/org-settings.data.ts
+++ b/src/app/core/mock-data/org-settings.data.ts
@@ -1262,6 +1262,18 @@ export const orgSettingsWoTax: OrgSettings = {
   },
 };
 
+export const orgSettingsWoTaxAndRtf: OrgSettings = {
+  ...orgSettingsWoTax,
+  visa_enrollment_settings: {
+    allowed: false,
+    enabled: false,
+  },
+  mastercard_enrollment_settings: {
+    allowed: false,
+    enabled: false,
+  },
+};
+
 export const orgSettingsCCCDisabled2: OrgSettings = {
   ...orgSettingsRes,
   corporate_credit_card_settings: null,

--- a/src/app/fyle/add-edit-expense/add-edit-expense-6.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-6.spec.ts
@@ -74,6 +74,8 @@ import { TransactionsOutboxService } from 'src/app/core/services/transactions-ou
 import { multiplePaymentModesData, orgSettingsData } from 'src/app/core/test-data/accounts.service.spec.data';
 import { expectedProjectsResponse } from 'src/app/core/test-data/projects.spec.data';
 import { AddEditExpensePage } from './add-edit-expense.page';
+import { TransactionStatus } from 'src/app/core/models/platform/v1/expense.model';
+import { TransactionStatusInfoPopoverComponent } from 'src/app/shared/components/transaction-status-info-popover/transaction-status-info-popover.component';
 
 export function TestCases6(getTestBed) {
   describe('AddEditExpensePage-6', () => {
@@ -1120,5 +1122,23 @@ export function TestCases6(getTestBed) {
         expect(result).toBeTrue();
       });
     });
+
+    it('openTransactionStatusInfoModal(): should open the transaction status info modal', fakeAsync(() => {
+      const popoverSpy = jasmine.createSpyObj('HTMLIonPopoverElement', ['present']);
+      popoverController.create.and.resolveTo(popoverSpy);
+
+      component.openTransactionStatusInfoModal(TransactionStatus.PENDING);
+
+      tick();
+
+      expect(popoverController.create).toHaveBeenCalledOnceWith({
+        component: TransactionStatusInfoPopoverComponent,
+        componentProps: {
+          transactionStatus: TransactionStatus.PENDING,
+        },
+        cssClass: 'fy-dialog-popover',
+      });
+      expect(popoverSpy.present).toHaveBeenCalledTimes(1);
+    }));
   });
 }

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -472,10 +472,6 @@ export class AddEditExpensePage implements OnInit {
     private expensesService: ExpensesService
   ) {}
 
-  get TransactionStatus(): typeof TransactionStatus {
-    return TransactionStatus;
-  }
-
   get isExpandedView(): boolean {
     return this._isExpandedView;
   }

--- a/src/app/fyle/view-expense/view-expense.page.ts
+++ b/src/app/fyle/view-expense/view-expense.page.ts
@@ -157,10 +157,6 @@ export class ViewExpensePage {
     return ExpenseView;
   }
 
-  get TransactionStatus(): typeof TransactionStatus {
-    return TransactionStatus;
-  }
-
   ionViewWillLeave(): void {
     this.onPageExit.next(null);
   }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 247f3cf</samp>

This pull request updates the test cases and components for the add-edit-expense and view-expense pages to support the platform expense and RTF features. It also removes some redundant getters for the transaction status enum and adds mock data for org settings.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 247f3cf</samp>

> _Mock data for tests_
> _`add-edit-expense` changes_
> _Autumn leaves fall fast_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 247f3cf</samp>

*  Add mock data object for org settings without tax and RTF features ([link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-1cac010b51c1a7c2fbdf9bf224a7e267779365abe08b0f16df1ef46e41483951R1265-R1276))
  * Import mock data and service for platform expenses ([link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-ba304f41b9ceb84ec3edd25c39133e53d238dc01ad0cb7b04fbd999aa2300639L30-R30), [link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-ba304f41b9ceb84ec3edd25c39133e53d238dc01ad0cb7b04fbd999aa2300639R109-R110))
  * Declare and initialize spy object for expenses service ([link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-ba304f41b9ceb84ec3edd25c39133e53d238dc01ad0cb7b04fbd999aa2300639R160), [link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-ba304f41b9ceb84ec3edd25c39133e53d238dc01ad0cb7b04fbd999aa2300639R217))
  * Stub expenses service method to return mock platform expense data ([link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-ba304f41b9ceb84ec3edd25c39133e53d238dc01ad0cb7b04fbd999aa2300639R1358))
  * Test that component detects and enables RTF feature for platform expense ([link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-ba304f41b9ceb84ec3edd25c39133e53d238dc01ad0cb7b04fbd999aa2300639R1404-R1407))
  * Test that component assigns and renders platform expense data ([link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-ba304f41b9ceb84ec3edd25c39133e53d238dc01ad0cb7b04fbd999aa2300639R1472-R1477))
  * Test that component detects and disables RTF feature for platform expense when org settings do not have it ([link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-ba304f41b9ceb84ec3edd25c39133e53d238dc01ad0cb7b04fbd999aa2300639L1613-R1629), [link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-ba304f41b9ceb84ec3edd25c39133e53d238dc01ad0cb7b04fbd999aa2300639R1693-R1696))
  * Test that component does not assign and render platform expense data when RTF feature is disabled ([link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-ba304f41b9ceb84ec3edd25c39133e53d238dc01ad0cb7b04fbd999aa2300639R1760-R1762))
  * Import transaction status enum and component from shared module ([link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-f819d5efa05ff0d70b82a4b7a544bf8cb8a000eaf147d4fc2be232844156469bR77-R78))
  * Test that method creates and presents popover with transaction status info component and passes transaction status as prop ([link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-f819d5efa05ff0d70b82a4b7a544bf8cb8a000eaf147d4fc2be232844156469bR1125-R1142))
  * Use enum directly in component templates ([link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL475-L478), [link](https://github.com/fylein/fyle-mobile-app/pull/2584/files?diff=unified&w=0#diff-717fc694a7c204cc8c4c0a0534c256936252ffa212d988754376936a1fe543a1L160-L163))

## Clickup
https://app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes