### PR TITLE
feat: use attach_receipt instead of public post api in expense card v2

### DIFF
--- a/src/app/core/services/platform/v1/spender/expenses.service.ts
+++ b/src/app/core/services/platform/v1/spender/expenses.service.ts
@@ -164,4 +164,17 @@ export class ExpensesService {
 
     return this.getAllExpenses(params);
   }
+
+  attachReceiptToExpense(expenseId: string, fileId: string): Observable<Expense> {
+    const payload = {
+      data: {
+        id: expenseId,
+        file_id: fileId,
+      },
+    };
+
+    return this.spenderService
+      .post<PlatformApiResponse<Expense>>('/expenses/attach_receipt', payload)
+      .pipe(map((res) => res.data));
+  }
 }

--- a/src/app/shared/components/expenses-card-v2/expenses-card.component.spec.ts
+++ b/src/app/shared/components/expenses-card-v2/expenses-card.component.spec.ts
@@ -68,7 +68,7 @@ describe('ExpensesCardComponent', () => {
 
   beforeEach(waitForAsync(() => {
     const transactionServiceSpy = jasmine.createSpyObj('TransactionService', ['transformExpense']);
-    const expensesServiceSpy = jasmine.createSpyObj('ExpensesService', ['getExpenseById']);
+    const expensesServiceSpy = jasmine.createSpyObj('ExpensesService', ['getExpenseById', 'attachReceiptToExpense']);
     const sharedExpenseServiceSpy = jasmine.createSpyObj('SharedExpenseService', [
       'isExpenseInDraft',
       'isCriticalPolicyViolatedExpense',
@@ -675,7 +675,7 @@ describe('ExpensesCardComponent', () => {
 
       fileService.getAttachmentType.and.returnValue(attachmentType);
       transactionsOutboxService.fileUpload.and.resolveTo(fileObj);
-      fileService.post.and.returnValue(of(fileObjectData));
+      expensesService.attachReceiptToExpense.and.returnValue(of(platformExpenseData));
 
       spyOn(component, 'matchReceiptWithEtxn').and.callThrough();
 
@@ -685,7 +685,7 @@ describe('ExpensesCardComponent', () => {
       expect(fileService.getAttachmentType).toHaveBeenCalledOnceWith(receiptDetailsaRes.type);
       expect(transactionsOutboxService.fileUpload).toHaveBeenCalledOnceWith(dataUrl, attachmentType);
       expect(component.matchReceiptWithEtxn).toHaveBeenCalledOnceWith(fileObj);
-      expect(fileService.post).toHaveBeenCalledOnceWith(fileObj);
+      expect(expensesService.attachReceiptToExpense).toHaveBeenCalledOnceWith(component.expense.id, fileObj.id);
       expect(component.attachmentUploadInProgress).toBeFalse();
       tick(500);
     }));

--- a/src/app/shared/components/expenses-card-v2/expenses-card.component.ts
+++ b/src/app/shared/components/expenses-card-v2/expenses-card.component.ts
@@ -464,7 +464,7 @@ export class ExpensesCardComponent implements OnInit {
       .pipe(
         switchMap((fileObj: FileObject) => {
           this.matchReceiptWithEtxn(fileObj);
-          return this.fileService.post(fileObj);
+          return this.expensesService.attachReceiptToExpense(this.expense.id, fileObj.id);
         }),
         finalize(() => {
           this.attachmentUploadInProgress = false;


### PR DESCRIPTION
### Description
copilot:summary

copilot:poem

### Walkthrough
copilot:walkthrough

## Clickup
https://app.clickup.com/t/86cv5ku5b

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes