### PR TITLE
fix: my expenses complete method typeerror

### DIFF
--- a/src/app/fyle/my-expenses/my-expenses.page.ts
+++ b/src/app/fyle/my-expenses/my-expenses.page.ts
@@ -825,7 +825,7 @@ export class MyExpensesPage implements OnInit {
     this.loadExpenses$.next(params);
 
     setTimeout(() => {
-      event?.target?.complete();
+      event?.target?.complete?.();
     }, 1000);
   }
 

--- a/src/app/fyle/team-reports/team-reports.page.ts
+++ b/src/app/fyle/team-reports/team-reports.page.ts
@@ -252,7 +252,11 @@ export class TeamReportsPage implements OnInit {
     params.pageNumber = this.currentPageNumber;
     this.loadData$.next(params);
     setTimeout(() => {
-      event?.target?.complete();
+      if (typeof event?.target?.complete === 'function') {
+        event.target.complete();
+      } else {
+        console.error('complete() method is not available on the target element');
+      }
     }, 1000);
   }
 

--- a/src/app/fyle/team-reports/team-reports.page.ts
+++ b/src/app/fyle/team-reports/team-reports.page.ts
@@ -252,11 +252,7 @@ export class TeamReportsPage implements OnInit {
     params.pageNumber = this.currentPageNumber;
     this.loadData$.next(params);
     setTimeout(() => {
-      if (typeof event?.target?.complete === 'function') {
-        event.target.complete();
-      } else {
-        console.error('complete() method is not available on the target element');
-      }
+      event?.target?.complete?.();
     }, 1000);
   }
 


### PR DESCRIPTION
## Clickup
app.clickup.com

## Code Coverage
TypeError
i.complete is not a function. (In 'i.complete()', 'i.complete' is undefined)

Solved using optional chaining on the complete method too

The error i.complete() is not a function occurs when the complete method is either undefined or not a function on the target object. I confirmed through console logs that event.target is a valid ion-infinite-scroll element, and the complete method exists as a function. However, if the method doesn't exist for a specific user, it might be missing or incorrectly bound to the target element. As a fallback, I implemented a check using the optional chaining to ensure that if event.target or complete isn't a function, the complete method won't be called, preventing the error.

## UI Preview
Please add screenshots for UI changes