### PR TITLE
feat: Migrating Potential Duplicates and Suggested Duplicates Page

### DIFF
--- a/src/app/core/mock-data/duplicate-sets.data.ts
+++ b/src/app/core/mock-data/duplicate-sets.data.ts
@@ -9,3 +9,8 @@ export const duplicateSetData2: DuplicateSet = {
   fields: ['field1', 'field2'],
   transaction_ids: ['tx5fBcPBAxLv', 'tx3nHShG60zq'],
 };
+
+export const duplicateSetData3: DuplicateSet = {
+  fields: ['field1', 'field2'],
+  transaction_ids: ['txe0bYaJlRJf', 'txDDLtRaflUW'],
+};

--- a/src/app/core/mock-data/duplicate-sets.data.ts
+++ b/src/app/core/mock-data/duplicate-sets.data.ts
@@ -12,5 +12,5 @@ export const duplicateSetData2: DuplicateSet = {
 
 export const duplicateSetData3: DuplicateSet = {
   fields: ['field1', 'field2'],
-  transaction_ids: ['txe0bYaJlRJf', 'txDDLtRaflUW'],
+  transaction_ids: ['txcSFe6efB6R', 'txDDLtRaflUW'],
 };

--- a/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
@@ -1471,7 +1471,7 @@ export function TestCases2(getTestBed) {
         expect(modalController.create).toHaveBeenCalledOnceWith({
           component: SuggestedDuplicatesComponent,
           componentProps: {
-            duplicateExpenses: [expenseData1],
+            duplicateExpenseIDs: ['tx5fBcPBAxLv'],
           },
           mode: 'ios',
           ...properties,
@@ -1496,7 +1496,7 @@ export function TestCases2(getTestBed) {
         expect(modalController.create).toHaveBeenCalledOnceWith({
           component: SuggestedDuplicatesComponent,
           componentProps: {
-            duplicateExpenses: [expenseData1],
+            duplicateExpenseIDs: ['tx5fBcPBAxLv'],
           },
           mode: 'ios',
           ...properties,

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -4905,10 +4905,11 @@ export class AddEditExpensePage implements OnInit {
   }
 
   async showSuggestedDuplicates(duplicateExpenses: Expense[]): Promise<void> {
+    const txnIDs = duplicateExpenses.map((expense) => expense.tx_id);
     const currencyModal = await this.modalController.create({
       component: SuggestedDuplicatesComponent,
       componentProps: {
-        duplicateExpenses,
+        duplicateExpenseIDs: txnIDs,
       },
       mode: 'ios',
       ...this.modalProperties.getModalDefaultProperties(),

--- a/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.html
+++ b/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.html
@@ -7,15 +7,15 @@
     <div class="suggested-duplicates--container">
       <div class="suggested-duplicates--header text-center">
         {{ duplicateExpenses.length }} expenses for
-        {{ duplicateExpenses[0].tx_amount | currency : duplicateExpenses[0].tx_currency : 'symbol-narrow' }}
+        {{ duplicateExpenses[0].amount | currency : duplicateExpenses[0].currency : 'symbol-narrow' }}
       </div>
       <ng-container *ngFor="let expense of duplicateExpenses as list; let i = index">
-        <app-expense-card
-          [previousExpenseTxnDate]="list[i - 1]?.tx_txn_dt"
-          [previousExpenseCreatedAt]="list[i - 1]?.tx_created_at"
+        <app-expense-card-v2
+          [previousExpenseTxnDate]="list[i - 1]?.spent_at"
+          [previousExpenseCreatedAt]="list[i - 1]?.created_at"
           [expense]="expense"
         >
-        </app-expense-card>
+        </app-expense-card-v2>
       </ng-container>
     </div>
   </div>

--- a/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.html
+++ b/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.html
@@ -7,7 +7,7 @@
     <div class="suggested-duplicates--container">
       <div class="suggested-duplicates--header text-center">
         {{ duplicateExpenses.length }} expenses for
-        {{ duplicateExpenses[0].amount | currency : duplicateExpenses[0].currency : 'symbol-narrow' }}
+        {{ duplicateExpenses[0]?.amount | currency : duplicateExpenses[0]?.currency : 'symbol-narrow' }}
       </div>
       <ng-container *ngFor="let expense of duplicateExpenses as list; let i = index">
         <app-expense-card-v2

--- a/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.spec.ts
+++ b/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.spec.ts
@@ -7,7 +7,7 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { SuggestedDuplicatesComponent } from './suggested-duplicates.component';
 import { HandleDuplicatesService } from 'src/app/core/services/handle-duplicates.service';
 import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
-import { TransactionService } from 'src/app/core/services/transaction.service';
+import { ExpensesService } from 'src/app/core/services/platform/v1/spender/expenses.service';
 import { ToastMessageComponent } from 'src/app/shared/components/toast-message/toast-message.component';
 import { Router } from '@angular/router';
 import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar';
@@ -15,15 +15,15 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
-import { etxncData } from 'src/app/core/mock-data/expense.data';
 import { getAllElementsBySelector, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
+import { apiExpenses1, expenseData } from 'src/app/core/mock-data/platform/v1/expense.data';
 
 describe('SuggestedDuplicatesComponent', () => {
   let component: SuggestedDuplicatesComponent;
   let fixture: ComponentFixture<SuggestedDuplicatesComponent>;
   let modalController: jasmine.SpyObj<ModalController>;
   let handleDuplicatesService: jasmine.SpyObj<HandleDuplicatesService>;
-  let transactionService: jasmine.SpyObj<TransactionService>;
+  let expensesService: jasmine.SpyObj<ExpensesService>;
   let snackbarPropertiesService: jasmine.SpyObj<SnackbarPropertiesService>;
   let matSnackBar: jasmine.SpyObj<MatSnackBar>;
   let router: jasmine.SpyObj<Router>;
@@ -31,7 +31,7 @@ describe('SuggestedDuplicatesComponent', () => {
   beforeEach(waitForAsync(() => {
     const modalControllerSpy = jasmine.createSpyObj('ModalController', ['dismiss']);
     const handleDuplicatesServiceSpy = jasmine.createSpyObj('HandleDuplicatesService', ['dismissAll']);
-    const transactionServiceSpy = jasmine.createSpyObj('TransactionService', ['getETxnc']);
+    const expensesServiceSpy = jasmine.createSpyObj('ExpensesService', ['getExpenses']);
     const matSnackBarSpy = jasmine.createSpyObj('MatSnackBar', ['openFromComponent']);
     const snackbarPropertiesServiceSpy = jasmine.createSpyObj('SnackbarPropertiesService', ['setSnackbarProperties']);
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
@@ -50,7 +50,7 @@ describe('SuggestedDuplicatesComponent', () => {
       providers: [
         { provide: ModalController, useValue: modalControllerSpy },
         { provide: HandleDuplicatesService, useValue: handleDuplicatesServiceSpy },
-        { provide: TransactionService, useValue: transactionServiceSpy },
+        { provide: ExpensesService, useValue: expensesServiceSpy },
         { provide: MatSnackBar, useValue: matSnackBarSpy },
         { provide: SnackbarPropertiesService, useValue: snackbarPropertiesServiceSpy },
         { provide: Router, useValue: routerSpy },
@@ -60,14 +60,18 @@ describe('SuggestedDuplicatesComponent', () => {
 
     modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
     handleDuplicatesService = TestBed.inject(HandleDuplicatesService) as jasmine.SpyObj<HandleDuplicatesService>;
-    transactionService = TestBed.inject(TransactionService) as jasmine.SpyObj<TransactionService>;
+    expensesService = TestBed.inject(ExpensesService) as jasmine.SpyObj<ExpensesService>;
     snackbarPropertiesService = TestBed.inject(SnackbarPropertiesService) as jasmine.SpyObj<SnackbarPropertiesService>;
     matSnackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
     router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
 
     fixture = TestBed.createComponent(SuggestedDuplicatesComponent);
     component = fixture.componentInstance;
-    component.duplicateExpenses = [{ tx_id: 'tx1ZvrMjIj4W' }, { tx_id: 'tx8v1PZSUxy5' }, { tx_id: 'txKW3vYo8W2v' }];
+    component.duplicateExpenses = [
+      { ...expenseData, id: 'tx1ZvrMjIj4W' },
+      { ...expenseData, id: 'tx8v1PZSUxy5' },
+      { ...expenseData, id: 'txKW3vYo8W2v' },
+    ];
     fixture.detectChanges();
   }));
 
@@ -104,8 +108,8 @@ describe('SuggestedDuplicatesComponent', () => {
   });
 
   it('should dismiss the modal and navigate to the merge expense page', () => {
-    const getETxncSpy = transactionService.getETxnc.and.returnValue(of(etxncData.data));
-    const selectedExpenses = etxncData.data;
+    const getETxncSpy = expensesService.getExpenses.and.returnValue(of(apiExpenses1));
+    const selectedExpenses = apiExpenses1;
     component.mergeExpenses();
     fixture.detectChanges();
     expect(modalController.dismiss).toHaveBeenCalledTimes(1);
@@ -114,14 +118,14 @@ describe('SuggestedDuplicatesComponent', () => {
       'enterprise',
       'merge_expense',
       {
-        selectedElements: JSON.stringify(selectedExpenses),
+        expenseIDs: JSON.stringify(selectedExpenses.map((exp) => exp.id)),
         from: 'EDIT_EXPENSE',
       },
     ]);
     expect(getETxncSpy).toHaveBeenCalledOnceWith({
       offset: 0,
       limit: 10,
-      params: { tx_id: 'in.(tx1ZvrMjIj4W,tx8v1PZSUxy5,txKW3vYo8W2v)' },
+      queryParams: { id: 'in.(tx1ZvrMjIj4W,tx8v1PZSUxy5,txKW3vYo8W2v)' },
     });
   });
 
@@ -143,9 +147,9 @@ describe('SuggestedDuplicatesComponent', () => {
   it('should display the correct header information', () => {
     const expectedHeader = '3 expenses for $100.50';
     component.duplicateExpenses = [
-      { tx_amount: 100.5, tx_currency: 'USD' },
-      { tx_amount: 100.5, tx_currency: 'USD' },
-      { tx_amount: 100.5, tx_currency: 'USD' },
+      { ...expenseData, amount: 100.5, currency: 'USD' },
+      { ...expenseData, amount: 100.5, currency: 'USD' },
+      { ...expenseData, amount: 100.5, currency: 'USD' },
     ];
 
     const headerEl = getElementBySelector(fixture, '.suggested-duplicates--header');
@@ -154,7 +158,7 @@ describe('SuggestedDuplicatesComponent', () => {
   });
 
   it('should display correct number of expense cards', () => {
-    const expenseCardEls = getAllElementsBySelector(fixture, 'app-expense-card');
+    const expenseCardEls = getAllElementsBySelector(fixture, 'app-expense-card-v2');
     fixture.detectChanges();
     expect(expenseCardEls.length).toBe(component.duplicateExpenses.length);
   });

--- a/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.spec.ts
+++ b/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.spec.ts
@@ -67,16 +67,27 @@ describe('SuggestedDuplicatesComponent', () => {
 
     fixture = TestBed.createComponent(SuggestedDuplicatesComponent);
     component = fixture.componentInstance;
-    component.duplicateExpenses = [
-      { ...expenseData, id: 'tx1ZvrMjIj4W' },
-      { ...expenseData, id: 'tx8v1PZSUxy5' },
-      { ...expenseData, id: 'txKW3vYo8W2v' },
-    ];
+    component.duplicateExpenseIDs = apiExpenses1.map((expense) => expense.id);
+    component.duplicateExpenses = apiExpenses1;
     fixture.detectChanges();
   }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('ionViewWillEnter(): should get duplicate expenses', () => {
+    component.duplicateExpenseIDs = ['txDDLtRaflUW', 'tx5WDG9lxBDT'];
+    expensesService.getExpenses.and.returnValue(of(apiExpenses1));
+
+    component.ionViewWillEnter();
+
+    expect(component.duplicateExpenses).toEqual(apiExpenses1);
+    expect(expensesService.getExpenses).toHaveBeenCalledOnceWith({
+      offset: 0,
+      limit: 10,
+      queryParams: { id: 'in.(txDDLtRaflUW,tx5WDG9lxBDT)' },
+    });
   });
 
   it('should show success toast message when called', () => {
@@ -108,8 +119,6 @@ describe('SuggestedDuplicatesComponent', () => {
   });
 
   it('should dismiss the modal and navigate to the merge expense page', () => {
-    const getETxncSpy = expensesService.getExpenses.and.returnValue(of(apiExpenses1));
-    const selectedExpenses = apiExpenses1;
     component.mergeExpenses();
     fixture.detectChanges();
     expect(modalController.dismiss).toHaveBeenCalledTimes(1);
@@ -118,15 +127,10 @@ describe('SuggestedDuplicatesComponent', () => {
       'enterprise',
       'merge_expense',
       {
-        expenseIDs: JSON.stringify(selectedExpenses.map((exp) => exp.id)),
+        expenseIDs: JSON.stringify(['txDDLtRaflUW', 'tx5WDG9lxBDT']),
         from: 'EDIT_EXPENSE',
       },
     ]);
-    expect(getETxncSpy).toHaveBeenCalledOnceWith({
-      offset: 0,
-      limit: 10,
-      queryParams: { id: 'in.(tx1ZvrMjIj4W,tx8v1PZSUxy5,txKW3vYo8W2v)' },
-    });
   });
 
   it('should dismiss all duplicate expenses and display success toast message', () => {
@@ -136,10 +140,7 @@ describe('SuggestedDuplicatesComponent', () => {
 
     component.dismissAll();
     fixture.detectChanges();
-    expect(dismissAllSpy).toHaveBeenCalledOnceWith(
-      ['tx1ZvrMjIj4W', 'tx8v1PZSUxy5', 'txKW3vYo8W2v'],
-      ['tx1ZvrMjIj4W', 'tx8v1PZSUxy5', 'txKW3vYo8W2v']
-    );
+    expect(dismissAllSpy).toHaveBeenCalledOnceWith(['txDDLtRaflUW', 'tx5WDG9lxBDT'], ['txDDLtRaflUW', 'tx5WDG9lxBDT']);
     expect(showDismissedSuccessToastSpy).toHaveBeenCalledTimes(1);
     expect(modalControllerDismissSpy).toHaveBeenCalledOnceWith({ action: 'dismissed' });
   });

--- a/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.ts
+++ b/src/app/fyle/add-edit-expense/suggested-duplicates/suggested-duplicates.component.ts
@@ -36,7 +36,8 @@ export class SuggestedDuplicatesComponent {
 
     this.expensesService
       .getExpenses({ offset: 0, limit: 10, queryParams })
-      .pipe(map((expenses) => (this.duplicateExpenses = expenses)));
+      .pipe(map((expenses) => (this.duplicateExpenses = expenses)))
+      .subscribe(noop);
   }
 
   dismissAll(): void {

--- a/src/app/fyle/my-expenses-v2/my-expenses-v2.page.spec.ts
+++ b/src/app/fyle/my-expenses-v2/my-expenses-v2.page.spec.ts
@@ -2901,7 +2901,7 @@ describe('MyExpensesV2Page', () => {
       'enterprise',
       'merge_expense',
       {
-        txnIDs: JSON.stringify(['txDDLtRaflUW', 'tx5WDG9lxBDT']),
+        expenseIDs: JSON.stringify(['txDDLtRaflUW', 'tx5WDG9lxBDT']),
         from: 'MY_EXPENSES',
       },
     ]);

--- a/src/app/fyle/my-expenses-v2/my-expenses-v2.page.ts
+++ b/src/app/fyle/my-expenses-v2/my-expenses-v2.page.ts
@@ -1553,13 +1553,13 @@ export class MyExpensesV2Page implements OnInit {
   }
 
   mergeExpenses(): void {
-    const txnIDs = this.selectedElements.map((expense) => expense.id);
+    const expenseIDs = this.selectedElements.map((expense) => expense.id);
     this.router.navigate([
       '/',
       'enterprise',
       'merge_expense',
       {
-        txnIDs: JSON.stringify(txnIDs),
+        expenseIDs: JSON.stringify(expenseIDs),
         from: 'MY_EXPENSES',
       },
     ]);

--- a/src/app/fyle/my-expenses/my-expenses.page.spec.ts
+++ b/src/app/fyle/my-expenses/my-expenses.page.spec.ts
@@ -2790,7 +2790,7 @@ describe('MyExpensesPage', () => {
       'enterprise',
       'merge_expense',
       {
-        txnIDs: JSON.stringify(['tx3nHShG60zq']),
+        expenseIDs: JSON.stringify(['tx3nHShG60zq']),
         from: 'MY_EXPENSES',
       },
     ]);

--- a/src/app/fyle/my-expenses/my-expenses.page.ts
+++ b/src/app/fyle/my-expenses/my-expenses.page.ts
@@ -1450,13 +1450,13 @@ export class MyExpensesPage implements OnInit {
   }
 
   mergeExpenses(): void {
-    const txnIDs = this.selectedElements.map((expense) => expense.tx_id);
+    const expenseIDs = this.selectedElements.map((expense) => expense.tx_id);
     this.router.navigate([
       '/',
       'enterprise',
       'merge_expense',
       {
-        txnIDs: JSON.stringify(txnIDs),
+        expenseIDs: JSON.stringify(expenseIDs),
         from: 'MY_EXPENSES',
       },
     ]);

--- a/src/app/fyle/potential-duplicates/potential-duplicates.page.html
+++ b/src/app/fyle/potential-duplicates/potential-duplicates.page.html
@@ -22,12 +22,12 @@
     <div class="potential-duplicates--container" *ngIf="!isLoading">
       <ng-container *ngFor="let duplicatesSet of duplicateExpenses; let setIndex=index">
         <div *ngIf="setIndex === selectedSet" class="potential-duplicates--header text-center">
-          {{duplicatesSet?.length}} expenses for {{ duplicatesSet[0].tx_amount | currency: duplicatesSet[0].tx_currency:
+          {{duplicatesSet?.length}} expenses for {{ duplicatesSet[0].amount | currency: duplicatesSet[0].currency:
           'symbol-narrow' }}
         </div>
         <ng-container *ngFor="let expense of duplicatesSet as list; let i = index;">
           <ng-container *ngIf="setIndex === selectedSet">
-            <app-expense-card
+            <app-expense-card-v2
               [showDt]="false"
               [isFromPotentialDuplicates]="true"
               [expense]="expense"
@@ -35,7 +35,7 @@
               (dismissed)="dismiss($event)"
               (goToTransaction)="goToTransaction($event)"
             >
-            </app-expense-card>
+            </app-expense-card-v2>
           </ng-container>
         </ng-container>
       </ng-container>

--- a/src/app/fyle/potential-duplicates/potential-duplicates.page.spec.ts
+++ b/src/app/fyle/potential-duplicates/potential-duplicates.page.spec.ts
@@ -166,7 +166,7 @@ describe('PotentialDuplicatesPage', () => {
       component.dismiss(apiExpenses1[0]);
 
       expect(component.duplicateExpenses[0].length).toEqual(1);
-      expect(handleDuplicates.dismissAll).toHaveBeenCalledOnceWith(['txe0bYaJlRJf', 'txDDLtRaflUW'], ['txDDLtRaflUW']);
+      expect(handleDuplicates.dismissAll).toHaveBeenCalledOnceWith(['txcSFe6efB6R', 'txDDLtRaflUW'], ['txDDLtRaflUW']);
       expect(component.showDismissedSuccessToast).toHaveBeenCalledTimes(1);
     });
   });
@@ -215,7 +215,7 @@ describe('PotentialDuplicatesPage', () => {
         'enterprise',
         'merge_expense',
         {
-          expenseIDs: JSON.stringify(['txe0bYaJlRJf', 'txDDLtRaflUW']),
+          expenseIDs: JSON.stringify(['txcSFe6efB6R', 'txDDLtRaflUW']),
           from: 'TASK',
         },
       ]);

--- a/src/app/fyle/potential-duplicates/potential-duplicates.page.ts
+++ b/src/app/fyle/potential-duplicates/potential-duplicates.page.ts
@@ -65,7 +65,6 @@ export class PotentialDuplicatesPage {
             return this.expensesService
               .getExpenses({
                 offset: 0,
-
                 ...queryParams,
               })
               .pipe(

--- a/src/app/fyle/potential-duplicates/potential-duplicates.page.ts
+++ b/src/app/fyle/potential-duplicates/potential-duplicates.page.ts
@@ -3,12 +3,12 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { Params, Router } from '@angular/router';
 import { BehaviorSubject, EMPTY, Observable, noop } from 'rxjs';
 import { finalize, map, switchMap, tap } from 'rxjs/operators';
-import { Expense } from 'src/app/core/models/expense.model';
+import { Expense } from 'src/app/core/models/platform/v1/expense.model';
 import { DuplicateSet } from 'src/app/core/models/v2/duplicate-sets.model';
 import { HandleDuplicatesService } from 'src/app/core/services/handle-duplicates.service';
 import { SnackbarPropertiesService } from 'src/app/core/services/snackbar-properties.service';
 import { TrackingService } from 'src/app/core/services/tracking.service';
-import { TransactionService } from 'src/app/core/services/transaction.service';
+import { ExpensesService } from 'src/app/core/services/platform/v1/spender/expenses.service';
 import { ToastMessageComponent } from 'src/app/shared/components/toast-message/toast-message.component';
 
 type Expenses = Expense[];
@@ -33,7 +33,7 @@ export class PotentialDuplicatesPage {
 
   constructor(
     private handleDuplicates: HandleDuplicatesService,
-    private transaction: TransactionService,
+    private expensesService: ExpensesService,
     private router: Router,
     private snackbarProperties: SnackbarPropertiesService,
     private matSnackBar: MatSnackBar,
@@ -57,17 +57,25 @@ export class PotentialDuplicatesPage {
             const duplicateIds = duplicateSets
               .map((value) => value.transaction_ids)
               .reduce((acc, curVal) => acc.concat(curVal), []);
-            const params = {
-              tx_id: `in.(${duplicateIds.join(',')})`,
+
+            const queryParams = {
+              id: `in.(${duplicateIds.join(',')})`,
             };
-            return this.transaction.getETxnc({ offset: 0, limit: 10, params }).pipe(
-              map((expenses) => {
-                const expensesArray = expenses as [];
-                return duplicateSets.map((duplicateSet) =>
-                  this.addExpenseDetailsToDuplicateSets(duplicateSet, expensesArray)
-                );
+
+            return this.expensesService
+              .getExpenses({
+                offset: 0,
+
+                ...queryParams,
               })
-            );
+              .pipe(
+                map((expenses) => {
+                  const expensesArray = expenses as [];
+                  return duplicateSets.map((duplicateSet) =>
+                    this.addExpenseDetailsToDuplicateSets(duplicateSet, expensesArray)
+                  );
+                })
+              );
           }),
           finalize(() => {
             this.isLoading = false;
@@ -82,7 +90,7 @@ export class PotentialDuplicatesPage {
 
   addExpenseDetailsToDuplicateSets(duplicateSet: DuplicateSet, expensesArray: Expense[]): Expense[] {
     return duplicateSet.transaction_ids.map(
-      (expenseId) => expensesArray[expensesArray.findIndex((duplicateTxn: Expense) => expenseId === duplicateTxn.tx_id)]
+      (expenseId) => expensesArray[expensesArray.findIndex((duplicateTxn: Expense) => expenseId === duplicateTxn.id)]
     );
   }
 
@@ -95,16 +103,16 @@ export class PotentialDuplicatesPage {
   }
 
   dismiss(expense: Expense): void {
-    const transactionIds = [expense.tx_id];
+    const transactionIds = [expense.id];
     const duplicateTxnIds = this.duplicateSetData[this.selectedSet].transaction_ids;
     this.handleDuplicates.dismissAll(duplicateTxnIds, transactionIds).subscribe(() => {
       this.trackingService.dismissedIndividualExpenses();
       this.showDismissedSuccessToast();
       this.duplicateSetData[this.selectedSet].transaction_ids = this.duplicateSetData[
         this.selectedSet
-      ].transaction_ids.filter((expId) => expId !== expense.tx_id);
+      ].transaction_ids.filter((expId) => expId !== expense.id);
       this.duplicateExpenses[this.selectedSet] = this.duplicateExpenses[this.selectedSet].filter(
-        (exp) => exp.tx_id !== expense.tx_id
+        (exp) => exp.id !== expense.id
       );
     });
   }
@@ -126,21 +134,30 @@ export class PotentialDuplicatesPage {
 
   mergeExpense(): void {
     const selectedTxnIds = this.duplicateSetData[this.selectedSet].transaction_ids;
-    const params = {
-      tx_id: `in.(${selectedTxnIds.join(',')})`,
+
+    const queryParams = {
+      id: `in.(${selectedTxnIds.join(',')})`,
     };
-    this.transaction.getETxnc({ offset: 0, limit: 10, params }).subscribe((selectedExpenses) => {
-      this.trackingService.visitedMergeExpensesPageFromTask();
-      this.router.navigate([
-        '/',
-        'enterprise',
-        'merge_expense',
-        {
-          selectedElements: JSON.stringify(selectedExpenses),
-          from: 'TASK',
-        },
-      ]);
-    });
+
+    this.expensesService
+      .getExpenses({
+        offset: 0,
+        limit: 10,
+        ...queryParams,
+      })
+      .subscribe((selectedExpenses) => {
+        const expenseIDs = selectedExpenses.map((expense) => expense.id);
+        this.trackingService.visitedMergeExpensesPageFromTask();
+        this.router.navigate([
+          '/',
+          'enterprise',
+          'merge_expense',
+          {
+            expenseIDs: JSON.stringify(expenseIDs),
+            from: 'TASK',
+          },
+        ]);
+      });
   }
 
   showDismissedSuccessToast(): void {
@@ -165,6 +182,6 @@ export class PotentialDuplicatesPage {
   }
 
   goToTransaction({ etxn: expense }: { etxn: Expense }): void {
-    this.router.navigate(['/', 'enterprise', 'add_edit_expense', { id: expense.tx_id, persist_filters: true }]);
+    this.router.navigate(['/', 'enterprise', 'add_edit_expense', { id: expense.id, persist_filters: true }]);
   }
 }


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d9a5e4a</samp>

This pull request refactors several components and pages related to the expense model and the duplicate expenses feature. It uses the new expense model properties, the new expense card component, and the new input properties for the suggested duplicates and merge expense components. It also updates and improves the test cases and mock data for these components and pages. It affects the files `add-edit-expense-2.spec.ts`, `suggested-duplicates.component.spec.ts`, `suggested-duplicates.component.ts`, `my-expenses-v2.page.ts`, `my-expenses.page.ts`, `potential-duplicates.page.html`, `potential-duplicates.page.spec.ts`, `potential-duplicates.page.ts`, `duplicate-sets.data.ts`, `add-edit-expense.page.ts`, `suggested-duplicates.component.html`, `my-expenses-v2.page.spec.ts`, and `my-expenses.page.spec.ts`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d9a5e4a</samp>

> _Oh we're the jolly coders of the `expense` app_
> _We refactor and we test and we never take a nap_
> _We use the new `expenseIDs` and the new `expense` model_
> _And we heave away the duplicates on the count of three_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d9a5e4a</samp>

*  Update the suggested duplicates component to use the new input property duplicateExpenseIDs and get the duplicate expenses from the expenses service ([link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL4908-R4912), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-93ef678857bdbc1462c22b2643bf2ba85fc741ea095e749e7235e2fbe8fd24bdL10-R18), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L10-R10), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L18-R19), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L26-R26), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L34-R34), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L53-R53), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L63-R63), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L70-R71), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914R79-R92), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-e0af331613b29230fddab8e581b8caff736ecf22112b92bcaa160b7bcdc24d44L1-R9), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-e0af331613b29230fddab8e581b8caff736ecf22112b92bcaa160b7bcdc24d44L16-R25), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-e0af331613b29230fddab8e581b8caff736ecf22112b92bcaa160b7bcdc24d44L28-R44), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-e0af331613b29230fddab8e581b8caff736ecf22112b92bcaa160b7bcdc24d44L40-R67))
*  Update the mergeExpenses methods in the add-edit-expense, my-expenses, and my-expenses-v2 pages to use the new input property expenseIDs for the merge expense page ([link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-492aac4c505a9ef8fb102b40f692554c3d0dc493b7abddc97b6665166efcc83bL4908-R4912), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L117-R133), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-78852007f7f771f391cd018245481b4e60b9c658507ae2f11280ee35604c87b2L2904-R2904), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-2d8cc214c1ee75be28b08af2707dc932d95b04397fd63bb5b56cef6e5ea04fe9L1556-R1556), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-2d8cc214c1ee75be28b08af2707dc932d95b04397fd63bb5b56cef6e5ea04fe9L1562-R1562), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-446039c75c9b2d02f68c2a029282002588ffa48a5d20add67bfbce3c26dacbb7L2793-R2793), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-8ba341e210d765eda548d0c9e9ed2568f06e061fafd19b0fc3280e1db80c1533L1453-R1453), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-8ba341e210d765eda548d0c9e9ed2568f06e061fafd19b0fc3280e1db80c1533L1459-R1459))
*  Update the potential duplicates page to use the expenses service instead of the transaction service and the new properties of the expense model ([link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-1cf7f96acd49d884a42f448a25552070027caddc44d8e145a01441745636852dL25-R30), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-1cf7f96acd49d884a42f448a25552070027caddc44d8e145a01441745636852dL38-R38), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L7-R7), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R15-R17), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L21-R32), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R41), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L47-R52), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R68-R71), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L76-R85), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L94-R101), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L101-R117), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L115-R124), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L123-R139), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L151-R169), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L171-R181), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L187-R210), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L205-R218), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L242-R255), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L248-R261), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL6-R11), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL36-R36), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL60-R77), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL85-R92), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL98-R105), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL105-R114), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL129-R159), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-5431dd9ec23dcf3e41d33455ddf902d4339a2c1782aa8c58622cda780313df6bL168-R184))
*  Update the templates and test cases to use the new properties of the expense model, which are amount and currency instead of tx_amount and tx_currency ([link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-93ef678857bdbc1462c22b2643bf2ba85fc741ea095e749e7235e2fbe8fd24bdL10-R18), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L146-R153), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-1cf7f96acd49d884a42f448a25552070027caddc44d8e145a01441745636852dL25-R30), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-1cf7f96acd49d884a42f448a25552070027caddc44d8e145a01441745636852dL38-R38))
*  Update the templates and test cases to use the new expense card component, which is app-expense-card-v2 instead of app-expense-card ([link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-93ef678857bdbc1462c22b2643bf2ba85fc741ea095e749e7235e2fbe8fd24bdL10-R18), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L157-R162), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-1cf7f96acd49d884a42f448a25552070027caddc44d8e145a01441745636852dL25-R30), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-1cf7f96acd49d884a42f448a25552070027caddc44d8e145a01441745636852dL38-R38))
*  Add a new mock data for a duplicate set with two expenses with different fields ([link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-08994ab67f55c1a7ea9ee90f7380a90fbd85abd94db9dbeee14f217f2cb1ebdfR12-R16))
*  Update the test cases to use the new mock data from the platform/v1/expense.data and duplicate-sets.data files ([link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c294271c8dad15915f84fbf86ca0233e9317d1c66b356eaef309058076e7fa15L1474-R1474), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c294271c8dad15915f84fbf86ca0233e9317d1c66b356eaef309058076e7fa15L1499-R1499), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L18-R19), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L70-R71), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914R79-R92), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L107-L108), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L135-R143), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L7-R7), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R15-R17), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L94-R101), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L101-R117), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L151-R169), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L171-R181), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L187-R210), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L205-R218), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L242-R255), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L248-R261))
*  Remove the unused variables and services from the imports, declarations, providers, spies, and injections ([link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L10-R10), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L26-R26), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L34-R34), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L53-R53), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L63-R63), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L107-L108), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-389c009fcd57769de543497409e8fcd5fab6091b14029c495dfc0696a6925914L117-R133), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L7-R7), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L21-R32), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R41), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L47-R52), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60R68-R71), [link](https://github.com/fylein/fyle-mobile-app/pull/2641/files?diff=unified&w=0#diff-c4bead936fc3074e5ac6af7e880dc5a2bce140004655c48b3b8ba1738e2d3e60L76-R85))

## Clickup
https://app.clickup.com/t/86cu0ynta

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes