### PR TITLE
fix: Make projectService name consistent

### DIFF
--- a/src/app/core/services/merge-expenses.service.spec.ts
+++ b/src/app/core/services/merge-expenses.service.spec.ts
@@ -104,7 +104,7 @@ describe('MergeExpensesService', () => {
   let corporateCreditCardExpenseService: jasmine.SpyObj<CorporateCreditCardExpenseService>;
   let customInputsService: jasmine.SpyObj<CustomInputsService>;
   let humanizeCurrencyPipe: jasmine.SpyObj<HumanizeCurrencyPipe>;
-  let projectService: jasmine.SpyObj<ProjectsService>;
+  let projectsService: jasmine.SpyObj<ProjectsService>;
   let categoriesService: jasmine.SpyObj<CategoriesService>;
   let dateService: jasmine.SpyObj<DateService>;
   let taxGroupService: jasmine.SpyObj<TaxGroupService>;
@@ -121,7 +121,7 @@ describe('MergeExpensesService', () => {
     ]);
     const customInputsServiceSpy = jasmine.createSpyObj('CustomInputsService', ['getAll']);
     const humanizeCurrencyPipeSpy = jasmine.createSpyObj('HumanizeCurrencyPipe', ['transform']);
-    const projectServiceSpy = jasmine.createSpyObj('ProjectsService', ['getAllActive']);
+    const projectsServiceSpy = jasmine.createSpyObj('ProjectsService', ['getAllActive']);
     const categoriesServiceSpy = jasmine.createSpyObj('CategoriesService', ['getAll', 'filterRequired']);
     const dateServiceSpy = jasmine.createSpyObj('DateService', ['isValidDate']);
     const taxGroupServiceSpy = jasmine.createSpyObj('TaxGroupService', ['get']);
@@ -134,7 +134,7 @@ describe('MergeExpensesService', () => {
         { provide: CorporateCreditCardExpenseService, useValue: corporateCreditCardExpenseServiceSpy },
         { provide: CustomInputsService, useValue: customInputsServiceSpy },
         { provide: HumanizeCurrencyPipe, useValue: humanizeCurrencyPipeSpy },
-        { provide: ProjectsService, useValue: projectServiceSpy },
+        { provide: ProjectsService, useValue: projectsServiceSpy },
         { provide: CategoriesService, useValue: categoriesServiceSpy },
         { provide: DateService, useValue: dateServiceSpy },
         { provide: TaxGroupService, useValue: taxGroupServiceSpy },
@@ -148,7 +148,7 @@ describe('MergeExpensesService', () => {
     ) as jasmine.SpyObj<CorporateCreditCardExpenseService>;
     customInputsService = TestBed.inject(CustomInputsService) as jasmine.SpyObj<CustomInputsService>;
     humanizeCurrencyPipe = TestBed.inject(HumanizeCurrencyPipe) as jasmine.SpyObj<HumanizeCurrencyPipe>;
-    projectService = TestBed.inject(ProjectsService) as jasmine.SpyObj<ProjectsService>;
+    projectsService = TestBed.inject(ProjectsService) as jasmine.SpyObj<ProjectsService>;
     categoriesService = TestBed.inject(CategoriesService) as jasmine.SpyObj<CategoriesService>;
     dateService = TestBed.inject(DateService) as jasmine.SpyObj<DateService>;
     taxGroupService = TestBed.inject(TaxGroupService) as jasmine.SpyObj<TaxGroupService>;
@@ -404,7 +404,7 @@ describe('MergeExpensesService', () => {
 
   describe('formatProjectOptions():', () => {
     it('should return the project options', (done) => {
-      projectService.getAllActive.and.returnValue(of(projectsV1Data));
+      projectsService.getAllActive.and.returnValue(of(projectsV1Data));
       // @ts-ignore
       mergeExpensesService.formatProjectOptions(projectOptionsData).subscribe((res) => {
         expect(res).toEqual(projectOptionsData);
@@ -413,7 +413,7 @@ describe('MergeExpensesService', () => {
     });
 
     it('should return the project options with label as project name if id matches with option', (done) => {
-      projectService.getAllActive.and.returnValue(of(projectsV1Data));
+      projectsService.getAllActive.and.returnValue(of(projectsV1Data));
       // @ts-ignore
       mergeExpensesService.formatProjectOptions({ ...projectOptionsData, value: 257528 }).subscribe((res) => {
         expect(res).toEqual({ label: 'Customer Mapped Project', value: 257528 });
@@ -422,7 +422,7 @@ describe('MergeExpensesService', () => {
     });
 
     it('should return the project options when project is not present', (done) => {
-      projectService.getAllActive.and.returnValue(of([]));
+      projectsService.getAllActive.and.returnValue(of([]));
       // @ts-ignore
       mergeExpensesService.formatProjectOptions({ label: null, value: null }).subscribe((res) => {
         expect(res).toEqual({ label: undefined, value: null });

--- a/src/app/core/services/merge-expenses.service.ts
+++ b/src/app/core/services/merge-expenses.service.ts
@@ -43,7 +43,7 @@ export class MergeExpensesService {
     private corporateCreditCardExpenseService: CorporateCreditCardExpenseService,
     private customInputsService: CustomInputsService,
     private humanizeCurrency: HumanizeCurrencyPipe,
-    private projectService: ProjectsService,
+    private projectsService: ProjectsService,
     private categoriesService: CategoriesService,
     private dateService: DateService,
     private taxGroupService: TaxGroupService
@@ -748,7 +748,7 @@ export class MergeExpensesService {
   }
 
   private formatProjectOptions(option: MergeExpensesOption<number>): Observable<MergeExpensesOption<number>> {
-    const projects$ = this.projectService.getAllActive().pipe(shareReplay(1));
+    const projects$ = this.projectsService.getAllActive().pipe(shareReplay(1));
     return projects$.pipe(
       map((projects) => {
         const index = projects.map((project) => project.id).indexOf(option.value);

--- a/src/app/core/services/projects.service.spec.ts
+++ b/src/app/core/services/projects.service.spec.ts
@@ -25,7 +25,7 @@ const fixDate = (data) =>
   }));
 
 describe('ProjectsService', () => {
-  let projectService: ProjectsService;
+  let projectsService: ProjectsService;
   let apiService: jasmine.SpyObj<ApiService>;
   let apiV2Service: jasmine.SpyObj<ApiV2Service>;
 
@@ -46,18 +46,18 @@ describe('ProjectsService', () => {
         },
       ],
     });
-    projectService = TestBed.inject(ProjectsService);
+    projectsService = TestBed.inject(ProjectsService);
     apiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
     apiV2Service = TestBed.inject(ApiV2Service) as jasmine.SpyObj<ApiV2Service>;
   });
 
   it('should be created', () => {
-    expect(projectService).toBeTruthy();
+    expect(projectsService).toBeTruthy();
   });
 
   it('should be able to fetch project by id', (done) => {
     apiV2Service.get.and.returnValue(of(apiV2ResponseSingle));
-    projectService.getbyId(257528).subscribe((res) => {
+    projectsService.getbyId(257528).subscribe((res) => {
       expect(res).toEqual(fixDate(apiV2ResponseSingle.data)[0]);
       done();
     });
@@ -71,7 +71,7 @@ describe('ProjectsService', () => {
 
   it('should be able to fetch all active projects', (done) => {
     apiService.get.and.returnValue(of(apiResponseActiveOnly));
-    projectService.getAllActive().subscribe((res) => {
+    projectsService.getAllActive().subscribe((res) => {
       expect(res).toEqual(expectedReponseActiveOnly);
       done();
     });
@@ -86,7 +86,7 @@ describe('ProjectsService', () => {
   it('should be able to fetch data when no params provided', (done) => {
     apiV2Service.get.and.returnValue(of(apiV2ResponseMultiple));
 
-    projectService.getByParamsUnformatted({}).subscribe((res) => {
+    projectsService.getByParamsUnformatted({}).subscribe((res) => {
       expect(res).toEqual(fixDate(apiV2ResponseMultiple.data));
       done();
     });
@@ -95,7 +95,7 @@ describe('ProjectsService', () => {
   it('should be able to fetch data when params are provided', (done) => {
     apiV2Service.get.and.returnValue(of(apiV2ResponseMultiple));
 
-    const result = projectService.getByParamsUnformatted(testProjectParams);
+    const result = projectsService.getByParamsUnformatted(testProjectParams);
 
     result.subscribe((res) => {
       expect(res).toEqual(expectedProjectsResponse);
@@ -107,19 +107,19 @@ describe('ProjectsService', () => {
   });
 
   it('should category list after filter as per project passed', () => {
-    const result = projectService.getAllowedOrgCategoryIds(testProjectV2, testActiveCategoryList);
+    const result = projectsService.getAllowedOrgCategoryIds(testProjectV2, testActiveCategoryList);
     expect(result).toEqual(allowedActiveCategories);
   });
 
   it('should return whole category list if project passed is not present', () => {
-    const result = projectService.getAllowedOrgCategoryIds(null, testActiveCategoryList);
+    const result = projectsService.getAllowedOrgCategoryIds(null, testActiveCategoryList);
     expect(result).toEqual(testActiveCategoryList);
   });
 
   it('should get project count restricted by a set of category IDs', (done) => {
     apiService.get.and.returnValue(of(apiResponseActiveOnly));
 
-    const result = projectService.getProjectCount({ categoryIds: testCategoryIds });
+    const result = projectsService.getProjectCount({ categoryIds: testCategoryIds });
     result.subscribe((res) => {
       expect(res).toEqual(2);
       done();
@@ -129,8 +129,8 @@ describe('ProjectsService', () => {
   it('should get project count not restricted by a set of category IDs', (done) => {
     apiService.get.and.returnValue(of(apiResponseActiveOnly));
 
-    const resultWithOutParam = projectService.getProjectCount();
-    const resultWithParam = projectService.getProjectCount({ categoryIds: null });
+    const resultWithOutParam = projectsService.getProjectCount();
+    const resultWithParam = projectsService.getProjectCount({ categoryIds: null });
 
     resultWithOutParam.subscribe((res) => {
       expect(res).toEqual(apiResponseActiveOnly.length);

--- a/src/app/core/services/recently-used-items.service.spec.ts
+++ b/src/app/core/services/recently-used-items.service.spec.ts
@@ -20,7 +20,7 @@ import { recentUsedCategoriesRes } from '../mock-data/org-category-list-item.dat
 describe('RecentlyUsedItemsService', () => {
   let recentlyUsedItemsService: RecentlyUsedItemsService;
   let apiService: jasmine.SpyObj<ApiService>;
-  let projectService: jasmine.SpyObj<ProjectsService>;
+  let projectsService: jasmine.SpyObj<ProjectsService>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -38,7 +38,7 @@ describe('RecentlyUsedItemsService', () => {
     });
     recentlyUsedItemsService = TestBed.inject(RecentlyUsedItemsService);
     apiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
-    projectService = TestBed.inject(ProjectsService) as jasmine.SpyObj<ProjectsService>;
+    projectsService = TestBed.inject(ProjectsService) as jasmine.SpyObj<ProjectsService>;
   });
 
   it('should be created', () => {
@@ -56,14 +56,14 @@ describe('RecentlyUsedItemsService', () => {
 
   describe('getRecentlyUsedProjects():', () => {
     it('should get all the recently used projects', (done) => {
-      projectService.getByParamsUnformatted.and.returnValue(of(recentlyUsedProjectRes));
+      projectsService.getByParamsUnformatted.and.returnValue(of(recentlyUsedProjectRes));
       const config = {
         recentValues: recentlyUsedRes,
         eou: apiEouRes,
         categoryIds: ['16558', '16559', '16560', '16561', '16562'],
       };
       recentlyUsedItemsService.getRecentlyUsedProjects(config).subscribe((res) => {
-        expect(projectService.getByParamsUnformatted).toHaveBeenCalledOnceWith({
+        expect(projectsService.getByParamsUnformatted).toHaveBeenCalledOnceWith({
           orgId: config.eou.ou.org_id,
           active: true,
           sortDirection: 'asc',

--- a/src/app/core/services/recently-used-items.service.ts
+++ b/src/app/core/services/recently-used-items.service.ts
@@ -13,7 +13,7 @@ import { Currency, CurrencyName } from '../models/currency.model';
   providedIn: 'root',
 })
 export class RecentlyUsedItemsService {
-  constructor(private apiService: ApiService, private projectService: ProjectsService) {}
+  constructor(private apiService: ApiService, private projectsService: ProjectsService) {}
 
   getRecentlyUsed(): Observable<RecentlyUsed> {
     return this.apiService.get('/recently_used');
@@ -30,7 +30,7 @@ export class RecentlyUsedItemsService {
       config.recentValues.recent_project_ids.length > 0 &&
       config.eou
     ) {
-      return this.projectService
+      return this.projectsService
         .getByParamsUnformatted({
           orgId: config.eou.ou.org_id,
           active: true,

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -296,7 +296,7 @@ export class AddEditMileagePage implements OnInit {
     private reportService: ReportService,
     private platformReportService: ReportsService,
     private fb: FormBuilder,
-    private projectService: ProjectsService,
+    private projectsService: ProjectsService,
     private mileageService: MileageService,
     private mileageRatesService: MileageRatesService,
     private transactionsOutboxService: TransactionsOutboxService,
@@ -467,7 +467,7 @@ export class AddEditMileagePage implements OnInit {
       concatMap((project: ProjectV2) =>
         activeCategories$.pipe(
           map((activeCategories: OrgCategory[]) =>
-            this.projectService.getAllowedOrgCategoryIds(project, activeCategories)
+            this.projectsService.getAllowedOrgCategoryIds(project, activeCategories)
           )
         )
       ),
@@ -1160,7 +1160,7 @@ export class AddEditMileagePage implements OnInit {
       }),
       switchMap((projectId) => {
         if (projectId) {
-          return this.projectService.getbyId(projectId);
+          return this.projectsService.getbyId(projectId);
         } else {
           return of(null);
         }
@@ -1570,7 +1570,7 @@ export class AddEditMileagePage implements OnInit {
     this.setupFilteredCategories(this.subCategories$);
     this.projectCategoryIds$ = this.getProjectCategoryIds();
     this.isProjectVisible$ = this.projectCategoryIds$.pipe(
-      switchMap((projectCategoryIds) => this.projectService.getProjectCount({ categoryIds: projectCategoryIds })),
+      switchMap((projectCategoryIds) => this.projectsService.getProjectCount({ categoryIds: projectCategoryIds })),
       map((projectCount) => projectCount > 0)
     );
     this.comments$ = this.statusService.find('transactions', this.activatedRoute.snapshot.params.id as string);

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.setup.spec.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.setup.spec.ts
@@ -66,7 +66,7 @@ describe('AddEditPerDiemPage', () => {
       'removeTransaction',
     ]);
     const platformReportsServiceSpy = jasmine.createSpyObj('ReportsService', ['getAllReportsByParams']);
-    const projectServiceSpy = jasmine.createSpyObj('ProjectService', [
+    const projectsServiceSpy = jasmine.createSpyObj('ProjectService', [
       'getAllowedOrgCategoryIds',
       'getProjectCount',
       'getbyId',
@@ -175,7 +175,7 @@ describe('AddEditPerDiemPage', () => {
         },
         {
           provide: ProjectsService,
-          useValue: projectServiceSpy,
+          useValue: projectsServiceSpy,
         },
         {
           provide: TransactionsOutboxService,

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -259,7 +259,7 @@ export class AddEditPerDiemPage implements OnInit {
     private currencyService: CurrencyService,
     private reportService: ReportService,
     private platformReportService: ReportsService,
-    private projectService: ProjectsService,
+    private projectsService: ProjectsService,
     private transactionsOutboxService: TransactionsOutboxService,
     private transactionService: TransactionService,
     private authService: AuthService,
@@ -689,7 +689,7 @@ export class AddEditPerDiemPage implements OnInit {
       startWith(this.fg.controls.project.value),
       concatMap((project: ProjectV2) =>
         activeCategories$.pipe(
-          map((activeCategories) => this.projectService.getAllowedOrgCategoryIds(project, activeCategories))
+          map((activeCategories) => this.projectsService.getAllowedOrgCategoryIds(project, activeCategories))
         )
       ),
       map((categories) => categories.map((category) => ({ label: category.sub_category, value: category })))
@@ -1008,7 +1008,7 @@ export class AddEditPerDiemPage implements OnInit {
 
     this.projectCategoryIds$ = this.getProjectCategoryIds();
     this.isProjectVisible$ = this.projectCategoryIds$.pipe(
-      switchMap((projectCategoryIds) => this.projectService.getProjectCount({ categoryIds: projectCategoryIds })),
+      switchMap((projectCategoryIds) => this.projectsService.getProjectCount({ categoryIds: projectCategoryIds })),
       map((projectCount) => projectCount > 0)
     );
     this.comments$ = this.statusService.find('transactions', this.activatedRoute.snapshot.params.id as string);
@@ -1309,7 +1309,7 @@ export class AddEditPerDiemPage implements OnInit {
       }),
       switchMap((projectId) => {
         if (projectId) {
-          return this.projectService.getbyId(projectId);
+          return this.projectsService.getbyId(projectId);
         } else {
           return of(null);
         }

--- a/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.spec.ts
+++ b/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.spec.ts
@@ -40,7 +40,7 @@ describe('FyProjectSelectModalComponent', () => {
   let fixture: ComponentFixture<FyProjectSelectModalComponent>;
   let modalController: jasmine.SpyObj<ModalController>;
   let cdr: ChangeDetectorRef;
-  let projectService: jasmine.SpyObj<ProjectsService>;
+  let projectsService: jasmine.SpyObj<ProjectsService>;
   let authService: jasmine.SpyObj<AuthService>;
   let recentLocalStorageItemsService: jasmine.SpyObj<RecentLocalStorageItemsService>;
   let utilityService: jasmine.SpyObj<UtilityService>;
@@ -50,7 +50,7 @@ describe('FyProjectSelectModalComponent', () => {
 
   beforeEach(waitForAsync(() => {
     const modalControllerSpy = jasmine.createSpyObj('ModalController', ['dismiss']);
-    const projectServiceSpy = jasmine.createSpyObj('ProjectsService', ['getbyId', 'getByParamsUnformatted']);
+    const projectsServiceSpy = jasmine.createSpyObj('ProjectsService', ['getbyId', 'getByParamsUnformatted']);
     const authServiceSpy = jasmine.createSpyObj('AuthService', ['getEou']);
     const recentLocalStorageItemsServiceSpy = jasmine.createSpyObj('RecentLocalStorageItemsService', ['get', 'post']);
     const utilityServiceSpy = jasmine.createSpyObj('UtilityService', ['searchArrayStream']);
@@ -76,7 +76,7 @@ describe('FyProjectSelectModalComponent', () => {
         },
         {
           provide: ProjectsService,
-          useValue: projectServiceSpy,
+          useValue: projectsServiceSpy,
         },
         {
           provide: AuthService,
@@ -105,7 +105,7 @@ describe('FyProjectSelectModalComponent', () => {
 
     modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
     cdr = TestBed.inject(ChangeDetectorRef);
-    projectService = TestBed.inject(ProjectsService) as jasmine.SpyObj<ProjectsService>;
+    projectsService = TestBed.inject(ProjectsService) as jasmine.SpyObj<ProjectsService>;
     authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
     recentLocalStorageItemsService = TestBed.inject(
       RecentLocalStorageItemsService
@@ -114,13 +114,13 @@ describe('FyProjectSelectModalComponent', () => {
     orgSettingsService = TestBed.inject(OrgSettingsService) as jasmine.SpyObj<OrgSettingsService>;
     orgUserSettingsService = TestBed.inject(OrgUserSettingsService) as jasmine.SpyObj<OrgUserSettingsService>;
 
-    projectService.getbyId.and.returnValue(of(singleProjects1));
+    projectsService.getbyId.and.returnValue(of(singleProjects1));
 
     orgSettingsService.get.and.returnValue(of(orgSettingsData));
     authService.getEou.and.returnValue(Promise.resolve(apiEouRes));
     orgUserSettingsService.get.and.returnValue(of(orgUserSettingsData));
 
-    projectService.getByParamsUnformatted.and.returnValue(of([singleProject2]));
+    projectsService.getByParamsUnformatted.and.returnValue(of([singleProject2]));
 
     component.cacheName = 'projects';
     component.defaultValue = true;
@@ -138,8 +138,8 @@ describe('FyProjectSelectModalComponent', () => {
 
   describe('getProjects():', () => {
     it('should get projects when current selection is not defined', (done) => {
-      projectService.getByParamsUnformatted.and.returnValue(of(projects));
-      projectService.getbyId.and.returnValue(of(expectedProjects[0].value));
+      projectsService.getByParamsUnformatted.and.returnValue(of(projects));
+      projectsService.getbyId.and.returnValue(of(expectedProjects[0].value));
       authService.getEou.and.returnValue(Promise.resolve(apiEouRes));
 
       component.getProjects('projects').subscribe((res) => {
@@ -147,7 +147,7 @@ describe('FyProjectSelectModalComponent', () => {
         expect(orgSettingsService.get).toHaveBeenCalledTimes(2);
         expect(authService.getEou).toHaveBeenCalledTimes(2);
         expect(orgUserSettingsService.get).toHaveBeenCalledTimes(4);
-        expect(projectService.getByParamsUnformatted).toHaveBeenCalledWith({
+        expect(projectsService.getByParamsUnformatted).toHaveBeenCalledWith({
           orgId: 'orNVthTo2Zyo',
           active: true,
           sortDirection: 'asc',
@@ -158,13 +158,13 @@ describe('FyProjectSelectModalComponent', () => {
           offset: 0,
           limit: 20,
         });
-        expect(projectService.getbyId).toHaveBeenCalledWith(3943);
+        expect(projectsService.getbyId).toHaveBeenCalledWith(3943);
         done();
       });
     });
 
     it('should get projects when current selection is defined', (done) => {
-      projectService.getByParamsUnformatted.and.returnValue(of(projects));
+      projectsService.getByParamsUnformatted.and.returnValue(of(projects));
       component.currentSelection = testProjectV2;
       fixture.detectChanges();
 
@@ -173,7 +173,7 @@ describe('FyProjectSelectModalComponent', () => {
         expect(orgSettingsService.get).toHaveBeenCalledTimes(2);
         expect(authService.getEou).toHaveBeenCalledTimes(2);
         expect(orgUserSettingsService.get).toHaveBeenCalledTimes(4);
-        expect(projectService.getByParamsUnformatted).toHaveBeenCalledWith({
+        expect(projectsService.getByParamsUnformatted).toHaveBeenCalledWith({
           orgId: 'orNVthTo2Zyo',
           active: true,
           sortDirection: 'asc',
@@ -184,14 +184,14 @@ describe('FyProjectSelectModalComponent', () => {
           offset: 0,
           limit: 20,
         });
-        expect(projectService.getbyId).toHaveBeenCalledWith(3943);
+        expect(projectsService.getbyId).toHaveBeenCalledWith(3943);
         done();
       });
     });
 
     it('should get projects when default value is null and no default projects are available', (done) => {
       orgSettingsService.get.and.returnValue(of(orgSettingsDataWithoutAdvPro));
-      projectService.getbyId.and.returnValue(of(expectedProjects[0].value));
+      projectsService.getbyId.and.returnValue(of(expectedProjects[0].value));
       component.defaultValue = false;
       fixture.detectChanges();
 
@@ -199,7 +199,7 @@ describe('FyProjectSelectModalComponent', () => {
         expect(orgSettingsService.get).toHaveBeenCalledTimes(2);
         expect(authService.getEou).toHaveBeenCalledTimes(2);
         expect(orgUserSettingsService.get).toHaveBeenCalledTimes(4);
-        expect(projectService.getByParamsUnformatted).toHaveBeenCalledWith({
+        expect(projectsService.getByParamsUnformatted).toHaveBeenCalledWith({
           orgId: 'orNVthTo2Zyo',
           active: true,
           sortDirection: 'asc',
@@ -210,7 +210,7 @@ describe('FyProjectSelectModalComponent', () => {
           offset: 0,
           limit: 20,
         });
-        expect(projectService.getbyId).toHaveBeenCalledWith(3943);
+        expect(projectsService.getbyId).toHaveBeenCalledWith(3943);
         done();
       });
     });

--- a/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.ts
+++ b/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.ts
@@ -46,7 +46,7 @@ export class FyProjectSelectModalComponent implements AfterViewInit {
   constructor(
     private modalController: ModalController,
     private cdr: ChangeDetectorRef,
-    private projectService: ProjectsService,
+    private projectsService: ProjectsService,
     private authService: AuthService,
     private recentLocalStorageItemsService: RecentLocalStorageItemsService,
     private utilityService: UtilityService,
@@ -63,7 +63,7 @@ export class FyProjectSelectModalComponent implements AfterViewInit {
     const defaultProject$ = this.orgUserSettingsService.get().pipe(
       switchMap((orgUserSettings) => {
         if (orgUserSettings && orgUserSettings.preferences && orgUserSettings.preferences.default_project_id) {
-          return this.projectService.getbyId(orgUserSettings.preferences.default_project_id);
+          return this.projectsService.getbyId(orgUserSettings.preferences.default_project_id);
         } else {
           return of(null);
         }
@@ -83,7 +83,7 @@ export class FyProjectSelectModalComponent implements AfterViewInit {
       concatMap((allowedProjectIds) =>
         from(this.authService.getEou()).pipe(
           switchMap((eou) =>
-            this.projectService.getByParamsUnformatted({
+            this.projectsService.getByParamsUnformatted({
               orgId: eou.ou.org_id,
               active: true,
               sortDirection: 'asc',


### PR DESCRIPTION
### Description
Before starting with any changes what I have observed is in some places we are using service name as `projectsService` and in some `projectService` and hence while invoking the service functions I need to check in two different places. This PR is just to fix that inconsistency.

## Clickup
[Please add link here](https://app.clickup.com/t/86cv9n9jw)