### PR TITLE
test: test fix for my expenses scanning receipt issue

### DIFF
--- a/src/app/fyle/my-expenses/my-expenses.page.spec.ts
+++ b/src/app/fyle/my-expenses/my-expenses.page.spec.ts
@@ -1411,15 +1411,17 @@ describe('MyExpensesV2Page', () => {
   });
 
   it('syncOutboxExpenses(): should call transactionoutboxService and do a refresh', fakeAsync(() => {
-    spyOn(component, 'formatTransactions').and.returnValues(apiExpenseRes, []);
-    transactionOutboxService.getPendingTransactions.and.returnValues(txnList, []);
+    const mockFormattedTransactions = cloneDeep(apiExpenseRes);
+    const mockPendingTransactions = cloneDeep(txnList);
+    spyOn(component, 'formatTransactions').and.returnValues(mockFormattedTransactions, []);
+    transactionOutboxService.getPendingTransactions.and.returnValues(mockPendingTransactions, []);
     transactionOutboxService.sync.and.resolveTo(undefined);
     spyOn(component, 'doRefresh');
 
     component.syncOutboxExpenses();
     tick(100);
 
-    expect(component.pendingTransactions).toEqual(apiExpenseRes);
+    expect(component.pendingTransactions).toEqual([]);
     expect(component.formatTransactions).toHaveBeenCalledTimes(2);
     expect(transactionOutboxService.getPendingTransactions).toHaveBeenCalledTimes(2);
     expect(transactionOutboxService.sync).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1ToX3dCktWnjknRk04ifeuVlBqN14apf4%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=QNvivmJ)
### Description
copilot:summary

copilot:poem

### Walkthrough
copilot:walkthrough

## Clickup
app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6860d4a80c24edcff296c6dddbcaac2546583989.  | 
|--------|--------|

### Summary:
This PR modifies the `syncOutboxExpenses()` function in `my-expenses.page.spec.ts` to use cloned versions of variables and changes the expected value of `pendingTransactions`.

**Key points**:
- Modified `syncOutboxExpenses()` function in `my-expenses.page.spec.ts`.
- Cloned `apiExpenseRes` and `txnList` to `mockFormattedTransactions` and `mockPendingTransactions` respectively.
- Called `formatTransactions` and `getPendingTransactions` with cloned versions.
- Changed expected value of `pendingTransactions` to an empty array.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
