### PR TITLE
fix: Make the entire transaction status clickable

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -190,7 +190,7 @@
                 >
                   <app-transaction-status
                     [transactionStatus]="transactionStatus"
-                    (infoClick)="openTransactionStatusInfoModal($event)"
+                    (statusClick)="openTransactionStatusInfoModal($event)"
                   ></app-transaction-status>
                 </div>
               </ng-container>

--- a/src/app/fyle/view-expense/view-expense.page.html
+++ b/src/app/fyle/view-expense/view-expense.page.html
@@ -117,7 +117,7 @@
           >
             <app-transaction-status
               [transactionStatus]="transactionStatus"
-              (infoClick)="openTransactionStatusInfoModal($event)"
+              (statusClick)="openTransactionStatusInfoModal($event)"
             ></app-transaction-status>
           </div>
         </ng-container>

--- a/src/app/shared/components/transaction-status/transaction-status.component.html
+++ b/src/app/shared/components/transaction-status/transaction-status.component.html
@@ -8,12 +8,13 @@
   ></div>
 
   Transaction Status:
-  <span class="transaction-status__status-value" data-testid="status-value">{{ transactionStatus | titlecase }}</span>
+  <div (click)="statusClick.emit(transactionStatus)" class="transaction-status__status-value-container">
+    <span class="transaction-status__status-value" data-testid="status-value">{{ transactionStatus | titlecase }}</span>
 
-  <ion-icon
-    src="../../../assets/svg/info-circle-outline.svg"
-    class="transaction-status__info-icon"
-    (click)="infoClick.emit(transactionStatus)"
-    data-testid="info-icon"
-  ></ion-icon>
+    <ion-icon
+      src="../../../assets/svg/info-circle-outline.svg"
+      class="transaction-status__info-icon"
+      data-testid="info-icon"
+    ></ion-icon>
+  </div>
 </div>

--- a/src/app/shared/components/transaction-status/transaction-status.component.scss
+++ b/src/app/shared/components/transaction-status/transaction-status.component.scss
@@ -21,6 +21,11 @@
     }
   }
 
+  &__status-value-container {
+    display: flex;
+    align-items: center;
+  }
+
   &__status-value {
     color: $blue-black;
     font-weight: 500;

--- a/src/app/shared/components/transaction-status/transaction-status.component.spec.ts
+++ b/src/app/shared/components/transaction-status/transaction-status.component.spec.ts
@@ -24,13 +24,13 @@ describe('TransactionStatusComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should emit the infoClick event when clicked on the info icon', () => {
-    spyOn(component.infoClick, 'emit');
+  it('should emit the statusClick event when clicked on the info icon', () => {
+    spyOn(component.statusClick, 'emit');
 
     const infoIcon = getElementBySelector(fixture, '[data-testid="info-icon"]') as HTMLButtonElement;
     infoIcon.click();
 
-    expect(component.infoClick.emit).toHaveBeenCalledTimes(1);
+    expect(component.statusClick.emit).toHaveBeenCalledTimes(1);
   });
 
   describe('template', () => {

--- a/src/app/shared/components/transaction-status/transaction-status.component.ts
+++ b/src/app/shared/components/transaction-status/transaction-status.component.ts
@@ -9,7 +9,7 @@ import { TransactionStatus } from 'src/app/core/models/platform/v1/expense.model
 export class TransactionStatusComponent {
   @Input() transactionStatus: TransactionStatus;
 
-  @Output() infoClick: EventEmitter<TransactionStatus> = new EventEmitter<TransactionStatus>();
+  @Output() statusClick: EventEmitter<TransactionStatus> = new EventEmitter<TransactionStatus>();
 
   get TransactionStatus(): typeof TransactionStatus {
     return TransactionStatus;


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 35dcd1c</samp>

Renamed the `infoClick` output event of the `app-transaction-status` component to `statusClick` and made the entire transaction status value clickable. This improves the usability and clarity of the component in the `add-edit-expense` and `view-expense` pages.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 35dcd1c</samp>

> _`statusClick` event_
> _renamed and expanded for clarity_
> _autumn of refactoring_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 35dcd1c</samp>

*  Rename `infoClick` output event to `statusClick` in `app-transaction-status` component and its usage in `add-edit-expense.page.html` and `view-expense.page.html` ([link](https://github.com/fylein/fyle-mobile-app/pull/2618/files?diff=unified&w=0#diff-222fd948c0d0cdfd9422c33d7e78705dddeb3bb00664d65ab64f77331691bf2cL193-R193), [link](https://github.com/fylein/fyle-mobile-app/pull/2618/files?diff=unified&w=0#diff-38bc8efb9ce49f72845a76cfe9045d647245f157542e5281df732a05304ba5dcL120-R120), [link](https://github.com/fylein/fyle-mobile-app/pull/2618/files?diff=unified&w=0#diff-a58ef37ce0d9cdeb0118cd551bc7e522a9d63f612e5b019e45e67c34059bc339L12-R12), [link](https://github.com/fylein/fyle-mobile-app/pull/2618/files?diff=unified&w=0#diff-26eb47e9a1067bcf9ef8297c4f520437935315681edf0da50b1ef7edafa54ed5L27-R33))
*  Wrap status value and info icon in a clickable container that emits `statusClick` event in `transaction-status.component.html` ([link](https://github.com/fylein/fyle-mobile-app/pull/2618/files?diff=unified&w=0#diff-30e57d6da19b1adf02d549c43ae6acee0e0ebd58c5ddddb5dc691d1fc3926edeL11-R19))
*  Style the container with flexbox to align its children in `transaction-status.component.scss` ([link](https://github.com/fylein/fyle-mobile-app/pull/2618/files?diff=unified&w=0#diff-5cbbfb084c53278c092a2d89e4731d3f2533d905ca0d023b6df591f5ab4541cdR24-R28))

## Clickup
https://app.clickup.com