### PR TITLE
fix: TypeError: Cannot read properties of undefined (reading 'currency')

### DIFF
--- a/src/app/shared/components/fy-currency/fy-currency.component.ts
+++ b/src/app/shared/components/fy-currency/fy-currency.component.ts
@@ -178,8 +178,8 @@ export class FyCurrencyComponent implements ControlValueAccessor, OnInit, OnChan
 
   showAutoCodeMessage(): void {
     const { currency, amount } = this.autoCodedData || {};
-    const formCurrency = (this.fg?.value as CurrencyAmountFormValues).currency;
-    const formAmount = (this.fg?.value as CurrencyAmountFormValues).amount;
+    const formCurrency = (this.fg?.value as CurrencyAmountFormValues)?.currency;
+    const formAmount = (this.fg?.value as CurrencyAmountFormValues)?.amount;
 
     const isCurrencyAutoCoded = currency && currency === formCurrency;
     const isAmountAutoCoded = amount && amount === formAmount;

--- a/src/app/shared/components/fy-currency/fy-currency.component.ts
+++ b/src/app/shared/components/fy-currency/fy-currency.component.ts
@@ -178,8 +178,7 @@ export class FyCurrencyComponent implements ControlValueAccessor, OnInit, OnChan
 
   showAutoCodeMessage(): void {
     const { currency, amount } = this.autoCodedData || {};
-    const formCurrency = (this.fg?.value as CurrencyAmountFormValues)?.currency;
-    const formAmount = (this.fg?.value as CurrencyAmountFormValues)?.amount;
+    const { currency: formCurrency, amount: formAmount } = (this.fg?.value as CurrencyAmountFormValues) || {};
 
     const isCurrencyAutoCoded = currency && currency === formCurrency;
     const isAmountAutoCoded = amount && amount === formAmount;


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cwkmzjr

Here the fix will need a check.
Current issue is with currency and the same will arise for amount which I tested so fixing both.
```js
    const formCurrency = (this.fg?.value as CurrencyAmountFormValues)?.currency;
    const formAmount = (this.fg?.value as CurrencyAmountFormValues)?.amount;
```

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the currency component by implementing destructuring with a fallback for safer property access, reducing the risk of runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->