### PR TITLE
fix: Fix for danger and filter icon

### DIFF
--- a/src/app/fyle/my-expenses-v2/my-expenses-v2.page.html
+++ b/src/app/fyle/my-expenses-v2/my-expenses-v2.page.html
@@ -13,10 +13,10 @@
       </ion-button>
       <ion-button class="my-expenses--header-btn" (click)="openFilters()">
         <ng-container *ngIf="filterPills?.length; else noFilterAppliedIcon">
-          <ion-icon slot="icon-only" src="../../../assets/svg/fy-applied-filter.svg"></ion-icon>
+          <ion-icon slot="icon-only" src="../../../assets/svg/filter-applied.svg"></ion-icon>
         </ng-container>
         <ng-template #noFilterAppliedIcon>
-          <ion-icon slot="icon-only" src="../../../assets/svg/fy-unapplied-filter.svg"></ion-icon>
+          <ion-icon slot="icon-only" src="../../../assets/svg/filter.svg"></ion-icon>
         </ng-template>
       </ion-button>
       <ng-container *ngIf="isConnected$ | async">

--- a/src/app/shared/components/fy-alert-info/fy-alert-info.component.html
+++ b/src/app/shared/components/fy-alert-info/fy-alert-info.component.html
@@ -3,7 +3,7 @@
   <mat-icon
     *ngIf="type === 'warning'"
     class="alert-info-container--icon icon--alert-warning"
-    svgIcon="danger"
+    svgIcon="warning-fill"
   ></mat-icon>
   <mat-icon *ngIf="type === 'error'" class="alert-info-container--icon" svgIcon="error-filled"></mat-icon>
   <div class="alert-info-container--message">{{ message }}</div>

--- a/src/app/shared/components/fy-policy-violation-info/fy-policy-violation-info.component.html
+++ b/src/app/shared/components/fy-policy-violation-info/fy-policy-violation-info.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="showPolicyInfo" class="policy-violation-info--container">
   <div class="policy-violation-info--block">
-    <mat-icon class="icon--alert-warning" svgIcon="danger"></mat-icon>
+    <mat-icon class="icon--alert-warning" svgIcon="warning-fill"></mat-icon>
     <div class="policy-violation-info--list-container">
       <ul
         class="policy-violation-info--list"


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8e16c1f</samp>

Updated icons for filter, warning, and policy violation components to match the new design. Changed the icons in `my-expenses-v2.page.html`, `fy-alert-info.component.html`, and `fy-policy-violation-info.component.html`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8e16c1f</samp>

> _`filter` icons change_
> _warning signs fill with color_
> _autumn of design_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8e16c1f</samp>

*  Update filter icons for my expenses page ([link](https://github.com/fylein/fyle-mobile-app/pull/2644/files?diff=unified&w=0#diff-b4465e7e0f48a51685b799138a4f40911bc55b2e90a2563e2d9c1e457f41fc21L16-R19))
*  Use filled warning icon for alert and policy violation components ([link](https://github.com/fylein/fyle-mobile-app/pull/2644/files?diff=unified&w=0#diff-acc16d1c70348840b548a66324a0c4dea6741e9162264094e10f3abdf5e8afbaL6-R6), [link](https://github.com/fylein/fyle-mobile-app/pull/2644/files?diff=unified&w=0#diff-65899eab6ccd3d8c4d76c0e37a35b147d2cbf5ecb34fb2019b424ab2785fb53dL3-R3))

## Clickup
https://app.clickup.com/t/86cu2uwcw

## UI fix
![Screenshot 2023-12-05 at 11 34 59 PM](https://github.com/fylein/fyle-mobile-app/assets/31147415/c711b421-9264-43d0-a4c6-6077f50eddd6)