### PR TITLE
fix: Fy-select-project-modal is not working properly with new selected

### DIFF
--- a/src/app/core/mock-data/org-category.data.ts
+++ b/src/app/core/mock-data/org-category.data.ts
@@ -370,6 +370,8 @@ export const orgCategoryPaginated1: OrgCategory[] = deepFreeze([
   },
 ]);
 
+export const categoryIds: string[] = deepFreeze(['129140', '129112']);
+
 export const orgCategoryPaginated2: OrgCategory[] = deepFreeze([
   {
     code: '51708',

--- a/src/app/core/mock-data/org-category.data.ts
+++ b/src/app/core/mock-data/org-category.data.ts
@@ -370,7 +370,7 @@ export const orgCategoryPaginated1: OrgCategory[] = deepFreeze([
   },
 ]);
 
-export const categoryIds: string[] = deepFreeze(['129140', '129112']);
+export const categoryIds: string[] = deepFreeze(['129140']);
 
 export const orgCategoryPaginated2: OrgCategory[] = deepFreeze([
   {

--- a/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.spec.ts
+++ b/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.spec.ts
@@ -35,9 +35,15 @@ import {
 import { click, getAllElementsBySelector, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
 import { By } from '@angular/platform-browser';
 import { CategoriesService } from 'src/app/core/services/categories.service';
-import { orgCategoryData, sortedCategory } from 'src/app/core/mock-data/org-category.data';
+import {
+  categoryIds,
+  expectedAllOrgCategories,
+  orgCategoryData,
+  orgCategoryPaginated1,
+  sortedCategory,
+} from 'src/app/core/mock-data/org-category.data';
 
-describe('FyProjectSelectModalComponent', () => {
+fdescribe('FyProjectSelectModalComponent', () => {
   let component: FyProjectSelectModalComponent;
   let fixture: ComponentFixture<FyProjectSelectModalComponent>;
   let modalController: jasmine.SpyObj<ModalController>;
@@ -59,7 +65,11 @@ describe('FyProjectSelectModalComponent', () => {
     const utilityServiceSpy = jasmine.createSpyObj('UtilityService', ['searchArrayStream']);
     const orgUserSettingsServiceSpy = jasmine.createSpyObj('OrgUserSettingsService', ['get']);
     const orgSettingsServiceSpy = jasmine.createSpyObj('OrgSettingsService', ['get']);
-    const categoriesServiceSpy = jasmine.createSpyObj('CategoriesService', ['getAll', 'filterRequired']);
+    const categoriesServiceSpy = jasmine.createSpyObj('CategoriesService', [
+      'getAll',
+      'filterRequired',
+      'getCategoryById',
+    ]);
 
     TestBed.configureTestingModule({
       declarations: [FyProjectSelectModalComponent, FyHighlightTextComponent, HighlightPipe],
@@ -366,33 +376,49 @@ describe('FyProjectSelectModalComponent', () => {
     });
   });
 
-  it('ngAfterViewInit(): show filtered projects and recently used items', fakeAsync((done) => {
-    spyOn(component, 'getRecentlyUsedItems').and.returnValue(of(expectedProjects));
-    spyOn(component, 'getProjects').and.returnValue(of(labelledProjects));
+  describe('ngAfterViewInit():', () => {
+    it('should get all categories by id if categoryIds are present', (done) => {
+      categoriesService.getCategoryById.and.callFake((id) => of(orgCategoryPaginated1.find((cat) => cat.id === id)));
 
-    utilityService.searchArrayStream.and.returnValue(() => of([{ label: 'project1', value: testProjectV2 }]));
-    fixture.detectChanges();
+      component.categoryIds = categoryIds;
+      component.ngAfterViewInit();
 
-    component.ngAfterViewInit();
-    inputElement.value = 'projects';
-    inputElement.dispatchEvent(new Event('keyup'));
-
-    tick(300);
-    component.recentrecentlyUsedItems$.subscribe((res) => {
-      expect(res).toEqual(expectedProjects4);
+      component.activeCategories$.subscribe((categories) => {
+        expect(categoriesService.getCategoryById).toHaveBeenCalledTimes(2);
+        expect(categories.length).toBe(2);
+        expect(categories).toEqual(orgCategoryPaginated1);
+        done();
+      });
     });
 
-    tick(300);
-    component.filteredOptions$.subscribe((res) => {
-      expect(res).toEqual(expectedLabelledProjects);
-    });
+    it('should show filtered projects and recently used items', fakeAsync((done) => {
+      spyOn(component, 'getRecentlyUsedItems').and.returnValue(of(expectedProjects));
+      spyOn(component, 'getProjects').and.returnValue(of(labelledProjects));
 
-    expect(component.getProjects).toHaveBeenCalledWith('projects');
-    expect(component.getRecentlyUsedItems).toHaveBeenCalled();
-    expect(utilityService.searchArrayStream).toHaveBeenCalledWith('projects');
+      utilityService.searchArrayStream.and.returnValue(() => of([{ label: 'project1', value: testProjectV2 }]));
+      fixture.detectChanges();
 
-    discardPeriodicTasks();
-  }));
+      component.ngAfterViewInit();
+      inputElement.value = 'projects';
+      inputElement.dispatchEvent(new Event('keyup'));
+
+      tick(300);
+      component.recentrecentlyUsedItems$.subscribe((res) => {
+        expect(res).toEqual(expectedProjects4);
+      });
+
+      tick(300);
+      component.filteredOptions$.subscribe((res) => {
+        expect(res).toEqual(expectedLabelledProjects);
+      });
+
+      expect(component.getProjects).toHaveBeenCalledWith('projects');
+      expect(component.getRecentlyUsedItems).toHaveBeenCalled();
+      expect(utilityService.searchArrayStream).toHaveBeenCalledWith('projects');
+
+      discardPeriodicTasks();
+    }));
+  });
 
   it('should show label on the screen', () => {
     component.activeCategories$ = of([]);

--- a/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.spec.ts
+++ b/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.spec.ts
@@ -140,6 +140,7 @@ describe('FyProjectSelectModalComponent', () => {
     orgUserSettingsService.get.and.returnValue(of(orgUserSettingsData));
 
     categoriesService.getAll.and.returnValue(of([orgCategoryData]));
+    categoriesService.getCategoryById.and.returnValue(of(orgCategoryPaginated1[0]));
 
     projectsService.getByParamsUnformatted.and.returnValue(of([singleProject2]));
 
@@ -378,15 +379,13 @@ describe('FyProjectSelectModalComponent', () => {
 
   describe('ngAfterViewInit():', () => {
     it('should get all categories by id if categoryIds are present', (done) => {
-      categoriesService.getCategoryById.and.callFake((id) => of(orgCategoryPaginated1.find((cat) => cat.id === id)));
-
       component.categoryIds = categoryIds;
       component.ngAfterViewInit();
 
       component.activeCategories$.subscribe((categories) => {
-        expect(categoriesService.getCategoryById).toHaveBeenCalledTimes(2);
-        expect(categories.length).toBe(2);
-        expect(categories).toEqual(orgCategoryPaginated1);
+        expect(categoriesService.getCategoryById).toHaveBeenCalledTimes(categoryIds.length);
+        expect(categories.length).toBe(categoryIds.length);
+        expect(categories).toEqual([orgCategoryPaginated1[0]]);
         done();
       });
     });

--- a/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.spec.ts
+++ b/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.spec.ts
@@ -43,7 +43,7 @@ import {
   sortedCategory,
 } from 'src/app/core/mock-data/org-category.data';
 
-fdescribe('FyProjectSelectModalComponent', () => {
+describe('FyProjectSelectModalComponent', () => {
   let component: FyProjectSelectModalComponent;
   let fixture: ComponentFixture<FyProjectSelectModalComponent>;
   let modalController: jasmine.SpyObj<ModalController>;

--- a/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.ts
+++ b/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.ts
@@ -91,10 +91,10 @@ export class FyProjectSelectModalComponent implements AfterViewInit {
         return forkJoin({
           allowedProjectIds: allowedProjectIds$,
           eou: from(this.authService.getEou()),
-          allActiveCategories: this.activeCategories$,
+          activeCategories: this.activeCategories$,
         });
       }),
-      switchMap(({ allowedProjectIds, eou, allActiveCategories }) =>
+      switchMap(({ allowedProjectIds, eou, activeCategories }) =>
         this.projectsService.getByParamsUnformatted(
           {
             orgId: eou.ou.org_id,
@@ -107,7 +107,7 @@ export class FyProjectSelectModalComponent implements AfterViewInit {
             offset: 0,
             limit: 20,
           },
-          allActiveCategories
+          activeCategories
         )
       ),
       switchMap((projects) => {
@@ -176,7 +176,17 @@ export class FyProjectSelectModalComponent implements AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this.activeCategories$ = this.getActiveCategories().pipe(shareReplay(1));
+    if (this.categoryIds?.length > 0) {
+      this.activeCategories$ = forkJoin(
+        this.categoryIds.map((id) => this.categoriesService.getCategoryById(parseInt(id, 10)))
+      ).pipe(
+        map((categories) => categories),
+        shareReplay(1)
+      );
+    } else {
+      // Fallback if this.categoryIds is empty
+      this.activeCategories$ = this.getActiveCategories().pipe(shareReplay(1));
+    }
 
     this.filteredOptions$ = fromEvent<{ target: HTMLInputElement }>(this.searchBarRef.nativeElement, 'keyup').pipe(
       map((event) => event.target.value),

--- a/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.ts
+++ b/src/app/shared/components/fy-select-project/fy-select-modal/fy-select-project-modal.component.ts
@@ -179,10 +179,7 @@ export class FyProjectSelectModalComponent implements AfterViewInit {
     if (this.categoryIds?.length > 0) {
       this.activeCategories$ = forkJoin(
         this.categoryIds.map((id) => this.categoriesService.getCategoryById(parseInt(id, 10)))
-      ).pipe(
-        map((categories) => categories),
-        shareReplay(1)
-      );
+      ).pipe(shareReplay(1));
     } else {
       // Fallback if this.categoryIds is empty
       this.activeCategories$ = this.getActiveCategories().pipe(shareReplay(1));


### PR DESCRIPTION
### Description
Found one bug while testing...
What is the bug? Fy-select-project-modal is not working properly with newly selected projects, it is working properly with recently used projects.
Solution: I have figured out a solution. The problem is I am making call for allActiveCategories in fy-select-project-modal, instead, I need to get only selected categories. So making fixing changes.


## ClickUp
[click-up](https://app.clickup.com/t/86cvjxg6j)