### PR TITLE
feat: Move Merge Expense to Platform: Moved API Call

### DIFF
--- a/src/app/core/services/expenses-info.model.ts
+++ b/src/app/core/services/expenses-info.model.ts
@@ -1,4 +1,4 @@
-import { Expense } from '../models/expense.model';
+import { Expense } from '../models/platform/v1/expense.model';
 
 export interface ExpensesInfo {
   isReportedAndAbove: boolean;


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d47c43d</samp>

Updated the merge expenses feature to use the new platform/v1 expense model and service. This involved changing the import paths, property names, and account type enum in the merge expenses service, page, and model files.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d47c43d</samp>

> _We're merging expenses on the platform/v1_
> _We're using the new model and the enum_
> _Heave away, me hearties, heave away_
> _We'll make the code more consistent and display_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d47c43d</samp>

*  Update the import paths for the expense model and the account type enum to reflect the new platform/v1 folder structure ([link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-a0c79174687db530ae66c40d85a2f282ec08ca9a4a0ac3a67acd9dc1722d0761L1-R1), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L5-R5), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L16), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98R26), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L15-R15), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20R35))
*  Inject the expenses service as a dependency in the merge expense page constructor and use it to get the expenses by id instead of the transaction service ([link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L151-R153), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L188-R195))
*  Use the new expense properties such as state, matched_corporate_card_transaction_ids, category.name, merchant, project.display_name, spent_at, amount, currency, id, foreign_currency, foreign_amount, source_account.type, project_id, is_billable, category.id, tax_group_id, tax_amount, cost_center.name, purpose, locations, started_at, ended_at, travel_classes, distance, distance_unit, custom_fields, source_account_id, cost_center_id instead of the old tx_ prefixed properties and the source_account_type property in the merge expenses service and the merge expense page ([link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L64-R73), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L75-R79), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L94-R98), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L104-R108), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L136-R140), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L160-R179), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L181-R185), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L196-R200), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L208-R232), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L247-R254), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L269-R274), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L283-R290), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L298-R305), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L316-R320), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L335-R342), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L351-R358), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L366-R373), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L381-R388), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L396-R403), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L417-R424), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L438-R445), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L459-R466), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L474-R481), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L489-R496), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L504-R511), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L519-R526), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L534-R541), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L550-R555), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L574-R585), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L592-R599), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L602-R607), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-8623ffc8daf66fa9d963149e7c0d04ba3d2c7a4b191a307c83ae6824deefcb98L768-R775), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L367-R369), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L391-R399), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L404-R405), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L410-R411), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L416-R417), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L422-R423), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L428-R429), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L434-R435), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L440-R441), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L446-R447), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L452-R453), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L458-R459), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L526-R527), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L576-R580), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L593-R597), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L612-R613), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L766-R767), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L774-R775), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L811-R812), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L817-R818), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L823-R824), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L829-R830), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L835-R836), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L841-R842), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L847-R848), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L853-R854), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L859-R860), [link](https://github.com/fylein/fyle-mobile-app/pull/2637/files?diff=unified&w=0#diff-55eb912dd07fa23beec12c78c591076d1caf6fba1de5cd9aa18f181b8436bc20L865-R866))

## Clickup
https://app.clickup.com/t/86cu0yntg

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes