### PR TITLE
chore: change the last release branch to mondays release branch

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,8 +1,8 @@
 name: Create Release Branch
 on:
   schedule:
-    # Run every Friday at 11:30 AM UTC (5:00 PM IST)
-    - cron: '30 11 * * FRI'
+    # Run every Monday at 11:30 AM UTC (5:00 PM IST)
+    - cron: '30 11 * * MON'
 jobs:
   create-release-branch:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Get Release Branch Name
         run: |
           echo "release_branch=mobile_release_$(date +%Y_%m_%d)" >> $GITHUB_ENV
-          echo "last_release_branch=mobile_release_$(date -d 'last friday' +%Y_%m_%d)" >> $GITHUB_ENV
+          echo "last_release_branch=mobile_release_$(date -d 'last monday' +%Y_%m_%d)" >> $GITHUB_ENV
       - name: Check if release branch exists
         run: |
           if git ls-remote --exit-code --heads origin ${{env.release_branch}}; then


### PR DESCRIPTION
## Clickup
https://app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the logic for determining the last release branch name to reference the last Monday instead of the last Friday. 
	- Cron schedule remains unchanged, running every Monday at 11:30 AM UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->