### PR TITLE
test: Move Suggested Duplicates to Platform: Fixed Test

### DIFF
--- a/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.spec.ts
+++ b/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.spec.ts
@@ -7,7 +7,7 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { SuggestedDuplicatesComponent } from './suggested-duplicates.component';
 import { HandleDuplicatesService } from 'src/app/core/services/handle-duplicates.service';
 import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
-import { TransactionService } from 'src/app/core/services/transaction.service';
+import { ExpensesService } from 'src/app/core/services/platform/v1/spender/expenses.service';
 import { ToastMessageComponent } from 'src/app/shared/components/toast-message/toast-message.component';
 import { Router } from '@angular/router';
 import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar';
@@ -15,15 +15,15 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
-import { etxncData } from 'src/app/core/mock-data/expense.data';
 import { getAllElementsBySelector, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
+import { apiExpenses1, expenseData } from 'src/app/core/mock-data/platform/v1/expense.data';
 
 describe('SuggestedDuplicatesComponent', () => {
   let component: SuggestedDuplicatesComponent;
   let fixture: ComponentFixture<SuggestedDuplicatesComponent>;
   let modalController: jasmine.SpyObj<ModalController>;
   let handleDuplicatesService: jasmine.SpyObj<HandleDuplicatesService>;
-  let transactionService: jasmine.SpyObj<TransactionService>;
+  let expensesService: jasmine.SpyObj<ExpensesService>;
   let snackbarPropertiesService: jasmine.SpyObj<SnackbarPropertiesService>;
   let matSnackBar: jasmine.SpyObj<MatSnackBar>;
   let router: jasmine.SpyObj<Router>;
@@ -31,7 +31,7 @@ describe('SuggestedDuplicatesComponent', () => {
   beforeEach(waitForAsync(() => {
     const modalControllerSpy = jasmine.createSpyObj('ModalController', ['dismiss']);
     const handleDuplicatesServiceSpy = jasmine.createSpyObj('HandleDuplicatesService', ['dismissAll']);
-    const transactionServiceSpy = jasmine.createSpyObj('TransactionService', ['getETxnc']);
+    const expensesServiceSpy = jasmine.createSpyObj('ExpensesService', ['getExpenses']);
     const matSnackBarSpy = jasmine.createSpyObj('MatSnackBar', ['openFromComponent']);
     const snackbarPropertiesServiceSpy = jasmine.createSpyObj('SnackbarPropertiesService', ['setSnackbarProperties']);
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
@@ -50,7 +50,7 @@ describe('SuggestedDuplicatesComponent', () => {
       providers: [
         { provide: ModalController, useValue: modalControllerSpy },
         { provide: HandleDuplicatesService, useValue: handleDuplicatesServiceSpy },
-        { provide: TransactionService, useValue: transactionServiceSpy },
+        { provide: ExpensesService, useValue: expensesServiceSpy },
         { provide: MatSnackBar, useValue: matSnackBarSpy },
         { provide: SnackbarPropertiesService, useValue: snackbarPropertiesServiceSpy },
         { provide: Router, useValue: routerSpy },
@@ -60,14 +60,18 @@ describe('SuggestedDuplicatesComponent', () => {
 
     modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
     handleDuplicatesService = TestBed.inject(HandleDuplicatesService) as jasmine.SpyObj<HandleDuplicatesService>;
-    transactionService = TestBed.inject(TransactionService) as jasmine.SpyObj<TransactionService>;
+    expensesService = TestBed.inject(ExpensesService) as jasmine.SpyObj<ExpensesService>;
     snackbarPropertiesService = TestBed.inject(SnackbarPropertiesService) as jasmine.SpyObj<SnackbarPropertiesService>;
     matSnackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
     router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
 
     fixture = TestBed.createComponent(SuggestedDuplicatesComponent);
     component = fixture.componentInstance;
-    component.duplicateExpenses = [{ tx_id: 'tx1ZvrMjIj4W' }, { tx_id: 'tx8v1PZSUxy5' }, { tx_id: 'txKW3vYo8W2v' }];
+    component.duplicateExpenses = [
+      { ...expenseData, id: 'tx1ZvrMjIj4W' },
+      { ...expenseData, id: 'tx8v1PZSUxy5' },
+      { ...expenseData, id: 'txKW3vYo8W2v' },
+    ];
     fixture.detectChanges();
   }));
 
@@ -104,8 +108,8 @@ describe('SuggestedDuplicatesComponent', () => {
   });
 
   it('should dismiss the modal and navigate to the merge expense page', () => {
-    const getETxncSpy = transactionService.getETxnc.and.returnValue(of(etxncData.data));
-    const selectedExpenses = etxncData.data;
+    const getETxncSpy = expensesService.getExpenses.and.returnValue(of(apiExpenses1));
+    const selectedExpenses = apiExpenses1;
     component.mergeExpenses();
     fixture.detectChanges();
     expect(modalController.dismiss).toHaveBeenCalledTimes(1);
@@ -114,14 +118,14 @@ describe('SuggestedDuplicatesComponent', () => {
       'enterprise',
       'merge_expense',
       {
-        selectedElements: JSON.stringify(selectedExpenses),
+        expenseIDs: JSON.stringify(selectedExpenses.map((exp) => exp.id)),
         from: 'EDIT_EXPENSE',
       },
     ]);
     expect(getETxncSpy).toHaveBeenCalledOnceWith({
       offset: 0,
       limit: 10,
-      params: { tx_id: 'in.(tx1ZvrMjIj4W,tx8v1PZSUxy5,txKW3vYo8W2v)' },
+      queryParams: { id: 'in.(tx1ZvrMjIj4W,tx8v1PZSUxy5,txKW3vYo8W2v)' },
     });
   });
 
@@ -143,9 +147,9 @@ describe('SuggestedDuplicatesComponent', () => {
   it('should display the correct header information', () => {
     const expectedHeader = '3 expenses for $100.50';
     component.duplicateExpenses = [
-      { tx_amount: 100.5, tx_currency: 'USD' },
-      { tx_amount: 100.5, tx_currency: 'USD' },
-      { tx_amount: 100.5, tx_currency: 'USD' },
+      { ...expenseData, amount: 100.5, currency: 'USD' },
+      { ...expenseData, amount: 100.5, currency: 'USD' },
+      { ...expenseData, amount: 100.5, currency: 'USD' },
     ];
 
     const headerEl = getElementBySelector(fixture, '.suggested-duplicates--header');
@@ -154,7 +158,7 @@ describe('SuggestedDuplicatesComponent', () => {
   });
 
   it('should display correct number of expense cards', () => {
-    const expenseCardEls = getAllElementsBySelector(fixture, 'app-expense-card');
+    const expenseCardEls = getAllElementsBySelector(fixture, 'app-expense-card-v2');
     fixture.detectChanges();
     expect(expenseCardEls.length).toBe(component.duplicateExpenses.length);
   });


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c40be1a</samp>

This pull request refactors the suggested-duplicates component spec file to match the new expense model and UI. It uses the `ExpensesService` and the `expense card` component to test the duplicate detection and navigation logic. It also updates the mock data and parameters to use the new expense ids.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c40be1a</samp>

> _The spec file for suggested-duplicates_
> _Was updated with some new attributes_
> _It used `ExpensesService`_
> _And `expenseData` for this_
> _And changed the ids and the routes_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c40be1a</samp>

*  Migrate from the old expense model to the new platform expense model ([link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L10-R10), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L18-R19), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L26-R26), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L34-R34), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L53-R53), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L63-R63), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L70-R74), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L107-R112), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L117-R121), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L124-R128), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L146-R152), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L157-R161))
  * Replace `TransactionService` with `ExpensesService` in imports, declarations, providers, injections, and spy objects ([link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L10-R10), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L26-R26), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L34-R34), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L53-R53), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L63-R63))
  * Replace `etxncData` with `apiExpenses1` and `expenseData` in mock data objects and assignments ([link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L18-R19), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L70-R74), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L107-R112), [link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L146-R152))
  * Replace `transactionService.getETxnc` with `expensesService.getExpenses` in service calls ([link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L107-R112))
  * Replace `selectedElements` with `expenseIDs` in navigation parameters ([link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L117-R121))
  * Replace `tx_id` with `id` in query parameters ([link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L124-R128))
  * Replace `app-expense-card` with `app-expense-card-v2` in component selectors ([link](https://github.com/fylein/fyle-mobile-app/pull/2620/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L157-R161))

## Clickup
https://app.clickup.com/t/86cu0yntq

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes