### PR TITLE
feat: Move Potential Duplicates To Platform: Moved API Calls

### DIFF
--- a/src/app/fyle/my-expenses-v2/my-expenses-v2.page.ts
+++ b/src/app/fyle/my-expenses-v2/my-expenses-v2.page.ts
@@ -1553,13 +1553,13 @@ export class MyExpensesV2Page implements OnInit {
   }
 
   mergeExpenses(): void {
-    const txnIDs = this.selectedElements.map((expense) => expense.id);
+    const expenseIDs = this.selectedElements.map((expense) => expense.id);
     this.router.navigate([
       '/',
       'enterprise',
       'merge_expense',
       {
-        txnIDs: JSON.stringify(txnIDs),
+        expenseIDs: JSON.stringify(expenseIDs),
         from: 'MY_EXPENSES',
       },
     ]);

--- a/src/app/fyle/my-expenses/my-expenses.page.ts
+++ b/src/app/fyle/my-expenses/my-expenses.page.ts
@@ -1450,13 +1450,13 @@ export class MyExpensesPage implements OnInit {
   }
 
   mergeExpenses(): void {
-    const txnIDs = this.selectedElements.map((expense) => expense.tx_id);
+    const expenseIDs = this.selectedElements.map((expense) => expense.tx_id);
     this.router.navigate([
       '/',
       'enterprise',
       'merge_expense',
       {
-        txnIDs: JSON.stringify(txnIDs),
+        expenseIDs: JSON.stringify(expenseIDs),
         from: 'MY_EXPENSES',
       },
     ]);

--- a/src/app/fyle/potential-duplicates/potential-duplicates.page.html
+++ b/src/app/fyle/potential-duplicates/potential-duplicates.page.html
@@ -22,12 +22,12 @@
     <div class="potential-duplicates--container" *ngIf="!isLoading">
       <ng-container *ngFor="let duplicatesSet of duplicateExpenses; let setIndex=index">
         <div *ngIf="setIndex === selectedSet" class="potential-duplicates--header text-center">
-          {{duplicatesSet?.length}} expenses for {{ duplicatesSet[0].tx_amount | currency: duplicatesSet[0].tx_currency:
+          {{duplicatesSet?.length}} expenses for {{ duplicatesSet[0].amount | currency: duplicatesSet[0].currency:
           'symbol-narrow' }}
         </div>
         <ng-container *ngFor="let expense of duplicatesSet as list; let i = index;">
           <ng-container *ngIf="setIndex === selectedSet">
-            <app-expense-card
+            <app-expense-card-v2
               [showDt]="false"
               [isFromPotentialDuplicates]="true"
               [expense]="expense"
@@ -35,7 +35,7 @@
               (dismissed)="dismiss($event)"
               (goToTransaction)="goToTransaction($event)"
             >
-            </app-expense-card>
+            </app-expense-card-v2>
           </ng-container>
         </ng-container>
       </ng-container>

--- a/src/app/fyle/potential-duplicates/potential-duplicates.page.ts
+++ b/src/app/fyle/potential-duplicates/potential-duplicates.page.ts
@@ -3,12 +3,12 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { Params, Router } from '@angular/router';
 import { BehaviorSubject, EMPTY, Observable, noop } from 'rxjs';
 import { finalize, map, switchMap, tap } from 'rxjs/operators';
-import { Expense } from 'src/app/core/models/expense.model';
+import { Expense } from 'src/app/core/models/platform/v1/expense.model';
 import { DuplicateSet } from 'src/app/core/models/v2/duplicate-sets.model';
 import { HandleDuplicatesService } from 'src/app/core/services/handle-duplicates.service';
 import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
 import { TrackingService } from 'src/app/core/services/tracking.service';
-import { TransactionService } from 'src/app/core/services/transaction.service';
+import { ExpensesService } from 'src/app/core/services/platform/v1/spender/expenses.service';
 import { ToastMessageComponent } from 'src/app/shared/components/toast-message/toast-message.component';
 
 type Expenses = Expense[];
@@ -33,7 +33,7 @@ export class PotentialDuplicatesPage {
 
   constructor(
     private handleDuplicates: HandleDuplicatesService,
-    private transaction: TransactionService,
+    private expensesService: ExpensesService,
     private router: Router,
     private snackbarProperties: SnackbarPropertiesService,
     private matSnackBar: MatSnackBar,
@@ -57,17 +57,25 @@ export class PotentialDuplicatesPage {
             const duplicateIds = duplicateSets
               .map((value) => value.transaction_ids)
               .reduce((acc, curVal) => acc.concat(curVal), []);
-            const params = {
-              tx_id: `in.(${duplicateIds.join(',')})`,
+
+            const queryParams = {
+              id: `in.(${duplicateIds.join(',')})`,
             };
-            return this.transaction.getETxnc({ offset: 0, limit: 10, params }).pipe(
-              map((expenses) => {
-                const expensesArray = expenses as [];
-                return duplicateSets.map((duplicateSet) =>
-                  this.addExpenseDetailsToDuplicateSets(duplicateSet, expensesArray)
-                );
+
+            return this.expensesService
+              .getExpenses({
+                offset: 0,
+
+                ...queryParams,
               })
-            );
+              .pipe(
+                map((expenses) => {
+                  const expensesArray = expenses as [];
+                  return duplicateSets.map((duplicateSet) =>
+                    this.addExpenseDetailsToDuplicateSets(duplicateSet, expensesArray)
+                  );
+                })
+              );
           }),
           finalize(() => {
             this.isLoading = false;
@@ -82,7 +90,7 @@ export class PotentialDuplicatesPage {
 
   addExpenseDetailsToDuplicateSets(duplicateSet: DuplicateSet, expensesArray: Expense[]): Expense[] {
     return duplicateSet.transaction_ids.map(
-      (expenseId) => expensesArray[expensesArray.findIndex((duplicateTxn: Expense) => expenseId === duplicateTxn.tx_id)]
+      (expenseId) => expensesArray[expensesArray.findIndex((duplicateTxn: Expense) => expenseId === duplicateTxn.id)]
     );
   }
 
@@ -95,16 +103,16 @@ export class PotentialDuplicatesPage {
   }
 
   dismiss(expense: Expense): void {
-    const transactionIds = [expense.tx_id];
+    const transactionIds = [expense.id];
     const duplicateTxnIds = this.duplicateSetData[this.selectedSet].transaction_ids;
     this.handleDuplicates.dismissAll(duplicateTxnIds, transactionIds).subscribe(() => {
       this.trackingService.dismissedIndividualExpenses();
       this.showDismissedSuccessToast();
       this.duplicateSetData[this.selectedSet].transaction_ids = this.duplicateSetData[
         this.selectedSet
-      ].transaction_ids.filter((expId) => expId !== expense.tx_id);
+      ].transaction_ids.filter((expId) => expId !== expense.id);
       this.duplicateExpenses[this.selectedSet] = this.duplicateExpenses[this.selectedSet].filter(
-        (exp) => exp.tx_id !== expense.tx_id
+        (exp) => exp.id !== expense.id
       );
     });
   }
@@ -126,21 +134,30 @@ export class PotentialDuplicatesPage {
 
   mergeExpense(): void {
     const selectedTxnIds = this.duplicateSetData[this.selectedSet].transaction_ids;
-    const params = {
-      tx_id: `in.(${selectedTxnIds.join(',')})`,
+
+    const queryParams = {
+      id: `in.(${selectedTxnIds.join(',')})`,
     };
-    this.transaction.getETxnc({ offset: 0, limit: 10, params }).subscribe((selectedExpenses) => {
-      this.trackingService.visitedMergeExpensesPageFromTask();
-      this.router.navigate([
-        '/',
-        'enterprise',
-        'merge_expense',
-        {
-          selectedElements: JSON.stringify(selectedExpenses),
-          from: 'TASK',
-        },
-      ]);
-    });
+
+    this.expensesService
+      .getExpenses({
+        offset: 0,
+        limit: 10,
+        ...queryParams,
+      })
+      .subscribe((selectedExpenses) => {
+        const expenseIDs = selectedExpenses.map((expense) => expense.id);
+        this.trackingService.visitedMergeExpensesPageFromTask();
+        this.router.navigate([
+          '/',
+          'enterprise',
+          'merge_expense',
+          {
+            expenseIDs: JSON.stringify(expenseIDs),
+            from: 'TASK',
+          },
+        ]);
+      });
   }
 
   showDismissedSuccessToast(): void {
@@ -165,6 +182,6 @@ export class PotentialDuplicatesPage {
   }
 
   goToTransaction({ etxn: expense }: { etxn: Expense }): void {
-    this.router.navigate(['/', 'enterprise', 'add_edit_expense', { id: expense.tx_id, persist_filters: true }]);
+    this.router.navigate(['/', 'enterprise', 'add_edit_expense', { id: expense.id, persist_filters: true }]);
   }
 }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9198931</samp>

This pull request refactors the code and templates of the my-expenses and potential-duplicates pages to use the new expense model and service that are compatible with the platform v1 API. It renames some variables and router parameters to improve clarity and consistency. It also updates the bindings and selectors for the expense component in the potential-duplicates page.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9198931</samp>

> _We're breaking free from the old transaction model_
> _Renaming the fields and the routes to match the new_
> _We're binding the templates to the expense component_
> _Using the service that connects to the platform v1_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9198931</samp>

*  Rename `txnIDs` to `expenseIDs` in variables and router parameters to use the new expense model with `id` as the primary key ([link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-2d8cc214c1ee75be28b08af2707dc932d95b04397fd63bb5b56cef6e5ea04fe9L1556-R1556), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-2d8cc214c1ee75be28b08af2707dc932d95b04397fd63bb5b56cef6e5ea04fe9L1562-R1562), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-8ba341e210d765eda548d0c9e9ed2568f06e061fafd19b0fc3280e1db80c1533L1453-R1453), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-8ba341e210d765eda548d0c9e9ed2568f06e061fafd19b0fc3280e1db80c1533L1459-R1459), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL129-R160))
*  Change the import, constructor parameter, and methods of `PotentialDuplicatesPage` to use the new `ExpensesService` and `Expense` model that are compatible with the platform v1 API ([link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL6-R11), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL36-R36), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL60-R78), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL129-R160))
*  Replace `tx_id`, `tx_amount`, and `tx_currency` with `id`, `amount`, and `currency` in the template bindings, component selectors, and logic of `PotentialDuplicatesPage` and `potential-duplicates.page.html` to match the new expense model ([link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-1cf7f96acd49d884a42f448a25552070027caddc44d8e145a01441745636852dL25-R30), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-1cf7f96acd49d884a42f448a25552070027caddc44d8e145a01441745636852dL38-R38), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL85-R93), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL98-R106), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL105-R115), [link](https://github.com/fylein/fyle-mobile-app/pull/2632/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL168-R185))

## Clickup
https://app.clickup.com/t/86cu0ynta

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes