### PR TITLE
fix: fix reference for system_category field to make sub categories visible in Mileage Form

### DIFF
--- a/src/app/core/mock-data/org-category.data.ts
+++ b/src/app/core/mock-data/org-category.data.ts
@@ -1103,7 +1103,7 @@ export const mileageCategories2: OrgCategory[] = deepFreeze([
     created_at: new Date('2021-05-18T11:40:38.576Z'),
     displayName: 'mileage',
     enabled: true,
-    fyle_category: 'Food',
+    fyle_category: 'Mileage',
     id: 141295,
     name: 'mileage',
     org_id: 'orrjqbDbeP9p',

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-2.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-2.spec.ts
@@ -250,7 +250,7 @@ export function TestCases2(getTestBed) {
       component.getMileageCategories().subscribe((res) => {
         expect(res).toEqual({
           defaultMileageCategory: mileageCategories2[0],
-          mileageCategories: [mileageCategories2[1]],
+          mileageCategories: [mileageCategories2[0], mileageCategories2[1]],
         });
         expect(categoriesService.getAll).toHaveBeenCalledTimes(1);
         done();
@@ -262,7 +262,7 @@ export function TestCases2(getTestBed) {
         categoriesService.getAll.and.returnValue(of(mileageCategories2));
 
         component.getSubCategories().subscribe((res) => {
-          expect(res).toEqual([mileageCategories2[0]]);
+          expect(res).toEqual([mileageCategories2[0], mileageCategories2[1]]);
           expect(categoriesService.getAll).toHaveBeenCalledTimes(1);
           done();
         });

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -671,7 +671,7 @@ export class AddEditMileagePage implements OnInit {
         const parentCategoryName = 'mileage';
         return categories.filter(
           (orgCategory) =>
-            parentCategoryName.toLowerCase() === orgCategory.name?.toLowerCase() &&
+            parentCategoryName.toLowerCase() === orgCategory.fyle_category?.toLowerCase() &&
             parentCategoryName.toLowerCase() !== orgCategory.sub_category?.toLowerCase()
         );
       }),

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -634,7 +634,7 @@ export class AddEditPerDiemPage implements OnInit {
         const parentCategoryName = 'per diem';
         return categories.filter(
           (orgCategory) =>
-            parentCategoryName.toLowerCase() === orgCategory.name?.toLowerCase() &&
+            parentCategoryName.toLowerCase() === orgCategory.fyle_category?.toLowerCase() &&
             parentCategoryName.toLowerCase() !== orgCategory.sub_category?.toLowerCase()
         );
       }),


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86cwk7q7w

## Description
The sub category field was not visible in mobile app Mileage form, because the sub category filter was returning null. Instead of checking `name`, the system category needs to be checked here.

The web app equivalent for this filtering logic is getting category by checking if system category is mileage and sub category not being null, as follows:
```
is_enabled: eq.true
limit: 200
offset: 0
sub_category: neq.null
system_category: eq.Mileage
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced filtering logic for mileage and per diem categories, improving the accuracy of displayed options.
	- Updated methods now return both primary and secondary mileage categories, ensuring users have access to all relevant data.

- **Bug Fixes**
	- Corrected categorization of mileage data to ensure proper alignment with intended classifications.

- **Tests**
	- Adjusted test cases to reflect changes in category filtering and expected outputs, ensuring reliability of functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->