### PR TITLE
fix: ProjectsService.getByParamsUnformatted query param bug

### DIFF
--- a/src/app/core/services/projects.service.ts
+++ b/src/app/core/services/projects.service.ts
@@ -32,7 +32,7 @@ export class ProjectsService {
     // eslint-disable-next-line prefer-const
     let { orgId, isEnabled, orgCategoryIds, searchNameText, limit, offset, sortOrder, sortDirection, projectIds } =
       projectParams;
-    sortOrder = sortOrder || 'project_updated_at';
+    sortOrder = sortOrder || 'updated_at';
     sortDirection = sortDirection || 'desc';
 
     const params: PlatformProjectParams = {


### PR DESCRIPTION
### Description
ProjectsService.getByParamsUnformatted query param bug
This did not give any error because we are always passing sortOrder = "name" by default.

## Clickup
[clickup link](https://app.clickup.com/t/86cvz4km4)
