### PR TITLE
feat: added the routing guard for beta pages

### DIFF
--- a/src/app/core/guards/beta-page-feature-flag.guard.spec.ts
+++ b/src/app/core/guards/beta-page-feature-flag.guard.spec.ts
@@ -1,0 +1,77 @@
+import { ActivatedRoute, Router } from '@angular/router';
+import { OrgSettingsService } from '../services/org-settings.service';
+import { BetaPageFeatureFlagGuard } from './beta-page-feature-flag.guard';
+import { TestBed } from '@angular/core/testing';
+import { Observable, of } from 'rxjs';
+import { routerStateSnapshotData } from '../mock-data/router-state-snapshot.data';
+
+describe('BetaPageFeatureFlagGuard', () => {
+  let guard: BetaPageFeatureFlagGuard;
+  let orgSettingsService: jasmine.SpyObj<OrgSettingsService>;
+  let router: jasmine.SpyObj<Router>;
+  let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+
+  beforeEach(() => {
+    const orgSettingsServiceSpy = jasmine.createSpyObj('OrgSettingsService', ['isBetaPageEnabledForPath']);
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: OrgSettingsService,
+          useValue: orgSettingsServiceSpy,
+        },
+        {
+          provide: Router,
+          useValue: routerSpy,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              routeConfig: {
+                path: 'my_view_report',
+              },
+              data: {
+                url: '/enterprise/my_view_report',
+                root: null,
+              },
+            },
+          },
+        },
+      ],
+    });
+    guard = TestBed.inject(BetaPageFeatureFlagGuard);
+    orgSettingsService = TestBed.inject(OrgSettingsService) as jasmine.SpyObj<OrgSettingsService>;
+    activatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  describe('canActivate(): ', () => {
+    it('Should navigate to the beta page if the feature flag is enabled', (done) => {
+      orgSettingsService.isBetaPageEnabledForPath.and.returnValue(of(true));
+      const canActivate = guard.canActivate(activatedRoute.snapshot, routerStateSnapshotData) as Observable<boolean>;
+      canActivate.subscribe((res) => {
+        expect(orgSettingsService.isBetaPageEnabledForPath).toHaveBeenCalledTimes(1);
+        expect(res).toBeFalse();
+        expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'my_view_report_beta', {}]);
+        done();
+      });
+    });
+
+    it('Should navigate to the correct page if the feature flag is disabled', (done) => {
+      orgSettingsService.isBetaPageEnabledForPath.and.returnValue(of(false));
+      const canActivate = guard.canActivate(activatedRoute.snapshot, routerStateSnapshotData) as Observable<boolean>;
+      canActivate.subscribe((res) => {
+        expect(orgSettingsService.isBetaPageEnabledForPath).toHaveBeenCalledTimes(1);
+        expect(res).toBeTrue();
+        expect(router.navigate).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+});

--- a/src/app/core/guards/beta-page-feature-flag.guard.ts
+++ b/src/app/core/guards/beta-page-feature-flag.guard.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable, map, of } from 'rxjs';
+import { OrgSettingsService } from '../services/org-settings.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BetaPageFeatureFlagGuard implements CanActivate {
+  constructor(private orgSettingsService: OrgSettingsService, private router: Router) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    const currentPath = route.routeConfig && route.routeConfig.path;
+
+    if (currentPath) {
+      return this.orgSettingsService.isBetaPageEnabledForPath(currentPath).pipe(
+        map((isBetaPageEnabled) => {
+          if (isBetaPageEnabled) {
+            this.router.navigate(['/', 'enterprise', `${currentPath}_beta`, { ...route.params }]);
+            return false;
+          }
+          return true;
+        })
+      );
+    } else {
+      return of(true);
+    }
+  }
+}

--- a/src/app/core/services/org-settings.service.ts
+++ b/src/app/core/services/org-settings.service.ts
@@ -36,6 +36,15 @@ export class OrgSettingsService {
     return this.apiService.post('/org/settings', data);
   }
 
+  isBetaPageEnabledForPath(currentPath: string): Observable<boolean> {
+    const pathSettingsFlagMap = {
+      my_view_report: 'mobile_app_view_report_beta_enabled',
+      view_team_report: 'mobile_app_view_report_beta_enabled',
+    };
+    const featureFlag = pathSettingsFlagMap[currentPath];
+    return this.get().pipe(map((orgSettings: OrgSettings) => orgSettings[featureFlag]));
+  }
+
   getIncomingAccountingObject(incomingAccountExport: AccountingExportSettings): IncomingAccountObject {
     const accounting: IncomingAccountObject = {
       enabled: false,


### PR DESCRIPTION
### Description
https://app.clickup.com/t/86ctz82q6
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7d8b78a</samp>

This pull request adds a new guard class `BetaPageFeatureFlagGuard` and its test file to the core module. The guard checks if a beta page feature flag is enabled for a given route and redirects to the beta page if so. This allows the app to display different versions of pages based on the feature flag settings.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7d8b78a</samp>

> _`BetaPageFeatureFlagGuard`_
> _Checks and redirects the route_
> _A new guard in spring_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7d8b78a</samp>

*  Implement a guard to check and redirect to beta pages based on feature flags ([link](https://github.com/fylein/fyle-mobile-app/pull/2627/files?diff=unified&w=0#diff-2826eacf9c7cacfc884f6f686eacff7fbe72a82ff70623debf5c45d79ef0ddbaR1-R32),[link](https://github.com/fylein/fyle-mobile-app/pull/2627/files?diff=unified&w=0#diff-8f8a541e9bcd57ffadf6c8e67f351f239e9fcf71fad6915250e276fe2094817fR1-R77))
  - Create a new guard file `beta-page-feature-flag.guard.ts` that defines the `BetaPageFeatureFlagGuard` class ([link](https://github.com/fylein/fyle-mobile-app/pull/2627/files?diff=unified&w=0#diff-2826eacf9c7cacfc884f6f686eacff7fbe72a82ff70623debf5c45d79ef0ddbaR1-R32))
  - Create a new test file `beta-page-feature-flag.guard.spec.ts` that tests the guard functionality ([link](https://github.com/fylein/fyle-mobile-app/pull/2627/files?diff=unified&w=0#diff-8f8a541e9bcd57ffadf6c8e67f351f239e9fcf71fad6915250e276fe2094817fR1-R77))

## Clickup
Please add link here

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes