### PR TITLE
fix: Fix for edit report name test case failing randomly

### DIFF
--- a/src/app/fyle/view-team-report/view-team-report-v2.page.spec.ts
+++ b/src/app/fyle/view-team-report/view-team-report-v2.page.spec.ts
@@ -1,6 +1,6 @@
 import { CurrencyPipe } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA, EventEmitter } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flush, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { By } from '@angular/platform-browser';
@@ -1043,5 +1043,10 @@ describe('ViewTeamReportPageV2', () => {
       });
       expect(component.updateReportName).not.toHaveBeenCalled();
     }));
+
+    afterEach(() => {
+      // Clear remaining timers to avoid failures due to timers in queue
+      flush();
+    });
   });
 });

--- a/src/app/fyle/view-team-report/view-team-report-v2.page.spec.ts
+++ b/src/app/fyle/view-team-report/view-team-report-v2.page.spec.ts
@@ -1,6 +1,6 @@
 import { CurrencyPipe } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA, EventEmitter } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, flush, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flushMicrotasks, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { By } from '@angular/platform-browser';
@@ -1006,6 +1006,7 @@ describe('ViewTeamReportPageV2', () => {
 
       const editReportButton = getElementBySelector(fixture, '.view-reports--card ion-icon') as HTMLElement;
       click(editReportButton);
+      flushMicrotasks();
       tick(2000);
 
       expect(popoverController.create).toHaveBeenCalledOnceWith({
@@ -1032,6 +1033,7 @@ describe('ViewTeamReportPageV2', () => {
 
       const editReportButton = getElementBySelector(fixture, '.view-reports--card ion-icon') as HTMLElement;
       click(editReportButton);
+      flushMicrotasks();
       tick(2000);
 
       expect(popoverController.create).toHaveBeenCalledOnceWith({
@@ -1043,10 +1045,5 @@ describe('ViewTeamReportPageV2', () => {
       });
       expect(component.updateReportName).not.toHaveBeenCalled();
     }));
-
-    afterEach(() => {
-      // Clear remaining timers to avoid failures due to timers in queue
-      flush();
-    });
   });
 });


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7f08551</samp>

Improved test suite for `ViewTeamReportV2Page` component by importing `flush` and clearing timers.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7f08551</samp>

> _`flush` clears the timers_
> _test suite runs faster, better_
> _autumn leaves fall clean_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7f08551</samp>

* Import and use `flush` function to clear timers in test suite ([link](https://github.com/fylein/fyle-mobile-app/pull/2639/files?diff=unified&w=0#diff-ae04c73c2e3a969146461d8dee192005db71037395b21276237029283f0a223fL3-R3), [link](https://github.com/fylein/fyle-mobile-app/pull/2639/files?diff=unified&w=0#diff-ae04c73c2e3a969146461d8dee192005db71037395b21276237029283f0a223fR1046-R1050))

## Clickup
https://app.clickup.com/t/86cu2x9w7

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes