### PR TITLE
fix: fixed getCategoryById duplicate calls in add-edit expense page

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense-3.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-3.spec.ts
@@ -1069,14 +1069,13 @@ export function TestCases3(getTestBed) {
         component.recentlyUsedCategories$ = of(recentUsedCategoriesRes);
         component.etxn$ = of(unflattenedPaidExp);
         component.initialFetch = true;
-        categoriesService.getCategoryById.and.returnValue(of(orgCategoryData1[0]));
+        component.selectedCategory$ = of(orgCategoryData1[0]);
 
         fixture.detectChanges();
         component.getCategoryOnEdit(orgCategoryData1[0]).subscribe((res) => {
           expect(res).toEqual(orgCategoryPaginated1[0]);
           expect(orgUserSettingsService.get).toHaveBeenCalledTimes(1);
           expect(orgSettingsService.get).toHaveBeenCalledTimes(1);
-          expect(categoriesService.getCategoryById).toHaveBeenCalledOnceWith(unflattenedDraftExp.tx.org_category_id);
           done();
         });
       });
@@ -1091,14 +1090,13 @@ export function TestCases3(getTestBed) {
           tx: { ...unflattenedPaidExp.tx, fyle_category: undefined, state: 'DRAFT' },
         });
         component.initialFetch = true;
-        categoriesService.getCategoryById.and.returnValue(of(orgCategoryData1[0]));
+        component.selectedCategory$ = of(orgCategoryData1[0]);
 
         fixture.detectChanges();
         component.getCategoryOnEdit(orgCategoryData1[0]).subscribe((res) => {
           expect(res).toEqual(orgCategoryPaginated1[0]);
           expect(orgUserSettingsService.get).toHaveBeenCalledTimes(1);
           expect(orgSettingsService.get).toHaveBeenCalledTimes(1);
-          expect(categoriesService.getCategoryById).toHaveBeenCalledOnceWith(unflattenedDraftExp.tx.org_category_id);
           done();
         });
       });

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -429,6 +429,8 @@ export class AddEditExpensePage implements OnInit {
 
   activeCategories$: Observable<OrgCategory[]>;
 
+  selectedCategory$: Observable<OrgCategory>;
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private accountsService: AccountsService,
@@ -1655,7 +1657,7 @@ export class AddEditExpensePage implements OnInit {
   setupFormInit(): void {
     const selectedProject$ = this.getSelectedProjects();
 
-    const selectedCategory$ = this.getSelectedCategory();
+    this.selectedCategory$ = this.getSelectedCategory().pipe(shareReplay(1));
 
     const selectedReport$ = this.getSelectedReport();
 
@@ -1682,7 +1684,7 @@ export class AddEditExpensePage implements OnInit {
             etxn: this.etxn$,
             paymentMode: selectedPaymentMode$,
             project: selectedProject$,
-            category: selectedCategory$,
+            category: this.selectedCategory$,
             report: selectedReport$,
             costCenter: selectedCostCenter$,
             customExpenseFields: customExpenseFields$,
@@ -2058,7 +2060,7 @@ export class AddEditExpensePage implements OnInit {
         }) => {
           const isExpenseCategoryUnspecified = etxn.tx.fyle_category?.toLowerCase() === 'unspecified';
           if (this.initialFetch && etxn.tx.org_category_id && !isExpenseCategoryUnspecified) {
-            return this.categoriesService.getCategoryById(etxn.tx.org_category_id).pipe(
+            return this.selectedCategory$.pipe(
               map((selectedCategory) => ({
                 orgUserSettings,
                 orgSettings,


### PR DESCRIPTION
### Description
fixed getCategoryById duplicate calls in add-edit expense page

## Before:
https://github.com/fylein/fyle-mobile-app/assets/132900359/b9e86479-4f14-4d6c-94c3-581a118f7895

## After:
https://github.com/fylein/fyle-mobile-app/assets/132900359/8df3b1b2-08f6-42ad-80aa-e1ca95a690ec


## Clickup
https://app.clickup.com/t/86cvhh5wr