### PR TITLE
feat: Use mileage rates API in view mileage page 

### DIFF
--- a/src/app/core/services/mileage-rates.service.spec.ts
+++ b/src/app/core/services/mileage-rates.service.spec.ts
@@ -15,14 +15,17 @@ import { platformMileageRates, platformMileageRatesSingleData } from '../mock-da
 import { of } from 'rxjs';
 import { PAGINATION_SIZE } from 'src/app/constants';
 import { cloneDeep } from 'lodash';
+import { ApproverPlatformApiService } from './approver-platform-api.service';
 
 describe('MileageRatesService', () => {
   let mileageRatesService: MileageRatesService;
   let spenderPlatformV1ApiService: jasmine.SpyObj<SpenderPlatformV1ApiService>;
+  let approverPlatformApiService: jasmine.SpyObj<ApproverPlatformApiService>;
   let currencyPipe: jasmine.SpyObj<CurrencyPipe>;
 
   beforeEach(() => {
     const spenderPlatformV1ApiServiceSpy = jasmine.createSpyObj('SpenderPlatformV1ApiService', ['get']);
+    const approverPlatformApiServiceSpy = jasmine.createSpyObj('ApproverPlatformApiService', ['get']);
     const currencyPipeSpy = jasmine.createSpyObj('CurrencyPipe', ['transform']);
 
     TestBed.configureTestingModule({
@@ -31,6 +34,10 @@ describe('MileageRatesService', () => {
         {
           provide: SpenderPlatformV1ApiService,
           useValue: spenderPlatformV1ApiServiceSpy,
+        },
+        {
+          provide: ApproverPlatformApiService,
+          useValue: approverPlatformApiServiceSpy,
         },
         {
           provide: CurrencyPipe,
@@ -46,6 +53,9 @@ describe('MileageRatesService', () => {
     spenderPlatformV1ApiService = TestBed.inject(
       SpenderPlatformV1ApiService
     ) as jasmine.SpyObj<SpenderPlatformV1ApiService>;
+    approverPlatformApiService = TestBed.inject(
+      ApproverPlatformApiService
+    ) as jasmine.SpyObj<ApproverPlatformApiService>;
 
     currencyPipe = TestBed.inject(CurrencyPipe) as jasmine.SpyObj<CurrencyPipe>;
   });
@@ -158,6 +168,34 @@ describe('MileageRatesService', () => {
       expect(spyGetMileageRates).toHaveBeenCalledTimes(2);
       expect(spyGetMileageRates).toHaveBeenCalledWith(testParams1);
       expect(spyGetMileageRates).toHaveBeenCalledWith(testParams2);
+      done();
+    });
+  });
+
+  it('getSpenderMileageRateById(): should get spender mileage rate by id', (done) => {
+    spenderPlatformV1ApiService.get.and.returnValue(of(platformMileageRatesSingleData));
+    const id = 1234;
+    mileageRatesService.getSpenderMileageRateById(id).subscribe((response) => {
+      expect(response).toEqual(platformMileageRatesSingleData.data[0]);
+      expect(spenderPlatformV1ApiService.get).toHaveBeenCalledOnceWith('/mileage_rates', {
+        params: {
+          id: `eq.${id}`,
+        },
+      });
+      done();
+    });
+  });
+
+  it('getApproverMileageRateById(): should get approver mileage rate by id', (done) => {
+    approverPlatformApiService.get.and.returnValue(of(platformMileageRatesSingleData));
+    const id = 1234;
+    mileageRatesService.getApproverMileageRateById(id).subscribe((response) => {
+      expect(response).toEqual(platformMileageRatesSingleData.data[0]);
+      expect(approverPlatformApiService.get).toHaveBeenCalledOnceWith('/mileage_rates', {
+        params: {
+          id: `eq.${id}`,
+        },
+      });
       done();
     });
   });

--- a/src/app/core/services/mileage-rates.service.ts
+++ b/src/app/core/services/mileage-rates.service.ts
@@ -3,6 +3,7 @@ import { Cacheable } from 'ts-cacheable';
 import { Observable, range, Subject } from 'rxjs';
 import { PlatformMileageRates } from '../models/platform/platform-mileage-rates.model';
 import { SpenderPlatformV1ApiService } from './spender-platform-v1-api.service';
+import { ApproverPlatformApiService } from './approver-platform-api.service';
 import { PlatformApiResponse } from '../models/platform/platform-api-response.model';
 import { CurrencyPipe } from '@angular/common';
 import { switchMap, concatMap, map, reduce } from 'rxjs/operators';
@@ -17,6 +18,7 @@ export class MileageRatesService {
   constructor(
     @Inject(PAGINATION_SIZE) private paginationSize: number,
     private spenderPlatformV1ApiService: SpenderPlatformV1ApiService,
+    private approverPlatformV1ApiService: ApproverPlatformApiService,
     private currencyPipe: CurrencyPipe
   ) {}
 
@@ -85,5 +87,13 @@ export class MileageRatesService {
 
   filterEnabledMileageRates(allMileageRates: PlatformMileageRates[]): PlatformMileageRates[] {
     return allMileageRates.filter((rate) => !!rate.is_enabled);
+  }
+
+  getSpenderMileageRateById(id: number): Observable<PlatformMileageRates> {
+    return this.spenderPlatformV1ApiService.get<PlatformMileageRates>('/mileage_rates/' + id);
+  }
+
+  getApproverMileageRateById(id: number): Observable<PlatformMileageRates> {
+    return this.approverPlatformV1ApiService.get<PlatformMileageRates>('/mileage_rates/' + id);
   }
 }

--- a/src/app/core/services/mileage-rates.service.ts
+++ b/src/app/core/services/mileage-rates.service.ts
@@ -36,6 +36,36 @@ export class MileageRatesService {
     );
   }
 
+  @Cacheable({
+    cacheBusterObserver: mileageRateCacheBuster$,
+  })
+  getSpenderMileageRateById(id: number): Observable<PlatformMileageRates> {
+    const data = {
+      params: {
+        id: `eq.${id}`,
+      },
+    };
+
+    return this.spenderPlatformV1ApiService
+      .get<PlatformApiResponse<PlatformMileageRates>>('/mileage_rates', data)
+      .pipe(map((response) => response.data[0]));
+  }
+
+  @Cacheable({
+    cacheBusterObserver: mileageRateCacheBuster$,
+  })
+  getApproverMileageRateById(id: number): Observable<PlatformMileageRates> {
+    const data = {
+      params: {
+        id: `eq.${id}`,
+      },
+    };
+
+    return this.approverPlatformV1ApiService
+      .get<PlatformApiResponse<PlatformMileageRates>>('/mileage_rates', data)
+      .pipe(map((response) => response.data[0]));
+  }
+
   getAllMileageRatesCount(): Observable<number> {
     const data = {
       params: {
@@ -87,13 +117,5 @@ export class MileageRatesService {
 
   filterEnabledMileageRates(allMileageRates: PlatformMileageRates[]): PlatformMileageRates[] {
     return allMileageRates.filter((rate) => !!rate.is_enabled);
-  }
-
-  getSpenderMileageRateById(id: number): Observable<PlatformMileageRates> {
-    return this.spenderPlatformV1ApiService.get<PlatformMileageRates>('/mileage_rates/' + id);
-  }
-
-  getApproverMileageRateById(id: number): Observable<PlatformMileageRates> {
-    return this.approverPlatformV1ApiService.get<PlatformMileageRates>('/mileage_rates/' + id);
   }
 }

--- a/src/app/fyle/view-mileage/view-mileage.page.html
+++ b/src/app/fyle/view-mileage/view-mileage.page.html
@@ -277,7 +277,7 @@
       </ion-row>
     </ion-grid>
 
-    <ion-grid *ngIf="expense.mileage_rate" class="view-mileage--grid">
+    <ion-grid *ngIf="mileageRate$ | async as mileageRate" class="view-mileage--grid">
       <ion-row>
         <ion-col>
           <ion-grid>
@@ -293,9 +293,8 @@
               <ion-col class="view-mileage--content-container">
                 <div class="view-mileage--label">Mileage Rate</div>
                 <div class="view-mileage--value">
-                  <!-- TODO: Replace 0 with mileage rate amount when backend support is there -->
-                  {{ expense.mileage_rate.vehicle_type | mileageRateName }} ({{ 0 | currency:expense.currency:
-                  'symbol-narrow'}} / {{ expense.distance_unit | titlecase}})
+                  {{ mileageRate.vehicle_type | mileageRateName }} ({{ mileageRate.rate | currency:expense.currency:
+                  'symbol-narrow'}} / {{ mileageRate.unit | titlecase}})
                 </div>
               </ion-col>
             </ion-row>

--- a/src/app/fyle/view-mileage/view-mileage.page.ts
+++ b/src/app/fyle/view-mileage/view-mileage.page.ts
@@ -35,6 +35,8 @@ import { ExpensesService as SpenderExpensesService } from 'src/app/core/services
 import { Expense } from 'src/app/core/models/platform/v1/expense.model';
 import { AccountType } from 'src/app/core/models/platform/v1/account.model';
 import { ExpenseState } from 'src/app/core/models/expense-state.enum';
+import { MileageRatesService } from 'src/app/core/services/mileage-rates.service';
+import { PlatformMileageRates } from 'src/app/core/models/platform/platform-mileage-rates.model';
 
 @Component({
   selector: 'app-view-mileage',
@@ -104,6 +106,8 @@ export class ViewMileagePage {
 
   mapAttachment$: Observable<FileObject>;
 
+  mileageRate$: Observable<PlatformMileageRates>;
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private loaderService: LoaderService,
@@ -123,7 +127,8 @@ export class ViewMileagePage {
     private dependentFieldsService: DependentFieldsService,
     private fileService: FileService,
     private approverExpensesService: ApproverExpensesService,
-    private spenderExpensesService: SpenderExpensesService
+    private spenderExpensesService: SpenderExpensesService,
+    private mileageRatesService: MileageRatesService
   ) {}
 
   get ExpenseView(): typeof ExpenseView {
@@ -384,6 +389,15 @@ export class ViewMileagePage {
           return customProperty;
         })
       )
+    );
+
+    this.mileageRate$ = this.mileageExpense$.pipe(
+      switchMap((expense) => {
+        const id = expense.mileage_rate_id;
+        return this.view === ExpenseView.team
+          ? this.mileageRatesService.getApproverMileageRateById(id)
+          : this.mileageRatesService.getSpenderMileageRateById(id);
+      })
     );
 
     this.canFlagOrUnflag$ = this.mileageExpense$.pipe(


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ee633b1</samp>

This pull request adds the feature to show the latest mileage rates for team expenses from the approver platform API. It modifies the `MileageRatesService`, the `ViewMileagePage` component, and the `view-mileage.page.html` template to fetch and display the rate information.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ee633b1</samp>

> _Oh we're the jolly coders of the `ViewMileagePage`_
> _We fetch the rates from the platform API_
> _We heave and ho and inject the `MileageRatesService`_
> _And display the data with an observable, aye!_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ee633b1</samp>

*  Add `MileageRatesService` to fetch and provide mileage rate information from the platform API ([link](https://github.com/fylein/fyle-mobile-app/pull/2591/files?diff=unified&w=0#diff-3c789edd12fc41da591bd9c248fc12c338269f4526c520850f6146a1f33e8813R6), [link](https://github.com/fylein/fyle-mobile-app/pull/2591/files?diff=unified&w=0#diff-3c789edd12fc41da591bd9c248fc12c338269f4526c520850f6146a1f33e8813R21), [link](https://github.com/fylein/fyle-mobile-app/pull/2591/files?diff=unified&w=0#diff-3c789edd12fc41da591bd9c248fc12c338269f4526c520850f6146a1f33e8813R91-R98))
*  Import `MileageRatesService` and `PlatformMileageRates` model in `view-mileage.page.ts` component ([link](https://github.com/fylein/fyle-mobile-app/pull/2591/files?diff=unified&w=0#diff-1f66dc8a678505b425a50f4d2471159dc2b8c932f372ab63451b24d6db9a19daR38-R39))
*  Inject `MileageRatesService` as a dependency in `ViewMileagePage` class ([link](https://github.com/fylein/fyle-mobile-app/pull/2591/files?diff=unified&w=0#diff-1f66dc8a678505b425a50f4d2471159dc2b8c932f372ab63451b24d6db9a19daL126-R131))
*  Define `mileageRate$` observable in `ViewMileagePage` class to emit `PlatformMileageRates` model for the current expense ([link](https://github.com/fylein/fyle-mobile-app/pull/2591/files?diff=unified&w=0#diff-1f66dc8a678505b425a50f4d2471159dc2b8c932f372ab63451b24d6db9a19daR109-R110), [link](https://github.com/fylein/fyle-mobile-app/pull/2591/files?diff=unified&w=0#diff-1f66dc8a678505b425a50f4d2471159dc2b8c932f372ab63451b24d6db9a19daR394-R402))
*  Use `mileageRate$` observable in `view-mileage.page.html` template to display the vehicle type, rate and unit of the mileage rate from the platform API ([link](https://github.com/fylein/fyle-mobile-app/pull/2591/files?diff=unified&w=0#diff-52c28d7749dea1c87c22dc8b0949ba9eae9a53488b0861818624029d1c09032bL280-R280), [link](https://github.com/fylein/fyle-mobile-app/pull/2591/files?diff=unified&w=0#diff-52c28d7749dea1c87c22dc8b0949ba9eae9a53488b0861818624029d1c09032bL296-R297))

## Clickup
https://app.clickup.com

## Code Coverage
Please add code coverage here