### PR TITLE
test: Move Potential Duplicates to Platform: Fixed Unit Test

### DIFF
--- a/src/app/core/mock-data/duplicate-sets.data.ts
+++ b/src/app/core/mock-data/duplicate-sets.data.ts
@@ -9,3 +9,8 @@ export const duplicateSetData2: DuplicateSet = {
   fields: ['field1', 'field2'],
   transaction_ids: ['tx5fBcPBAxLv', 'tx3nHShG60zq'],
 };
+
+export const duplicateSetData3: DuplicateSet = {
+  fields: ['field1', 'field2'],
+  transaction_ids: ['txe0bYaJlRJf', 'txDDLtRaflUW'],
+};

--- a/src/app/fyle/potential-duplicates/potential-duplicates.page.ts
+++ b/src/app/fyle/potential-duplicates/potential-duplicates.page.ts
@@ -65,7 +65,6 @@ export class PotentialDuplicatesPage {
             return this.expensesService
               .getExpenses({
                 offset: 0,
-
                 ...queryParams,
               })
               .pipe(


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d58ca5</samp>

Refactor potential duplicates page and tests to use expensesService and new mock data. Update router navigation to match new expense model and merge expense page design. Remove unused import of transactionService.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d58ca5</samp>

> _`expensesService`_
> _replaces `transactionService`_
> _spring cleaning the code_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d58ca5</samp>

*  Add new mock data for duplicate sets, which is used for testing the potential duplicates page ([link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-08994ab67f55c1a7ea9ee90f7380a90fbd85abd94db9dbeee14f217f2cb1ebdfR12-R16))
*  Replace the transactionService with the expensesService to get expenses by ids in the potential duplicates page and its tests, as per the new expense model ([link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L7-R7), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R15-R17), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L21-R32), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R41), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L47-R52), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R68-R71), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L76-R85), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L94-R101), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L101-R117), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L115-R124), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L187-R210), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL68))
*  Update the test cases for populating duplicate sets, going to tasks page, adding expense details, dismissing and merging expenses, and going to transaction, to use the new mock data for duplicate sets and expenses, and to match the new query params and arguments ([link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L94-R101), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L101-R117), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L115-R124), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L123-R139), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L151-R169), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L171-R181), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L187-R210), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L205-R218), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L242-R255), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L248-R261))
*  Use the cloneDeep function from lodash to copy the mock data without mutating the original in the test cases for dismissing expenses ([link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R15-R17), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L151-R169), [link](https://github.com/fylein/fyle-mobile-app/pull/2611/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L171-R181))

## Clickup
https://app.clickup.com/t/86cu0ynta

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes