### PR TITLE
feat: Move My Expenses To Platform: Added Route Guard for redirection And Updated Model

### DIFF
--- a/src/app/core/guards/my-expenses-guard.guard.spec.ts
+++ b/src/app/core/guards/my-expenses-guard.guard.spec.ts
@@ -1,16 +1,69 @@
 import { TestBed } from '@angular/core/testing';
 
 import { MyExpensesGuardGuard } from './my-expenses-guard.guard';
+import { ActivatedRoute, Router } from '@angular/router';
+import { OrgSettingsService } from '../services/org-settings.service';
+import { of } from 'rxjs';
+import { orgSettingsWithV2ExpensesPage, orgSettingsWoV2ExpensesPage } from '../mock-data/org-settings.data';
 
-describe('MyExpensesGuardGuard', () => {
+fdescribe('MyExpensesGuardGuard', () => {
   let guard: MyExpensesGuardGuard;
+  let router: jasmine.SpyObj<Router>;
+  let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+  let orgSettingsSerivce: jasmine.SpyObj<OrgSettingsService>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    const orgSettingsSerivceSpy = jasmine.createSpyObj('OrgSettingsService', ['get']);
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: OrgSettingsService,
+          useValue: orgSettingsSerivceSpy,
+        },
+        {
+          provide: Router,
+          useValue: routerSpy,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: {
+                url: '/enterprise/dashboard',
+                root: null,
+              },
+            },
+          },
+        },
+      ],
+    });
     guard = TestBed.inject(MyExpensesGuardGuard);
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    orgSettingsSerivce = TestBed.inject(OrgSettingsService) as jasmine.SpyObj<OrgSettingsService>;
+    activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
   });
 
   it('should be created', () => {
     expect(guard).toBeTruthy();
+  });
+
+  describe('canActivate():', () => {
+    it('should continue to the new expenses page if enabled', async () => {
+      orgSettingsSerivce.get.and.returnValue(of(orgSettingsWithV2ExpensesPage));
+
+      const result = await guard.canActivate(activatedRoute.snapshot, { url: '/test', root: null });
+
+      expect(result).toBeTrue();
+    });
+
+    it('should redirect to the old page if not enabled', async () => {
+      orgSettingsSerivce.get.and.returnValue(of(orgSettingsWoV2ExpensesPage));
+
+      await guard.canActivate(activatedRoute.snapshot, { url: '/test', root: null });
+
+      expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_expenses']);
+    });
   });
 });

--- a/src/app/core/guards/my-expenses-guard.guard.spec.ts
+++ b/src/app/core/guards/my-expenses-guard.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MyExpensesGuardGuard } from './my-expenses-guard.guard';
+
+describe('MyExpensesGuardGuard', () => {
+  let guard: MyExpensesGuardGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(MyExpensesGuardGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/core/guards/my-expenses-guard.guard.ts
+++ b/src/app/core/guards/my-expenses-guard.guard.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+import { OrgSettingsService } from '../services/org-settings.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MyExpensesGuardGuard implements CanActivate {
+  constructor(private orgSettingsSerivce: OrgSettingsService, private router: Router) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    this.orgSettingsSerivce.get().subscribe((orgSettings) => {
+      if (!orgSettings?.mobile_app_my_expenses_beta_enabled) {
+        this.router.navigate(['/', 'enterprise', 'my_expenses']);
+      }
+    });
+    return true;
+  }
+}

--- a/src/app/core/guards/my-expenses-guard.guard.ts
+++ b/src/app/core/guards/my-expenses-guard.guard.ts
@@ -7,6 +7,8 @@ import { OrgSettingsService } from '../services/org-settings.service';
   providedIn: 'root',
 })
 export class MyExpensesGuardGuard implements CanActivate {
+  redirectToNewPage = true;
+
   constructor(private orgSettingsSerivce: OrgSettingsService, private router: Router) {}
 
   canActivate(
@@ -14,10 +16,14 @@ export class MyExpensesGuardGuard implements CanActivate {
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     this.orgSettingsSerivce.get().subscribe((orgSettings) => {
-      if (!orgSettings?.mobile_app_my_expenses_beta_enabled) {
-        this.router.navigate(['/', 'enterprise', 'my_expenses']);
+      if (!orgSettings.mobile_app_my_expenses_beta_enabled) {
+        this.redirectToNewPage = false;
       }
     });
-    return true;
+
+    if (!this.redirectToNewPage) {
+      this.router.navigate(['/', 'enterprise', 'my_expenses']);
+    }
+    return this.redirectToNewPage;
   }
 }

--- a/src/app/core/mock-data/org-settings.data.ts
+++ b/src/app/core/mock-data/org-settings.data.ts
@@ -1351,3 +1351,13 @@ export const orgSettingsWithUnsubscribeEvent: OrgSettings = {
     unsubscribed_events: [EmailEvents.DELEGATOR_SUBSCRIPTION, EmailEvents.EADVANCES_CREATED],
   },
 };
+
+export const orgSettingsWithV2ExpensesPage: OrgSettings = {
+  ...orgSettingsRes,
+  mobile_app_my_expenses_beta_enabled: true,
+};
+
+export const orgSettingsWoV2ExpensesPage: OrgSettings = {
+  ...orgSettingsRes,
+  mobile_app_my_expenses_beta_enabled: false,
+};

--- a/src/app/core/models/org-settings.model.ts
+++ b/src/app/core/models/org-settings.model.ts
@@ -551,4 +551,6 @@ export interface OrgSettings {
   mastercard_enrollment_settings?: CommonOrgSettings;
   company_expenses_beta_settings?: CommonOrgSettings;
   simplified_report_closure_settings?: CommonOrgSettings;
+  mobile_app_my_expenses_beta_enabled?: boolean;
+  view_report_beta_enabled?: boolean;
 }

--- a/src/app/fyle/fyle-routing.module.ts
+++ b/src/app/fyle/fyle-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { MyExpensesGuardGuard } from '../core/guards/my-expenses-guard.guard';
 
 const routes: Routes = [
   {
@@ -9,6 +10,7 @@ const routes: Routes = [
   {
     path: 'my_expenses-v2',
     loadChildren: () => import('./my-expenses-v2/my-expenses-v2.module').then((m) => m.MyExpensesV2PageModule),
+    canActivate: [MyExpensesGuardGuard],
   },
   {
     path: 'my_expenses',


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a39cb71</samp>

This pull request adds a new guard for the `my-expenses-beta` route, which checks the organization settings and redirects the user if the beta feature is disabled. It also adds a test file and two new properties to the `OrgSettings` interface.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a39cb71</samp>

> _To access the beta route of expenses_
> _You need a guard that checks some defenses_
> _It uses `OrgSettingsService`_
> _And `Router` with finesse_
> _To redirect or allow as the case commences_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a39cb71</samp>

*  Add a new guard class `MyExpensesGuardGuard` to check the organization settings and redirect the user if the beta feature is disabled ([link](https://github.com/fylein/fyle-mobile-app/pull/2607/files?diff=unified&w=0#diff-37bc87a5f54c23939dfa87b5be91b770f5995a9dad64d0d4d67780283e6c8e50R1-R23), [link](https://github.com/fylein/fyle-mobile-app/pull/2607/files?diff=unified&w=0#diff-c93d84613627aaadd08e7a7f1d5b20cde2542aacddaf14d50ed5a0676b733036R3), [link](https://github.com/fylein/fyle-mobile-app/pull/2607/files?diff=unified&w=0#diff-c93d84613627aaadd08e7a7f1d5b20cde2542aacddaf14d50ed5a0676b733036R13))
*  Add two new properties to the `OrgSettings` interface to store the beta feature flags ([link](https://github.com/fylein/fyle-mobile-app/pull/2607/files?diff=unified&w=0#diff-7ab4c682c94025cf52d451f9d87c6125129219f7ed1fa32a0ffe24df56d4b38fR554-R555))
*  Add a test file for the `MyExpensesGuardGuard` class and a simple test case to verify its creation ([link](https://github.com/fylein/fyle-mobile-app/pull/2607/files?diff=unified&w=0#diff-e2a717390f614f5357a07f9c56e226af10c8ae8bfb2cef1bfbf27e7ea1ee8e1dR1-R16))

## Clickup
https://app.clickup.com/t/86ctv3kk4

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes