### PR TITLE
test: Move Suggested Duplicates to Platform: Fixed Tests

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
@@ -1471,7 +1471,7 @@ export function TestCases2(getTestBed) {
         expect(modalController.create).toHaveBeenCalledOnceWith({
           component: SuggestedDuplicatesComponent,
           componentProps: {
-            duplicateExpenses: [expenseData1],
+            duplicateExpenseIDs: ['tx5fBcPBAxLv'],
           },
           mode: 'ios',
           ...properties,
@@ -1496,7 +1496,7 @@ export function TestCases2(getTestBed) {
         expect(modalController.create).toHaveBeenCalledOnceWith({
           component: SuggestedDuplicatesComponent,
           componentProps: {
-            duplicateExpenses: [expenseData1],
+            duplicateExpenseIDs: ['tx5fBcPBAxLv'],
           },
           mode: 'ios',
           ...properties,

--- a/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.html
+++ b/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.html
@@ -7,7 +7,7 @@
     <div class="suggested-duplicates--container">
       <div class="suggested-duplicates--header text-center">
         {{ duplicateExpenses.length }} expenses for
-        {{ duplicateExpenses[0].amount | currency : duplicateExpenses[0].currency : 'symbol-narrow' }}
+        {{ duplicateExpenses[0]?.amount | currency : duplicateExpenses[0]?.currency : 'symbol-narrow' }}
       </div>
       <ng-container *ngFor="let expense of duplicateExpenses as list; let i = index">
         <app-expense-card-v2

--- a/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.spec.ts
+++ b/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.spec.ts
@@ -7,7 +7,7 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { SuggestedDuplicatesComponent } from './suggested-duplicates.component';
 import { HandleDuplicatesService } from 'src/app/core/services/handle-duplicates.service';
 import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
-import { TransactionService } from 'src/app/core/services/transaction.service';
+import { ExpensesService } from 'src/app/core/services/platform/v1/spender/expenses.service';
 import { ToastMessageComponent } from 'src/app/shared/components/toast-message/toast-message.component';
 import { Router } from '@angular/router';
 import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar';
@@ -15,15 +15,15 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
-import { etxncData } from 'src/app/core/mock-data/expense.data';
 import { getAllElementsBySelector, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
+import { apiExpenses1, expenseData } from 'src/app/core/mock-data/platform/v1/expense.data';
 
 describe('SuggestedDuplicatesComponent', () => {
   let component: SuggestedDuplicatesComponent;
   let fixture: ComponentFixture<SuggestedDuplicatesComponent>;
   let modalController: jasmine.SpyObj<ModalController>;
   let handleDuplicatesService: jasmine.SpyObj<HandleDuplicatesService>;
-  let transactionService: jasmine.SpyObj<TransactionService>;
+  let expensesService: jasmine.SpyObj<ExpensesService>;
   let snackbarPropertiesService: jasmine.SpyObj<SnackbarPropertiesService>;
   let matSnackBar: jasmine.SpyObj<MatSnackBar>;
   let router: jasmine.SpyObj<Router>;
@@ -31,7 +31,7 @@ describe('SuggestedDuplicatesComponent', () => {
   beforeEach(waitForAsync(() => {
     const modalControllerSpy = jasmine.createSpyObj('ModalController', ['dismiss']);
     const handleDuplicatesServiceSpy = jasmine.createSpyObj('HandleDuplicatesService', ['dismissAll']);
-    const transactionServiceSpy = jasmine.createSpyObj('TransactionService', ['getETxnc']);
+    const expensesServiceSpy = jasmine.createSpyObj('ExpensesService', ['getExpenses']);
     const matSnackBarSpy = jasmine.createSpyObj('MatSnackBar', ['openFromComponent']);
     const snackbarPropertiesServiceSpy = jasmine.createSpyObj('SnackbarPropertiesService', ['setSnackbarProperties']);
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
@@ -50,7 +50,7 @@ describe('SuggestedDuplicatesComponent', () => {
       providers: [
         { provide: ModalController, useValue: modalControllerSpy },
         { provide: HandleDuplicatesService, useValue: handleDuplicatesServiceSpy },
-        { provide: TransactionService, useValue: transactionServiceSpy },
+        { provide: ExpensesService, useValue: expensesServiceSpy },
         { provide: MatSnackBar, useValue: matSnackBarSpy },
         { provide: SnackbarPropertiesService, useValue: snackbarPropertiesServiceSpy },
         { provide: Router, useValue: routerSpy },
@@ -60,14 +60,18 @@ describe('SuggestedDuplicatesComponent', () => {
 
     modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
     handleDuplicatesService = TestBed.inject(HandleDuplicatesService) as jasmine.SpyObj<HandleDuplicatesService>;
-    transactionService = TestBed.inject(TransactionService) as jasmine.SpyObj<TransactionService>;
+    expensesService = TestBed.inject(ExpensesService) as jasmine.SpyObj<ExpensesService>;
     snackbarPropertiesService = TestBed.inject(SnackbarPropertiesService) as jasmine.SpyObj<SnackbarPropertiesService>;
     matSnackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
     router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
 
     fixture = TestBed.createComponent(SuggestedDuplicatesComponent);
     component = fixture.componentInstance;
-    component.duplicateExpenses = [{ tx_id: 'tx1ZvrMjIj4W' }, { tx_id: 'tx8v1PZSUxy5' }, { tx_id: 'txKW3vYo8W2v' }];
+    component.duplicateExpenses = [
+      { ...expenseData, id: 'tx1ZvrMjIj4W' },
+      { ...expenseData, id: 'tx8v1PZSUxy5' },
+      { ...expenseData, id: 'txKW3vYo8W2v' },
+    ];
     fixture.detectChanges();
   }));
 
@@ -104,8 +108,8 @@ describe('SuggestedDuplicatesComponent', () => {
   });
 
   it('should dismiss the modal and navigate to the merge expense page', () => {
-    const getETxncSpy = transactionService.getETxnc.and.returnValue(of(etxncData.data));
-    const selectedExpenses = etxncData.data;
+    const getETxncSpy = expensesService.getExpenses.and.returnValue(of(apiExpenses1));
+    const selectedExpenses = apiExpenses1;
     component.mergeExpenses();
     fixture.detectChanges();
     expect(modalController.dismiss).toHaveBeenCalledTimes(1);
@@ -114,14 +118,14 @@ describe('SuggestedDuplicatesComponent', () => {
       'enterprise',
       'merge_expense',
       {
-        selectedElements: JSON.stringify(selectedExpenses),
+        expenseIDs: JSON.stringify(selectedExpenses.map((exp) => exp.id)),
         from: 'EDIT_EXPENSE',
       },
     ]);
     expect(getETxncSpy).toHaveBeenCalledOnceWith({
       offset: 0,
       limit: 10,
-      params: { tx_id: 'in.(tx1ZvrMjIj4W,tx8v1PZSUxy5,txKW3vYo8W2v)' },
+      queryParams: { id: 'in.(tx1ZvrMjIj4W,tx8v1PZSUxy5,txKW3vYo8W2v)' },
     });
   });
 
@@ -143,9 +147,9 @@ describe('SuggestedDuplicatesComponent', () => {
   it('should display the correct header information', () => {
     const expectedHeader = '3 expenses for $100.50';
     component.duplicateExpenses = [
-      { tx_amount: 100.5, tx_currency: 'USD' },
-      { tx_amount: 100.5, tx_currency: 'USD' },
-      { tx_amount: 100.5, tx_currency: 'USD' },
+      { ...expenseData, amount: 100.5, currency: 'USD' },
+      { ...expenseData, amount: 100.5, currency: 'USD' },
+      { ...expenseData, amount: 100.5, currency: 'USD' },
     ];
 
     const headerEl = getElementBySelector(fixture, '.suggested-duplicates--header');
@@ -154,7 +158,7 @@ describe('SuggestedDuplicatesComponent', () => {
   });
 
   it('should display correct number of expense cards', () => {
-    const expenseCardEls = getAllElementsBySelector(fixture, 'app-expense-card');
+    const expenseCardEls = getAllElementsBySelector(fixture, 'app-expense-card-v2');
     fixture.detectChanges();
     expect(expenseCardEls.length).toBe(component.duplicateExpenses.length);
   });

--- a/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.spec.ts
+++ b/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.spec.ts
@@ -67,16 +67,27 @@ describe('SuggestedDuplicatesComponent', () => {
 
     fixture = TestBed.createComponent(SuggestedDuplicatesComponent);
     component = fixture.componentInstance;
-    component.duplicateExpenses = [
-      { ...expenseData, id: 'tx1ZvrMjIj4W' },
-      { ...expenseData, id: 'tx8v1PZSUxy5' },
-      { ...expenseData, id: 'txKW3vYo8W2v' },
-    ];
+    component.duplicateExpenseIDs = apiExpenses1.map((expense) => expense.id);
+    component.duplicateExpenses = apiExpenses1;
     fixture.detectChanges();
   }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('ionViewWillEnter(): should get duplicate expenses', () => {
+    component.duplicateExpenseIDs = ['txDDLtRaflUW', 'tx5WDG9lxBDT'];
+    expensesService.getExpenses.and.returnValue(of(apiExpenses1));
+
+    component.ionViewWillEnter();
+
+    expect(component.duplicateExpenses).toEqual(apiExpenses1);
+    expect(expensesService.getExpenses).toHaveBeenCalledOnceWith({
+      offset: 0,
+      limit: 10,
+      queryParams: { id: 'in.(txDDLtRaflUW,tx5WDG9lxBDT)' },
+    });
   });
 
   it('should show success toast message when called', () => {
@@ -108,8 +119,6 @@ describe('SuggestedDuplicatesComponent', () => {
   });
 
   it('should dismiss the modal and navigate to the merge expense page', () => {
-    const getETxncSpy = expensesService.getExpenses.and.returnValue(of(apiExpenses1));
-    const selectedExpenses = apiExpenses1;
     component.mergeExpenses();
     fixture.detectChanges();
     expect(modalController.dismiss).toHaveBeenCalledTimes(1);
@@ -118,15 +127,10 @@ describe('SuggestedDuplicatesComponent', () => {
       'enterprise',
       'merge_expense',
       {
-        expenseIDs: JSON.stringify(selectedExpenses.map((exp) => exp.id)),
+        expenseIDs: JSON.stringify(['txDDLtRaflUW', 'tx5WDG9lxBDT']),
         from: 'EDIT_EXPENSE',
       },
     ]);
-    expect(getETxncSpy).toHaveBeenCalledOnceWith({
-      offset: 0,
-      limit: 10,
-      queryParams: { id: 'in.(tx1ZvrMjIj4W,tx8v1PZSUxy5,txKW3vYo8W2v)' },
-    });
   });
 
   it('should dismiss all duplicate expenses and display success toast message', () => {
@@ -136,10 +140,7 @@ describe('SuggestedDuplicatesComponent', () => {
 
     component.dismissAll();
     fixture.detectChanges();
-    expect(dismissAllSpy).toHaveBeenCalledOnceWith(
-      ['tx1ZvrMjIj4W', 'tx8v1PZSUxy5', 'txKW3vYo8W2v'],
-      ['tx1ZvrMjIj4W', 'tx8v1PZSUxy5', 'txKW3vYo8W2v']
-    );
+    expect(dismissAllSpy).toHaveBeenCalledOnceWith(['txDDLtRaflUW', 'tx5WDG9lxBDT'], ['txDDLtRaflUW', 'tx5WDG9lxBDT']);
     expect(showDismissedSuccessToastSpy).toHaveBeenCalledTimes(1);
     expect(modalControllerDismissSpy).toHaveBeenCalledOnceWith({ action: 'dismissed' });
   });

--- a/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.ts
+++ b/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.ts
@@ -36,7 +36,8 @@ export class SuggestedDuplicatesComponent {
 
     this.expensesService
       .getExpenses({ offset: 0, limit: 10, queryParams })
-      .pipe(map((expenses) => (this.duplicateExpenses = expenses)));
+      .pipe(map((expenses) => (this.duplicateExpenses = expenses)))
+      .subscribe(noop);
   }
 
   dismissAll(): void {


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1a0e0d6</samp>

Refactored the suggested duplicates feature in the add-edit-expense module to use the `ExpensesService` and the `ExpenseCardV2Component`. Fixed some template and observable issues in the `SuggestedDuplicatesComponent`. Updated and added test cases accordingly.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1a0e0d6</samp>

> _`ExpensesService`_
> _fetches duplicates for us_
> _autumn leaves fall fast_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1a0e0d6</samp>

*  Replace `duplicateExpenses` with `duplicateExpenseIDs` as input for `SuggestedDuplicatesComponent` and fetch expense objects from `ExpensesService` ([link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-c294271c8dad15915f84fbf86ca0233e9317d1c66b356eaef309058076e7fa15L1474-R1474), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-c294271c8dad15915f84fbf86ca0233e9317d1c66b356eaef309058076e7fa15L1499-R1499), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L70-R71), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914R79-R92), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L117-R133), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L135-R143), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-e0af331613b29230fddab8e581b8caff736ecf22112b92bcaa160b7bcdc24d44L39-R40))
*  Use optional chaining operator to avoid errors in template expressions for `duplicateExpenses` ([link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-93ef678857bdbc1462c22b2643bf2ba85fc741ea095e749e7235e2fbe8fd24bdL10-R10))
*  Replace `TransactionService` with `ExpensesService` as service dependency for `SuggestedDuplicatesComponent` and update mock data and providers accordingly ([link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L10-R10), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L18-R19), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L26-R26), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L34-R34), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L53-R53), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L63-R63))
*  Remove unnecessary code that mocked `getETxnc` method of `TransactionService` and assigned `selectedExpenses` variable ([link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L107-L108))
*  Use `ExpenseCardV2Component` to display expense cards and update selector and mock data accordingly ([link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L146-R153), [link](https://github.com/fylein/fyle-mobile-app/pull/2635/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L157-R162))

## Clickup
https://app.clickup.com/t/86cu0yntq

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes