### PR TITLE
fix: Do Not Display Unspecified Category in Dropdown

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -2505,7 +2505,11 @@ export class AddEditExpensePage implements OnInit {
               map((activeCategories) => this.projectsService.getAllowedOrgCategoryIds(project, activeCategories))
             )
           ),
-          map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
+          map((categories) =>
+            categories
+              .map((category) => ({ label: category.displayName, value: category }))
+              .filter((category) => category.value.name !== 'Unspecified')
+          )
         )
       ),
       shareReplay(1)

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -462,7 +462,9 @@ export class AddEditMileagePage implements OnInit {
         )
       ),
       map((categories) =>
-        categories.map((category: OrgCategory) => ({ label: category.sub_category, value: category }))
+        categories
+          .map((category: OrgCategory) => ({ label: category.sub_category, value: category }))
+          .filter((category) => category.value.name !== 'Unspecified')
       )
     );
 

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -675,7 +675,11 @@ export class AddEditPerDiemPage implements OnInit {
           map((activeCategories) => this.projectService.getAllowedOrgCategoryIds(project, activeCategories))
         )
       ),
-      map((categories) => categories.map((category) => ({ label: category.sub_category, value: category })))
+      map((categories) =>
+        categories
+          .map((category) => ({ label: category.sub_category, value: category }))
+          .filter((category) => category.value.name !== 'Unspecified')
+      )
     );
     const formValue = this.getFormValues();
     this.filteredCategories$.subscribe((categories) => {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6ae4f88</samp>

Filter out the 'Unspecified' category from the category list for different types of expenses. This avoids users selecting an invalid category that does not comply with the org policies or projects. The change affects the files `add-edit-expense.page.ts`, `add-edit-mileage.page.ts`, and `add-edit-per-diem.page.ts`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6ae4f88</samp>

> _`Unspecified` gone_
> _Categories depend on_
> _Expense type and org_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6ae4f88</samp>

*  Filter out 'Unspecified' category from expense categories ([link](https://github.com/fylein/fyle-mobile-app/pull/2608/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL2508-R2512), [link](https://github.com/fylein/fyle-mobile-app/pull/2608/files?diff=unified&w=0#diff-04c216da6200af711aa0f53bcd7e253086762b5d123b0729fac3b1862ec5fc3eL465-R467), [link](https://github.com/fylein/fyle-mobile-app/pull/2608/files?diff=unified&w=0#diff-b6e1f6e315ef2edc53799d40c1304deff11e97673e1003986d199937196dda0dL678-R682))

## Clickup
https://app.clickup.com/t/86ctxwkgc

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes