### PR TITLE
fix: Add cache buster

### DIFF
--- a/src/app/core/services/platform/v1/spender/reports.service.spec.ts
+++ b/src/app/core/services/platform/v1/spender/reports.service.spec.ts
@@ -12,24 +12,34 @@ import {
   mockQueryParams,
 } from 'src/app/core/mock-data/platform-report.data';
 import { ReportsQueryParams } from 'src/app/core/models/platform/v1/reports-query-params.model';
+import { UserEventService } from '../../../user-event.service';
+import { TransactionService } from '../../../transaction.service';
 
 describe('SpenderReportsService', () => {
   let spenderReportsService: SpenderReportsService;
   let spenderPlatformV1ApiService: jasmine.SpyObj<SpenderPlatformV1ApiService>;
+  let userEventService: jasmine.SpyObj<UserEventService>;
+  let transactionService: jasmine.SpyObj<TransactionService>;
 
   beforeEach(() => {
     const spenderPlatformV1ApiServiceSpy = jasmine.createSpyObj('SpenderPlatformV1ApiService', ['get', 'post']);
+    const userEventServiceSpy = jasmine.createSpyObj('UserEventServive', ['clearTaskCache']);
+    const transactionServiceSpy = jasmine.createSpyObj('TransactionService', ['clearCache']);
     TestBed.configureTestingModule({
       providers: [
         SpenderReportsService,
         { provide: PAGINATION_SIZE, useValue: 2 },
         { provide: SpenderPlatformV1ApiService, useValue: spenderPlatformV1ApiServiceSpy },
+        { provide: UserEventService, useValue: userEventServiceSpy },
+        { provide: TransactionService, useValue: transactionServiceSpy },
       ],
     });
     spenderReportsService = TestBed.inject(SpenderReportsService);
     spenderPlatformV1ApiService = TestBed.inject(
       SpenderPlatformV1ApiService
     ) as jasmine.SpyObj<SpenderPlatformV1ApiService>;
+    userEventService = TestBed.inject(UserEventService) as jasmine.SpyObj<UserEventService>;
+    transactionService = TestBed.inject(TransactionService) as jasmine.SpyObj<TransactionService>;
   });
 
   it('should be created', () => {
@@ -125,6 +135,7 @@ describe('SpenderReportsService', () => {
 
   it('addExpenses(): should add an expense to a report', (done) => {
     spenderPlatformV1ApiService.post.and.returnValue(of(null));
+    spyOn(spenderReportsService, 'clearTransactionCache').and.returnValue(of(null));
 
     const reportID = 'rpvcIMRMyM3A';
     const txns = ['txTQVBx7W8EO'];
@@ -137,12 +148,14 @@ describe('SpenderReportsService', () => {
     };
     spenderReportsService.addExpenses(reportID, txns).subscribe(() => {
       expect(spenderPlatformV1ApiService.post).toHaveBeenCalledOnceWith('/reports/add_expenses', payload);
+      expect(spenderReportsService.clearTransactionCache).toHaveBeenCalledTimes(1);
       done();
     });
   });
 
   it('ejectExpenses(): should remove an expense from a report', (done) => {
     spenderPlatformV1ApiService.post.and.returnValue(of(null));
+    spyOn(spenderReportsService, 'clearTransactionCache').and.returnValue(of(null));
 
     const reportID = 'rpvcIMRMyM3A';
     const txns = ['txTQVBx7W8EO'];
@@ -156,6 +169,7 @@ describe('SpenderReportsService', () => {
     };
     spenderReportsService.ejectExpenses(reportID, txns[0]).subscribe(() => {
       expect(spenderPlatformV1ApiService.post).toHaveBeenCalledOnceWith('/reports/eject_expenses', payload);
+      expect(spenderReportsService.clearTransactionCache).toHaveBeenCalledTimes(1);
       done();
     });
   });

--- a/src/app/core/services/platform/v1/spender/reports.service.ts
+++ b/src/app/core/services/platform/v1/spender/reports.service.ts
@@ -36,48 +36,6 @@ export class SpenderReportsService {
     return this.transactionService.clearCache();
   }
 
-  getAllReportsByParams(queryParams: ReportsQueryParams): Observable<Report[]> {
-    return this.getReportsCount(queryParams).pipe(
-      switchMap((count) => {
-        count = count > this.paginationSize ? count / this.paginationSize : 1;
-        return range(0, count);
-      }),
-      concatMap((page) => {
-        let params = {
-          state: queryParams.state,
-          offset: this.paginationSize * page,
-          limit: this.paginationSize,
-        };
-        return this.getReportsByParams(params);
-      }),
-      reduce((acc, curr) => acc.concat(curr.data), [] as Report[])
-    );
-  }
-
-  getReportsCount(queryParams: ReportsQueryParams): Observable<number> {
-    let params = {
-      state: queryParams.state,
-      limit: 1,
-      offset: 0,
-    };
-    return this.getReportsByParams(params).pipe(map((res) => res.count));
-  }
-
-  getReportsByParams(queryParams: ReportsQueryParams = {}): Observable<PlatformApiResponse<Report[]>> {
-    const config = {
-      params: {
-        ...queryParams,
-      },
-    };
-    return this.spenderPlatformV1ApiService.get<PlatformApiResponse<Report[]>>('/reports', config);
-  }
-
-  createDraft(data: CreateDraftParams): Observable<Report> {
-    return this.spenderPlatformV1ApiService
-      .post<PlatformApiPayload<Report>>('/reports', data)
-      .pipe(map((res) => res.data));
-  }
-
   @CacheBuster({
     cacheBusterNotifier: reportsCacheBuster$,
   })
@@ -111,5 +69,47 @@ export class SpenderReportsService {
         this.clearTransactionCache();
       })
     );
+  }
+
+  getAllReportsByParams(queryParams: ReportsQueryParams): Observable<Report[]> {
+    return this.getReportsCount(queryParams).pipe(
+      switchMap((count) => {
+        count = count > this.paginationSize ? count / this.paginationSize : 1;
+        return range(0, count);
+      }),
+      concatMap((page) => {
+        const params = {
+          state: queryParams.state,
+          offset: this.paginationSize * page,
+          limit: this.paginationSize,
+        };
+        return this.getReportsByParams(params);
+      }),
+      reduce((acc, curr) => acc.concat(curr.data), [] as Report[])
+    );
+  }
+
+  getReportsCount(queryParams: ReportsQueryParams): Observable<number> {
+    const params = {
+      state: queryParams.state,
+      limit: 1,
+      offset: 0,
+    };
+    return this.getReportsByParams(params).pipe(map((res) => res.count));
+  }
+
+  getReportsByParams(queryParams: ReportsQueryParams = {}): Observable<PlatformApiResponse<Report[]>> {
+    const config = {
+      params: {
+        ...queryParams,
+      },
+    };
+    return this.spenderPlatformV1ApiService.get<PlatformApiResponse<Report[]>>('/reports', config);
+  }
+
+  createDraft(data: CreateDraftParams): Observable<Report> {
+    return this.spenderPlatformV1ApiService
+      .post<PlatformApiPayload<Report>>('/reports', data)
+      .pipe(map((res) => res.data));
   }
 }

--- a/src/app/core/services/platform/v1/spender/reports.service.ts
+++ b/src/app/core/services/platform/v1/spender/reports.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
-import { Observable, Subject, from, of, range } from 'rxjs';
-import { catchError, concatMap, map, mergeMap, reduce, switchMap, tap } from 'rxjs/operators';
+import { Observable, Subject, range } from 'rxjs';
+import { concatMap, map, reduce, switchMap, tap } from 'rxjs/operators';
 import { Report } from 'src/app/core/models/platform/v1/report.model';
 import { SpenderPlatformV1ApiService } from '../../../spender-platform-v1-api.service';
 import { PlatformApiResponse } from 'src/app/core/models/platform/platform-api-response.model';


### PR DESCRIPTION
Context:
- On removal of an expense from a report, the cached data for expenses was causing an issue in displaying correct expense info for a report
- This PR adds back clearing transaction cache to show correct report data after expense removal
<!--app.clickup.com-->