### PR TITLE
fix: Minor fix in appflow release branch action

### DIFF
--- a/.github/workflows/appflow-release-branch.yml
+++ b/.github/workflows/appflow-release-branch.yml
@@ -3,7 +3,7 @@ name: Appflow Release Branch
 on:
   push:
     branches: 
-      - mobile_release_.*
+      - mobile_release_*
 
 jobs:
   build-app:

--- a/.github/workflows/appflow-release-branch.yml
+++ b/.github/workflows/appflow-release-branch.yml
@@ -3,7 +3,7 @@ name: Appflow Release Branch
 on:
   push:
     branches: 
-      - 'mobile_release_.*'
+      - mobile_release_.*
 
 jobs:
   build-app:

--- a/src/app/core/services/handle-duplicates.service.spec.ts
+++ b/src/app/core/services/handle-duplicates.service.spec.ts
@@ -7,7 +7,6 @@ import { handleDuplicatesDataResponse } from '../mock-data/handle-duplicates.ser
 describe('HandleDuplicatesService', () => {
   let handleDuplicatesService: HandleDuplicatesService;
   let apiService: jasmine.SpyObj<ApiService>;
-  // Testing
 
   beforeEach(() => {
     const apiServiceSpy = jasmine.createSpyObj('ApiService', ['get', 'post']);

--- a/src/app/core/services/handle-duplicates.service.spec.ts
+++ b/src/app/core/services/handle-duplicates.service.spec.ts
@@ -7,6 +7,7 @@ import { handleDuplicatesDataResponse } from '../mock-data/handle-duplicates.ser
 describe('HandleDuplicatesService', () => {
   let handleDuplicatesService: HandleDuplicatesService;
   let apiService: jasmine.SpyObj<ApiService>;
+  // Testing
 
   beforeEach(() => {
     const apiServiceSpy = jasmine.createSpyObj('ApiService', ['get', 'post']);


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9d52a33</samp>

This pull request fixes a workflow bug and adds a comment to a spec file. It removes the quotation marks from the `appflow-release-branch.yml` file to enable the release workflow, and it adds a comment to the `handle-duplicates.service.spec.ts` file to mark the testing section.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9d52a33</samp>

> _`branch` pattern fixed_
> _workflow runs on releases_
> _comment marks tests // kireji_

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9d52a33</samp>

* Fix workflow trigger bug by removing quotation marks from branch pattern ([link](https://github.com/fylein/fyle-mobile-app/pull/2646/files?diff=unified&w=0#diff-be5921f077f2d265286931b1ac72f1ac0e06a45d0d8bb90092972026d1c7e5f8L6-R6))
* Add comment to mark testing section in handle-duplicates service spec file ([link](https://github.com/fylein/fyle-mobile-app/pull/2646/files?diff=unified&w=0#diff-b5b35d0b1056b3604c3e4c0a3c3aae340988815ea1d3a4983e41ff785123c093R10))

## Clickup
https://app.clickup.com