### PR TITLE
feat: added params x-page-url

### DIFF
--- a/src/app/core/interceptors/httpInterceptor.spec.ts
+++ b/src/app/core/interceptors/httpInterceptor.spec.ts
@@ -14,7 +14,7 @@ import { BehaviorSubject, of, throwError } from 'rxjs';
 import { extendedDeviceInfoMockData, extendedDeviceInfoMockDataWoApp } from '../mock-data/extended-device-info.data';
 import { HttpErrorResponse, HttpHeaders, HttpRequest } from '@angular/common/http';
 
-fdescribe('HttpConfigInterceptor', () => {
+describe('HttpConfigInterceptor', () => {
   let httpInterceptor: HttpConfigInterceptor;
   let jwtHelperService: jasmine.SpyObj<JwtHelperService>;
   let tokenService: jasmine.SpyObj<TokenService>;

--- a/src/app/core/interceptors/httpInterceptor.spec.ts
+++ b/src/app/core/interceptors/httpInterceptor.spec.ts
@@ -14,7 +14,7 @@ import { BehaviorSubject, of, throwError } from 'rxjs';
 import { extendedDeviceInfoMockData, extendedDeviceInfoMockDataWoApp } from '../mock-data/extended-device-info.data';
 import { HttpErrorResponse, HttpHeaders, HttpRequest } from '@angular/common/http';
 
-describe('HttpConfigInterceptor', () => {
+fdescribe('HttpConfigInterceptor', () => {
   let httpInterceptor: HttpConfigInterceptor;
   let jwtHelperService: jasmine.SpyObj<JwtHelperService>;
   let tokenService: jasmine.SpyObj<TokenService>;
@@ -81,6 +81,36 @@ describe('HttpConfigInterceptor', () => {
 
   it('should be created', () => {
     expect(httpInterceptor).toBeTruthy();
+  });
+
+  describe('getUrlWithoutQueryParam:', () => {
+    it('should return value truncating ;', () => {
+      const result = httpInterceptor.getUrlWithoutQueryParam(
+        'https://staging1.fyle.tech/enterprise/add_edit_expense;dataUrl=data:image%2Fjpeg%3Bbase64,%2F9j'
+      );
+      expect(result).toEqual('https://staging1.fyle.tech/enterprise/add_edit_expense');
+    });
+
+    it('should return value truncating ?', () => {
+      const result = httpInterceptor.getUrlWithoutQueryParam(
+        'https://staging1.fyle.tech/enterprise/add_edit_expense?dataUrl=data:image%2Fjpeg%3Bbase64,%2F9j'
+      );
+      expect(result).toEqual('https://staging1.fyle.tech/enterprise/add_edit_expense');
+    });
+
+    it('should return value truncating ;?', () => {
+      const result = httpInterceptor.getUrlWithoutQueryParam(
+        'https://staging1.fyle.tech/enterprise/add_edit_expense;?dataUrl=data:image%2Fjpeg%3Bbase64,%2F9j'
+      );
+      expect(result).toEqual('https://staging1.fyle.tech/enterprise/add_edit_expense');
+    });
+
+    it('should return value truncating ?;', () => {
+      const result = httpInterceptor.getUrlWithoutQueryParam(
+        'https://staging1.fyle.tech/enterprise/add_edit_expense?;dataUrl=data:image%2Fjpeg%3Bbase64,%2F9j'
+      );
+      expect(result).toEqual('https://staging1.fyle.tech/enterprise/add_edit_expense');
+    });
   });
 
   describe('secureUrl():', () => {


### PR DESCRIPTION
Added `X-PAGE-URL` in interceptor.

app.clickup.com

<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit d2fade9368f829d4c70784e53b448626b8d868e9.  | 
|--------|--------|

### Summary:
This PR adds `X-PAGE-URL` and `X-Source-Identifier` parameters to HTTP request headers, introduces a new function `getUrlWithoutQueryParam()`, and includes unit tests for this function.

**Key points**:
- Added `X-PAGE-URL` and `X-Source-Identifier` to the headers in the `intercept()` function of the `HttpConfigInterceptor` class.
- Created a new function `getUrlWithoutQueryParam()` to generate the value for `X-PAGE-URL`.
- Added unit tests for the new function in `httpInterceptor.spec.ts`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
