### PR TITLE
feat: Add transformToV1Response & transformToV2Response for PlatformProject

### DIFF
--- a/src/app/core/models/platform/platform-project.model.ts
+++ b/src/app/core/models/platform/platform-project.model.ts
@@ -1,0 +1,13 @@
+export interface PlatformProject {
+  id: number;
+  org_id: string;
+  created_at: Date;
+  updated_at: Date;
+  name: string;
+  sub_project: string;
+  code: string;
+  display_name: string;
+  description: string;
+  is_enabled: boolean;
+  category_ids: number[];
+}

--- a/src/app/core/models/v2/project-v2.model.ts
+++ b/src/app/core/models/v2/project-v2.model.ts
@@ -1,11 +1,11 @@
 export interface ProjectV2 {
-  ap1_email: string;
-  ap1_full_name: string;
-  ap2_email: string;
-  ap2_full_name: string;
+  ap1_email?: string;
+  ap1_full_name?: string;
+  ap2_email?: string;
+  ap2_full_name?: string;
   project_active: boolean;
-  project_approver1_id: string;
-  project_approver2_id: string;
+  project_approver1_id?: string;
+  project_approver2_id?: string;
   project_code: string;
   project_created_at: Date;
   project_description: string;

--- a/src/app/core/services/projects.service.ts
+++ b/src/app/core/services/projects.service.ts
@@ -9,6 +9,7 @@ import { ProjectV1 } from '../models/v1/extended-project.model';
 import { ProjectParams } from '../models/project-params.model';
 import { intersection } from 'lodash';
 import { OrgCategory } from '../models/v1/org-category.model';
+import { PlatformProject } from '../models/platform/platform-project.model';
 
 @Injectable({
   providedIn: 'root',
@@ -161,5 +162,40 @@ export class ProjectsService {
             }))[0]
         )
       );
+  }
+
+  transformToV1Response(platformProject: PlatformProject[]): ProjectV1[] {
+    const projectV1 = platformProject.map((platformProject) => ({
+      id: platformProject.id,
+      created_at: platformProject.created_at,
+      updated_at: platformProject.updated_at,
+      name: platformProject.name,
+      sub_project: platformProject.sub_project,
+      code: platformProject.code,
+      org_id: platformProject.org_id,
+      description: platformProject.description,
+      active: platformProject.is_enabled,
+      org_category_ids: platformProject.category_ids,
+    }));
+
+    return projectV1;
+  }
+
+  transformToV2Response(platformProject: PlatformProject[]): ProjectV2[] {
+    const projectV2 = platformProject.map((platformProject) => ({
+      project_active: platformProject.is_enabled,
+      project_code: platformProject.code,
+      project_created_at: platformProject.created_at,
+      project_description: platformProject.description,
+      project_id: platformProject.id,
+      project_name: platformProject.name,
+      project_org_category_ids: platformProject.category_ids,
+      project_org_id: platformProject.org_id,
+      project_updated_at: platformProject.updated_at,
+      projectv2_name: platformProject.display_name,
+      sub_project_name: platformProject.sub_project,
+    }));
+
+    return projectV2;
   }
 }


### PR DESCRIPTION
### Description
As per the discussion in thread: https://fylein.slack.com/archives/C06M78V7JKD/p1713850203385719

Optional fields from `ProjectV2`
```diff
export interface ProjectV2 {
-  ap1_email?: string;
-  ap1_full_name?: string;
-  ap2_email?: string;
-  ap2_full_name?: string;
-  project_approver1_id?: string;
-  project_approver2_id?: string;
}
```

```diff
+ Created PlatformProject interface
+ Add transformToV1Response method
+ Add transformToV2Response method
```

## Clickup
[Please add link here](https://app.clickup.com/t/86cv9vhfa)