### PR TITLE
fix: Filter extracted merchant name before display

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense-3.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-3.spec.ts
@@ -254,6 +254,7 @@ export function TestCases3(getTestBed) {
       component._isExpandedView = true;
       component.navigateBack = true;
       component.hardwareBackButtonAction = new Subscription();
+      component.vendorOptions = ['vendor'];
       fixture.detectChanges();
     });
 

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -921,7 +921,7 @@
               </app-virtual-select>
               <div
                 class="add-edit-expense--auto-coded"
-                *ngIf="(autoCodedData?.vendor_name && fg.controls.vendor_id?.value?.display_name) && autoCodedData.vendor_name === fg.controls.vendor_id.value.display_name"
+                *ngIf="(autoCodedData?.vendor_name && fg.controls.vendor_id?.value?.display_name) && autoCodedData.vendor_name?.toLowerCase() === fg.controls.vendor_id.value.display_name?.toLowerCase()"
               >
                 <mat-icon class="add-edit-expense--sparkle-icon" svgIcon="sparkle"></mat-icon>
                 Merchant is auto coded.

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -4525,15 +4525,30 @@ export class AddEditExpensePage implements OnInit {
         }
 
         if (!this.fg.controls.vendor_id.value && extractedData.vendor) {
-          this.txnFields$.subscribe((res) => {
-            res.vendor_id.options.map((merchant) => {
-              if (merchant.label.toLowerCase() === extractedData.vendor.toLowerCase()) {
+          this.txnFields$
+            .pipe(
+              map((res) => res.vendor_id.options),
+              filter((options) => !!options && options.length > 0),
+              map((options) =>
+                options.find(
+                  (merchant) =>
+                    (typeof merchant === 'object' && merchant.label.toLowerCase()) ===
+                    extractedData.vendor.toLowerCase()
+                )
+              ),
+              filter((merchant) => !!merchant)
+            )
+            .subscribe((merchant) => {
+              if (typeof merchant === 'object' && typeof merchant.value === 'object') {
                 this.fg.patchValue({
                   vendor_id: { display_name: merchant.value.display_name },
                 });
+              } else {
+                this.fg.patchValue({
+                  vendor_id: null,
+                });
               }
             });
-          });
         }
 
         // If category is auto-filled and there exists extracted category, priority is given to extracted category

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1487,7 +1487,7 @@ export class AddEditExpensePage implements OnInit {
             }
 
             if (extractedData.vendor) {
-              const vendor = this.filterVendor(etxn.tx.extracted_data.vendor);
+              const vendor = this.filterVendor(extractedData.vendor);
               etxn.tx.vendor = vendor;
             }
 

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -4525,8 +4525,14 @@ export class AddEditExpensePage implements OnInit {
         }
 
         if (!this.fg.controls.vendor_id.value && extractedData.vendor) {
-          this.fg.patchValue({
-            vendor_id: { display_name: extractedData.vendor },
+          this.txnFields$.subscribe((res) => {
+            res.vendor_id.options.map((merchant) => {
+              if (merchant.label.toLowerCase() === extractedData.vendor.toLowerCase()) {
+                this.fg.patchValue({
+                  vendor_id: { display_name: merchant.value.display_name },
+                });
+              }
+            });
           });
         }
 


### PR DESCRIPTION
## Description
- This fixes an issue where it sets the extracted vendor to vendor field even when its not present in the company's vendor list
- Added a method for the fix which loops through the vendor list and checks if the extracted merchant is present 

## Clickup
https://app.clickup.com/t/86cwdt5t1

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced vendor filtering functionality when adding or editing expenses, improving the accuracy of vendor assignment.
	- Automatically updates vendor information based on available transaction data, ensuring users have the correct vendor displayed.
	- Improved form validation and user experience through case-insensitive comparisons and conditional rendering of form elements.

- **Tests**
	- Expanded test coverage for the `AddEditExpensePage` component, including vendor selection, policy violation checks, and expense parsing for various file types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->