### PR TITLE
fix: Sentry fix for - Error retrieving icon :card! Unable to find icon with the name ":card"

### DIFF
--- a/src/app/shared/icon/icon.module.ts
+++ b/src/app/shared/icon/icon.module.ts
@@ -30,6 +30,7 @@ export class IconModule {
     'calendar.svg',
     'camera.svg',
     'car.svg',
+    'card.svg',
     'cash-slash.svg',
     'cash.svg',
     'check-circle-outline.svg',


### PR DESCRIPTION
### Description
copilot:summary

copilot:poem

### Walkthrough
copilot:walkthrough

## Clickup
https://app.clickup.com/t/86cun95v7

Sentry error - https://fyle-technologies-private-limi.sentry.io/issues/4980325206/?alert_rule_id=8356629&alert_type=issue&environment=production&notification_uuid=13b793db-afd0-46db-aec9-6321d5fe05b8&project=5622998&referrer=slack