### PR TITLE
fix: breaking edit expense page

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -2542,11 +2542,11 @@ export class AddEditExpensePage implements OnInit {
       switchMap((etxn) => {
         if (etxn.tx.project_id) {
           return this.activeCategories$.pipe(
-            map((allActiveCategories) => this.projectsService.getbyId(etxn.tx.project_id, allActiveCategories))
+            concatMap((allActiveCategories) => this.projectsService.getbyId(etxn.tx.project_id, allActiveCategories))
           );
         } else if (projectControl?.value?.project_id) {
           return this.activeCategories$.pipe(
-            map((allActiveCategories) =>
+            concatMap((allActiveCategories) =>
               this.projectsService.getbyId(projectControl.value.project_id, allActiveCategories)
             )
           );


### PR DESCRIPTION
### Description
Why map caused the error and will concatMap work?
In this case, this.activeCategories$ emits categories and this.projectsService.getbyId()  returns an Observable representing the project data.
- `map`:  it would try to emit the Observable returned by getbyId directly. This would result in an error because the subscribe method expects a single value, not another Observable.
- `concatMap`: By using concatMap, we are instructing it to subscribe to the inner Observable (from getbyId) and then merge the project data emissions into the final stream.


## Clickup
[click-up](https://app.clickup.com/t/86cvjz2jy)
