### PR TITLE
feat: Move Suggested Duplicates to Platform: Moved API calls and refactored method in Add Edit Expense

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -4905,10 +4905,11 @@ export class AddEditExpensePage implements OnInit {
   }
 
   async showSuggestedDuplicates(duplicateExpenses: Expense[]): Promise<void> {
+    const txnIDs = duplicateExpenses.map((expense) => expense.tx_id);
     const currencyModal = await this.modalController.create({
       component: SuggestedDuplicatesComponent,
       componentProps: {
-        duplicateExpenses,
+        duplicateExpenseIDs: txnIDs,
       },
       mode: 'ios',
       ...this.modalProperties.getModalDefaultProperties(),

--- a/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.html
+++ b/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.html
@@ -7,15 +7,15 @@
     <div class="suggested-duplicates--container">
       <div class="suggested-duplicates--header text-center">
         {{ duplicateExpenses.length }} expenses for
-        {{ duplicateExpenses[0].tx_amount | currency : duplicateExpenses[0].tx_currency : 'symbol-narrow' }}
+        {{ duplicateExpenses[0].amount | currency : duplicateExpenses[0].currency : 'symbol-narrow' }}
       </div>
       <ng-container *ngFor="let expense of duplicateExpenses as list; let i = index">
-        <app-expense-card
-          [previousExpenseTxnDate]="list[i - 1]?.tx_txn_dt"
-          [previousExpenseCreatedAt]="list[i - 1]?.tx_created_at"
+        <app-expense-card-v2
+          [previousExpenseTxnDate]="list[i - 1]?.spent_at"
+          [previousExpenseCreatedAt]="list[i - 1]?.created_at"
           [expense]="expense"
         >
-        </app-expense-card>
+        </app-expense-card-v2>
       </ng-container>
     </div>
   </div>


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7f70020</samp>

Refactor the suggested duplicates feature to use the new `ExpensesService` and the `ExpenseCardV2Component`. This improves the performance, readability and consistency of the code and the UI.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7f70020</samp>

> _Sing, O Muse, of the swift and skillful coder_
> _Who reforged the expense page with cunning and care_
> _Like Hephaestus, who shapes the metal with his hammer_
> _He passed only the IDs of the duplicates, not the whole affair_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7f70020</samp>

*  Reduce data transfer and simplify logic for showing suggested duplicates by passing only expense IDs to `SuggestedDuplicatesComponent` ([link](https://github.com/fylein/fyle-mobile-app/pull/2634/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL4908-R4912))
*  Update template of `SuggestedDuplicatesComponent` to use new `ExpenseCardV2Component` and fix property names of expense object ([link](https://github.com/fylein/fyle-mobile-app/pull/2634/files?diff=unified&w=0#diff-93ef678857bdbc1462c22b2643bf2ba85fc741ea095e749e7235e2fbe8fd24bdL10-R18))
*  Replace deprecated `TransactionService` with new `ExpensesService` and use `map` operator to transform observable data in `SuggestedDuplicatesComponent` ([link](https://github.com/fylein/fyle-mobile-app/pull/2634/files?diff=unified&w=0#diff-e0af331613b29230fddab8e581b8caff736ecf22112b92bcaa160b7bcdc24d44L1-R9), [link](https://github.com/fylein/fyle-mobile-app/pull/2634/files?diff=unified&w=0#diff-e0af331613b29230fddab8e581b8caff736ecf22112b92bcaa160b7bcdc24d44L16-R25))
*  Fetch expense objects from platform service using expense IDs in `ionViewWillEnter` hook of `SuggestedDuplicatesComponent` and assign them to `duplicateExpenses` property ([link](https://github.com/fylein/fyle-mobile-app/pull/2634/files?diff=unified&w=0#diff-e0af331613b29230fddab8e581b8caff736ecf22112b92bcaa160b7bcdc24d44L28-R43))
*  Simplify `mergeExpenses` method in `SuggestedDuplicatesComponent` to dismiss modal and navigate to `MergeExpensePage` with expense IDs as parameter ([link](https://github.com/fylein/fyle-mobile-app/pull/2634/files?diff=unified&w=0#diff-e0af331613b29230fddab8e581b8caff736ecf22112b92bcaa160b7bcdc24d44L40-R66))

## Clickup
https://app.clickup.com/t/86cu0yntq

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes