### PR TITLE
test: Move Potential Duplicates to Platform: Fixing Test

### DIFF
--- a/src/app/core/mock-data/duplicate-sets.data.ts
+++ b/src/app/core/mock-data/duplicate-sets.data.ts
@@ -9,3 +9,8 @@ export const duplicateSetData2: DuplicateSet = {
   fields: ['field1', 'field2'],
   transaction_ids: ['tx5fBcPBAxLv', 'tx3nHShG60zq'],
 };
+
+export const duplicateSetData3: DuplicateSet = {
+  fields: ['field1', 'field2'],
+  transaction_ids: ['txe0bYaJlRJf', 'txDDLtRaflUW'],
+};

--- a/src/app/core/mock-data/duplicate-sets.data.ts
+++ b/src/app/core/mock-data/duplicate-sets.data.ts
@@ -12,5 +12,5 @@ export const duplicateSetData2: DuplicateSet = {
 
 export const duplicateSetData3: DuplicateSet = {
   fields: ['field1', 'field2'],
-  transaction_ids: ['txe0bYaJlRJf', 'txDDLtRaflUW'],
+  transaction_ids: ['txcSFe6efB6R', 'txDDLtRaflUW'],
 };

--- a/src/app/fyle/my-expenses-v2/my-expenses-v2.page.spec.ts
+++ b/src/app/fyle/my-expenses-v2/my-expenses-v2.page.spec.ts
@@ -2901,7 +2901,7 @@ describe('MyExpensesV2Page', () => {
       'enterprise',
       'merge_expense',
       {
-        txnIDs: JSON.stringify(['txDDLtRaflUW', 'tx5WDG9lxBDT']),
+        expenseIDs: JSON.stringify(['txDDLtRaflUW', 'tx5WDG9lxBDT']),
         from: 'MY_EXPENSES',
       },
     ]);

--- a/src/app/fyle/my-expenses/my-expenses.page.spec.ts
+++ b/src/app/fyle/my-expenses/my-expenses.page.spec.ts
@@ -2790,7 +2790,7 @@ describe('MyExpensesPage', () => {
       'enterprise',
       'merge_expense',
       {
-        txnIDs: JSON.stringify(['tx3nHShG60zq']),
+        expenseIDs: JSON.stringify(['tx3nHShG60zq']),
         from: 'MY_EXPENSES',
       },
     ]);

--- a/src/app/fyle/potential-duplicates/potential-duplicates.page.spec.ts
+++ b/src/app/fyle/potential-duplicates/potential-duplicates.page.spec.ts
@@ -166,7 +166,7 @@ describe('PotentialDuplicatesPage', () => {
       component.dismiss(apiExpenses1[0]);
 
       expect(component.duplicateExpenses[0].length).toEqual(1);
-      expect(handleDuplicates.dismissAll).toHaveBeenCalledOnceWith(['txe0bYaJlRJf', 'txDDLtRaflUW'], ['txDDLtRaflUW']);
+      expect(handleDuplicates.dismissAll).toHaveBeenCalledOnceWith(['txcSFe6efB6R', 'txDDLtRaflUW'], ['txDDLtRaflUW']);
       expect(component.showDismissedSuccessToast).toHaveBeenCalledTimes(1);
     });
   });
@@ -215,7 +215,7 @@ describe('PotentialDuplicatesPage', () => {
         'enterprise',
         'merge_expense',
         {
-          expenseIDs: JSON.stringify(['txe0bYaJlRJf', 'txDDLtRaflUW']),
+          expenseIDs: JSON.stringify(['txcSFe6efB6R', 'txDDLtRaflUW']),
           from: 'TASK',
         },
       ]);

--- a/src/app/fyle/potential-duplicates/potential-duplicates.page.ts
+++ b/src/app/fyle/potential-duplicates/potential-duplicates.page.ts
@@ -65,7 +65,6 @@ export class PotentialDuplicatesPage {
             return this.expensesService
               .getExpenses({
                 offset: 0,
-
                 ...queryParams,
               })
               .pipe(


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dd8c377</samp>

This pull request updates the potential duplicates page and its spec file to use the new mock data and the expenses service. It also removes an unused import and changes the router navigation parameters.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dd8c377</samp>

> _New mock data for_
> _`potential-duplicates`_
> _testing with `expenses`_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dd8c377</samp>

*  Replace the transactionService with the expensesService for fetching expenses by ids in the potential duplicates page and its tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L7-R7), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R15-R17), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L21-R32), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R41), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L47-R52), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R68-R71), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L76-R85), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L94-R101), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L101-R117), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L115-R124), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L187-R210), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL68))
*  Add a new mock data for duplicate sets with two fields and two transaction ids in `duplicate-sets.data.ts` ([link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-08994ab67f55c1a7ea9ee90f7380a90fbd85abd94db9dbeee14f217f2cb1ebdfR12-R16))
*  Import the new mock data for duplicate sets and the mock data for expenses from the platform folder in the potential duplicates page tests ([link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L7-R7))
*  Modify the test cases for populating duplicate sets, going to tasks page if no duplicate sets are found, adding expense details to duplicate sets, dismissing a duplicate expense, dismissing all duplicate expenses, and merging expenses to match the new mock data for duplicate sets and expenses ([link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L94-R101), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L101-R117), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L115-R124), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L123-R139), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L151-R169), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L171-R181), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L187-R210), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L205-R218))
*  Use the cloneDeep function from lodash to make a copy of the mock data without mutating the original in the test cases for dismissing a duplicate expense and dismissing all duplicate expenses ([link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R15-R17), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L151-R169), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L171-R181))
*  Modify the router navigation for merging expenses and going to transaction to pass the expense ids as a stringified array and to match the new mock data for expenses ([link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L205-R218), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L242-R255), [link](https://github.com/fylein/fyle-mobile-app/pull/2633/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L248-R261))

## Clickup
https://app.clickup.com/t/86cu0ynta

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes