### PR TITLE
fix: personal-cards-typeerror o.complete

### DIFF
--- a/src/app/fyle/personal-cards/personal-cards.page.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.ts
@@ -434,7 +434,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
     this.loadData$.next(params);
 
     setTimeout(() => {
-      event?.target?.complete();
+      event?.target?.complete?.();
     }, 1000);
   }
 


### PR DESCRIPTION
## Clickup
app.clickup.com

## Code Coverage
TypeError
o.complete is not a function. (In 'o.complete()', 'o.complete' is undefined)
Here we can solve it by applying optional chaining to the complete method also
Like: event?.target?.complete?.();

## UI Preview
Please add screenshots for UI changes