### PR TITLE
feat: Move My Expenses to Platform: Fixed Card Filter Param

### DIFF
--- a/src/app/core/guards/my-expenses-guard.guard.spec.ts
+++ b/src/app/core/guards/my-expenses-guard.guard.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MyExpensesGuardGuard } from './my-expenses-guard.guard';
+import { ActivatedRoute, Router } from '@angular/router';
+import { OrgSettingsService } from '../services/org-settings.service';
+import { of } from 'rxjs';
+import { orgSettingsWithV2ExpensesPage, orgSettingsWoV2ExpensesPage } from '../mock-data/org-settings.data';
+
+fdescribe('MyExpensesGuardGuard', () => {
+  let guard: MyExpensesGuardGuard;
+  let router: jasmine.SpyObj<Router>;
+  let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+  let orgSettingsSerivce: jasmine.SpyObj<OrgSettingsService>;
+
+  beforeEach(() => {
+    const orgSettingsSerivceSpy = jasmine.createSpyObj('OrgSettingsService', ['get']);
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: OrgSettingsService,
+          useValue: orgSettingsSerivceSpy,
+        },
+        {
+          provide: Router,
+          useValue: routerSpy,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: {
+                url: '/enterprise/dashboard',
+                root: null,
+              },
+            },
+          },
+        },
+      ],
+    });
+    guard = TestBed.inject(MyExpensesGuardGuard);
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    orgSettingsSerivce = TestBed.inject(OrgSettingsService) as jasmine.SpyObj<OrgSettingsService>;
+    activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  describe('canActivate():', () => {
+    it('should continue to the new expenses page if enabled', async () => {
+      orgSettingsSerivce.get.and.returnValue(of(orgSettingsWithV2ExpensesPage));
+
+      const result = await guard.canActivate(activatedRoute.snapshot, { url: '/test', root: null });
+
+      expect(result).toBeTrue();
+    });
+
+    it('should redirect to the old page if not enabled', async () => {
+      orgSettingsSerivce.get.and.returnValue(of(orgSettingsWoV2ExpensesPage));
+
+      await guard.canActivate(activatedRoute.snapshot, { url: '/test', root: null });
+
+      expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_expenses']);
+    });
+  });
+});

--- a/src/app/core/guards/my-expenses-guard.guard.ts
+++ b/src/app/core/guards/my-expenses-guard.guard.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+import { OrgSettingsService } from '../services/org-settings.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MyExpensesGuardGuard implements CanActivate {
+  redirectToNewPage = true;
+
+  constructor(private orgSettingsSerivce: OrgSettingsService, private router: Router) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    this.orgSettingsSerivce.get().subscribe((orgSettings) => {
+      if (!orgSettings.mobile_app_my_expenses_beta_enabled) {
+        this.redirectToNewPage = false;
+      }
+    });
+
+    if (!this.redirectToNewPage) {
+      this.router.navigate(['/', 'enterprise', 'my_expenses']);
+    }
+    return this.redirectToNewPage;
+  }
+}

--- a/src/app/core/mock-data/org-settings.data.ts
+++ b/src/app/core/mock-data/org-settings.data.ts
@@ -1351,3 +1351,13 @@ export const orgSettingsWithUnsubscribeEvent: OrgSettings = {
     unsubscribed_events: [EmailEvents.DELEGATOR_SUBSCRIPTION, EmailEvents.EADVANCES_CREATED],
   },
 };
+
+export const orgSettingsWithV2ExpensesPage: OrgSettings = {
+  ...orgSettingsRes,
+  mobile_app_my_expenses_beta_enabled: true,
+};
+
+export const orgSettingsWoV2ExpensesPage: OrgSettings = {
+  ...orgSettingsRes,
+  mobile_app_my_expenses_beta_enabled: false,
+};

--- a/src/app/core/models/org-settings.model.ts
+++ b/src/app/core/models/org-settings.model.ts
@@ -551,4 +551,6 @@ export interface OrgSettings {
   mastercard_enrollment_settings?: CommonOrgSettings;
   company_expenses_beta_settings?: CommonOrgSettings;
   simplified_report_closure_settings?: CommonOrgSettings;
+  mobile_app_my_expenses_beta_enabled?: boolean;
+  view_report_beta_enabled?: boolean;
 }

--- a/src/app/core/services/platform/v1/shared/expense.service.ts
+++ b/src/app/core/services/platform/v1/shared/expense.service.ts
@@ -130,7 +130,7 @@ export class ExpenseService {
     if (filters.cardNumbers?.length > 0) {
       let cardNumberString = '';
       cardNumberString = filters.cardNumbers.join(',');
-      cardNumberString = cardNumberString.slice(0, cardNumberString.length - 1);
+      cardNumberString = cardNumberString.slice(0, cardNumberString.length);
       newQueryParamsCopy['matched_corporate_card_transactions->0->corporate_card_number'] =
         'in.(' + cardNumberString + ')';
     }

--- a/src/app/fyle/fyle-routing.module.ts
+++ b/src/app/fyle/fyle-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { MyExpensesGuardGuard } from '../core/guards/my-expenses-guard.guard';
 
 const routes: Routes = [
   {
@@ -9,6 +10,7 @@ const routes: Routes = [
   {
     path: 'my_expenses-v2',
     loadChildren: () => import('./my-expenses-v2/my-expenses-v2.module').then((m) => m.MyExpensesV2PageModule),
+    canActivate: [MyExpensesGuardGuard],
   },
   {
     path: 'my_expenses',


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c46716d</samp>

Fixed a bug in the expense filter by card number feature that excluded the last card number from the query. Modified the `cardNumberString` variable in `expense.service.ts` to remove the slicing of the last character.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c46716d</samp>

> _`cardNumberString`_
> _No more slicing, bug is fixed_
> _Filter works in fall_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c46716d</samp>

* Fix bug where last card number in filter was not included in query parameter ([link](https://github.com/fylein/fyle-mobile-app/pull/2603/files?diff=unified&w=0#diff-9a808fcce64c2148898fe6d9e1416110d4c58e965864d9951d63a34ba7aaa370L133-R133))

## Clickup
https://app.clickup.com/t/86ctv3kk4

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes