### PR TITLE
fix: include sub project in projects search

### DIFF
--- a/src/app/core/mock-data/platform/v1/platform-projects-params.data.ts
+++ b/src/app/core/mock-data/platform/v1/platform-projects-params.data.ts
@@ -7,7 +7,6 @@ export const ProjectPlatformParams: PlatformProjectParams = deepFreeze({
   limit: 10,
   offset: 0,
   is_enabled: 'eq.true',
-  or: '(category_ids.is.null, category_ids.ov.{122269,122270,122271,122272,122273})',
+  or: '(category_ids.is.null, category_ids.ov.{122269,122270,122271,122272,122273},name.ilike."%search%",sub_project.ilike."%search%")',
   id: 'in.(3943,305792,148971,247936)',
-  name: 'ilike.%search%',
 });

--- a/src/app/core/services/projects.service.ts
+++ b/src/app/core/services/projects.service.ts
@@ -84,11 +84,11 @@ export class ProjectsService {
   addNameSearchFilter(searchNameText: string, params: PlatformProjectParams): void {
     if (typeof searchNameText !== 'undefined' && searchNameText !== null) {
       if (params.or) {
-        params.or = params.or.slice(0, -1);
-        params.or += ',name.ilike."%' + searchNameText + '%",sub_project.ilike."%' + searchNameText + '%")';
+        params.or = params.or.slice(0, -1) + ',';
       } else {
-        params.or = '(name.ilike."%' + searchNameText + '%",sub_project.ilike."%' + searchNameText + '%")';
+        params.or = '(';
       }
+      params.or += `name.ilike."%${searchNameText}%",sub_project.ilike."%${searchNameText}%")`;
     }
   }
 

--- a/src/app/core/services/projects.service.ts
+++ b/src/app/core/services/projects.service.ts
@@ -83,7 +83,7 @@ export class ProjectsService {
 
   addNameSearchFilter(searchNameText: string, params: PlatformProjectParams): void {
     if (typeof searchNameText !== 'undefined' && searchNameText !== null) {
-      params.name = 'ilike.%' + searchNameText + '%';
+      params.or = '(name.ilike."%' + searchNameText + '%",sub_project.ilike."%' + searchNameText + '%")';
     }
   }
 

--- a/src/app/core/services/projects.service.ts
+++ b/src/app/core/services/projects.service.ts
@@ -48,11 +48,11 @@ export class ProjectsService {
     // `orgCategoryIds` can be optional
     this.addOrgCategoryIdsFilter(orgCategoryIds, params);
 
-    // `projectIds` can be optional
-    this.addProjectIdsFilter(projectIds, params);
-
     // `searchNameText` can be optional
     this.addNameSearchFilter(searchNameText, params);
+
+    // `projectIds` can be optional
+    this.addProjectIdsFilter(projectIds, params);
 
     return this.spenderPlatformV1ApiService
       .get<PlatformApiResponse<PlatformProject[]>>('/projects', {
@@ -83,7 +83,12 @@ export class ProjectsService {
 
   addNameSearchFilter(searchNameText: string, params: PlatformProjectParams): void {
     if (typeof searchNameText !== 'undefined' && searchNameText !== null) {
-      params.or = '(name.ilike."%' + searchNameText + '%",sub_project.ilike."%' + searchNameText + '%")';
+      if (params.or) {
+        params.or = params.or.slice(0, -1);
+        params.or += ',name.ilike."%' + searchNameText + '%",sub_project.ilike."%' + searchNameText + '%")';
+      } else {
+        params.or = '(name.ilike."%' + searchNameText + '%",sub_project.ilike."%' + searchNameText + '%")';
+      }
     }
   }
 

--- a/src/app/core/services/projects.service.ts
+++ b/src/app/core/services/projects.service.ts
@@ -83,11 +83,7 @@ export class ProjectsService {
 
   addNameSearchFilter(searchNameText: string, params: PlatformProjectParams): void {
     if (typeof searchNameText !== 'undefined' && searchNameText !== null) {
-      if (params.or) {
-        params.or = params.or.slice(0, -1) + ',';
-      } else {
-        params.or = '(';
-      }
+      params.or = params.or ? `${params.or.slice(0, -1)},` : '(';
       params.or += `name.ilike."%${searchNameText}%",sub_project.ilike."%${searchNameText}%")`;
     }
   }


### PR DESCRIPTION
ClickUp: https://app.clickup.com/t/86cvy3jnh

The sub project field was not being included while searching projects, added both `name` and `sub_project` to `or` param here.
