### PR TITLE
fix: remove orgUserSettingsService.getAllowedCostCenters - use cost centers service

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense-1.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-1.spec.ts
@@ -77,6 +77,7 @@ import { expenseFieldResponse } from 'src/app/core/mock-data/expense-field.data'
 import { expectedProjects4 } from 'src/app/core/mock-data/extended-projects.data';
 import { reportData1 } from 'src/app/core/mock-data/report.data';
 import { sortedCategory } from 'src/app/core/mock-data/org-category.data';
+import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 
 export function TestCases1(getTestBed) {
   return describe('AddEditExpensePage-1', () => {
@@ -122,6 +123,7 @@ export function TestCases1(getTestBed) {
     let titleCasePipe: jasmine.SpyObj<TitleCasePipe>;
     let paymentModesService: jasmine.SpyObj<PaymentModesService>;
     let taxGroupService: jasmine.SpyObj<TaxGroupService>;
+    let costCentersService: jasmine.SpyObj<CostCentersService>;
     let orgUserSettingsService: jasmine.SpyObj<OrgUserSettingsService>;
     let storageService: jasmine.SpyObj<StorageService>;
     let launchDarklyService: jasmine.SpyObj<LaunchDarklyService>;
@@ -178,6 +180,7 @@ export function TestCases1(getTestBed) {
       titleCasePipe = TestBed.inject(TitleCasePipe) as jasmine.SpyObj<TitleCasePipe>;
       paymentModesService = TestBed.inject(PaymentModesService) as jasmine.SpyObj<PaymentModesService>;
       taxGroupService = TestBed.inject(TaxGroupService) as jasmine.SpyObj<TaxGroupService>;
+      costCentersService = TestBed.inject(CostCentersService) as jasmine.SpyObj<CostCentersService>;
       orgUserSettingsService = TestBed.inject(OrgUserSettingsService) as jasmine.SpyObj<OrgUserSettingsService>;
       storageService = TestBed.inject(StorageService) as jasmine.SpyObj<StorageService>;
       launchDarklyService = TestBed.inject(LaunchDarklyService) as jasmine.SpyObj<LaunchDarklyService>;
@@ -1500,7 +1503,7 @@ export function TestCases1(getTestBed) {
       it('should return list of cost centers if enabled', (done) => {
         component.orgUserSettings$ = of(orgUserSettingsData);
         orgSettingsService.get.and.returnValue(of(orgSettingsRes));
-        orgUserSettingsService.getAllowedCostCenters.and.returnValue(of(costCenterApiRes1));
+        costCentersService.getAllActive.and.returnValue(of(costCenterApiRes1));
         fixture.detectChanges();
 
         component.setupCostCenters();
@@ -1514,7 +1517,7 @@ export function TestCases1(getTestBed) {
         });
 
         expect(orgSettingsService.get).toHaveBeenCalledTimes(1);
-        expect(orgUserSettingsService.getAllowedCostCenters).toHaveBeenCalledOnceWith(orgUserSettingsData);
+        expect(costCentersService.getAllActive).toHaveBeenCalledTimes(1);
         done();
       });
 
@@ -1523,7 +1526,7 @@ export function TestCases1(getTestBed) {
         orgSettingsService.get.and.returnValue(
           of({ ...orgSettingsRes, cost_centers: { ...orgSettingsRes.cost_centers, enabled: false } })
         );
-        orgUserSettingsService.getAllowedCostCenters.and.returnValue(of(costCenterApiRes1));
+        costCentersService.getAllActive.and.returnValue(of(costCenterApiRes1));
         fixture.detectChanges();
 
         component.setupCostCenters();

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -485,7 +485,7 @@ export class AddEditExpensePage implements OnInit {
     private titleCasePipe: TitleCasePipe,
     private paymentModesService: PaymentModesService,
     private taxGroupService: TaxGroupService,
-    private costCenterService: CostCentersService,
+    private costCentersService: CostCentersService,
     private orgUserSettingsService: OrgUserSettingsService,
     private storageService: StorageService,
     private launchDarklyService: LaunchDarklyService,
@@ -1145,7 +1145,7 @@ export class AddEditExpensePage implements OnInit {
     this.costCenters$ = orgSettings$.pipe(
       switchMap((orgSettings) => {
         if (orgSettings.cost_centers.enabled) {
-          return this.costCenterService.getAllActive();
+          return this.costCentersService.getAllActive();
         } else {
           return of([]);
         }

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -138,6 +138,7 @@ import { corporateCardTransaction } from 'src/app/core/models/platform/v1/cc-tra
 import { PlatformFileGenerateUrlsResponse } from 'src/app/core/models/platform/platform-file-generate-urls-response.model';
 import { SpenderFileService } from 'src/app/core/services/platform/v1/spender/file.service';
 import { ExpenseTransactionStatus } from 'src/app/core/enums/platform/v1/expense-transaction-status.enum';
+import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 
 // eslint-disable-next-line
 type FormValue = {
@@ -484,6 +485,7 @@ export class AddEditExpensePage implements OnInit {
     private titleCasePipe: TitleCasePipe,
     private paymentModesService: PaymentModesService,
     private taxGroupService: TaxGroupService,
+    private costCenterService: CostCentersService,
     private orgUserSettingsService: OrgUserSettingsService,
     private storageService: StorageService,
     private launchDarklyService: LaunchDarklyService,
@@ -1140,13 +1142,10 @@ export class AddEditExpensePage implements OnInit {
 
     this.isCostCentersEnabled$ = orgSettings$.pipe(map((orgSettings) => orgSettings.cost_centers.enabled));
 
-    this.costCenters$ = forkJoin({
-      orgSettings: orgSettings$,
-      orgUserSettings: this.orgUserSettings$,
-    }).pipe(
-      switchMap(({ orgSettings, orgUserSettings }) => {
+    this.costCenters$ = orgSettings$.pipe(
+      switchMap((orgSettings) => {
         if (orgSettings.cost_centers.enabled) {
-          return this.orgUserSettingsService.getAllowedCostCenters(orgUserSettings);
+          return this.costCenterService.getAllActive();
         } else {
           return of([]);
         }

--- a/src/app/fyle/add-edit-expense/add-edit-expense.setup.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.setup.spec.ts
@@ -63,6 +63,7 @@ import { SpenderFileService } from 'src/app/core/services/platform/v1/spender/fi
 import { AdvanceWalletsService } from 'src/app/core/services/platform/v1/spender/advance-wallets.service';
 import { PAGINATION_SIZE } from 'src/app/constants';
 import { SpenderService } from 'src/app/core/services/platform/v1/spender/spender.service';
+import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 
 export function setFormValid(component) {
   Object.defineProperty(component.fg, 'valid', {
@@ -208,11 +209,8 @@ describe('AddEditExpensePage', () => {
       'checkIfPaymentModeConfigurationsIsEnabled',
     ]);
     const taxGroupServiceSpy = jasmine.createSpyObj('TaxGroupService', ['get']);
-    const orgUserSettingsServiceSpy = jasmine.createSpyObj('OrgUserSettingsService', [
-      'getAllowedCostCenters',
-      'getAllowedPaymentModes',
-      'get',
-    ]);
+    const costCentersServiceSpy = jasmine.createSpyObj('CostCentersService', ['getAllActive']);
+    const orgUserSettingsServiceSpy = jasmine.createSpyObj('OrgUserSettingsService', ['getAllowedPaymentModes', 'get']);
     const storageServiceSpy = jasmine.createSpyObj('StorageService', ['set', 'get']);
     const launchDarklyServiceSpy = jasmine.createSpyObj('LaunchDarklyService', ['getVariation']);
     const platformSpy = jasmine.createSpyObj('Platform', ['is']);
@@ -401,6 +399,10 @@ describe('AddEditExpensePage', () => {
         {
           provide: TaxGroupService,
           useValue: taxGroupServiceSpy,
+        },
+        {
+          provide: CostCentersService,
+          useValue: costCentersServiceSpy,
         },
         {
           provide: OrgUserSettingsService,

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-4.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-4.spec.ts
@@ -95,6 +95,7 @@ import { AddEditMileagePage } from './add-edit-mileage.page';
 import { commuteDetailsData } from 'src/app/core/mock-data/commute-details.data';
 import { CommuteDeduction } from 'src/app/core/enums/commute-deduction.enum';
 import { cloneDeep } from 'lodash';
+import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 
 export function TestCases4(getTestBed) {
   return describe('AddEditMileage-4', () => {
@@ -140,6 +141,7 @@ export function TestCases4(getTestBed) {
     let titleCasePipe: jasmine.SpyObj<TitleCasePipe>;
     let paymentModesService: jasmine.SpyObj<PaymentModesService>;
     let taxGroupService: jasmine.SpyObj<TaxGroupService>;
+    let costCentersService: jasmine.SpyObj<CostCentersService>;
     let orgUserSettingsService: jasmine.SpyObj<OrgUserSettingsService>;
     let storageService: jasmine.SpyObj<StorageService>;
     let launchDarklyService: jasmine.SpyObj<LaunchDarklyService>;
@@ -198,6 +200,7 @@ export function TestCases4(getTestBed) {
       titleCasePipe = TestBed.inject(TitleCasePipe) as jasmine.SpyObj<TitleCasePipe>;
       paymentModesService = TestBed.inject(PaymentModesService) as jasmine.SpyObj<PaymentModesService>;
       taxGroupService = TestBed.inject(TaxGroupService) as jasmine.SpyObj<TaxGroupService>;
+      costCentersService = TestBed.inject(CostCentersService) as jasmine.SpyObj<CostCentersService>;
       orgUserSettingsService = TestBed.inject(OrgUserSettingsService) as jasmine.SpyObj<OrgUserSettingsService>;
       storageService = TestBed.inject(StorageService) as jasmine.SpyObj<StorageService>;
       launchDarklyService = TestBed.inject(LaunchDarklyService) as jasmine.SpyObj<LaunchDarklyService>;
@@ -611,16 +614,16 @@ export function TestCases4(getTestBed) {
 
     describe('getCostCenters():', () => {
       it('should get cost center if enabled', (done) => {
-        orgUserSettingsService.getAllowedCostCenters.and.returnValue(of(costCentersData));
-        component.getCostCenters(of(orgSettingsData), of(orgUserSettingsData)).subscribe((res) => {
+        costCentersService.getAllActive.and.returnValue(of(costCentersData));
+        component.getCostCenters(of(orgSettingsData)).subscribe((res) => {
           expect(res).toEqual(costCenterOptions2);
-          expect(orgUserSettingsService.getAllowedCostCenters).toHaveBeenCalledOnceWith(orgUserSettingsData);
+          expect(costCentersService.getAllActive).toHaveBeenCalledTimes(1);
           done();
         });
       });
 
       it('should return empty array if cost centers are disabled', (done) => {
-        component.getCostCenters(of(orgSettingsCCDisabled), of(orgUserSettingsData)).subscribe((res) => {
+        component.getCostCenters(of(orgSettingsCCDisabled)).subscribe((res) => {
           expect(res).toEqual([]);
           done();
         });

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage-5.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage-5.spec.ts
@@ -415,7 +415,7 @@ export function TestCases5(getTestBed) {
           expect(res).toBeTrue();
         });
 
-        expect(component.getCostCenters).toHaveBeenCalledOnceWith(jasmine.any(Observable), jasmine.any(Observable));
+        expect(component.getCostCenters).toHaveBeenCalledOnceWith(jasmine.any(Observable));
 
         component.reports$.subscribe((res) => {
           expect(res).toEqual(reportOptionsData3);

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.setup.spec.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.setup.spec.ts
@@ -66,6 +66,7 @@ import { EmployeesService } from 'src/app/core/services/platform/v1/spender/empl
 import { AdvanceWalletsService } from 'src/app/core/services/platform/v1/spender/advance-wallets.service';
 import { PAGINATION_SIZE } from 'src/app/constants';
 import { SpenderService } from 'src/app/core/services/platform/v1/spender/spender.service';
+import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 
 export function setFormValid(component) {
   Object.defineProperty(component.fg, 'valid', {
@@ -210,6 +211,7 @@ describe('AddEditMileagePage', () => {
       'checkIfPaymentModeConfigurationsIsEnabled',
     ]);
     const taxGroupServiceSpy = jasmine.createSpyObj('TaxGroupService', ['get']);
+    const costCentersServiceSpy = jasmine.createSpyObj('CostCentersService', ['getAllActive']);
     const orgUserSettingsServiceSpy = jasmine.createSpyObj('OrgUserSettingsService', [
       'getAllowedCostCenters',
       'getAllowedPaymentModes',
@@ -417,6 +419,10 @@ describe('AddEditMileagePage', () => {
         {
           provide: TaxGroupService,
           useValue: taxGroupServiceSpy,
+        },
+        {
+          provide: CostCentersService,
+          useValue: costCentersServiceSpy,
         },
         {
           provide: OrgUserSettingsService,

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -1,3 +1,4 @@
+import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 // TODO: Very hard to fix this file without making massive changes
 /* eslint-disable complexity */
 import { ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, OnInit, ViewChild } from '@angular/core';
@@ -324,6 +325,7 @@ export class AddEditMileagePage implements OnInit {
     private currencyService: CurrencyService,
     private mileageRateService: MileageRatesService,
     private orgUserSettingsService: OrgUserSettingsService,
+    private costCentersService: CostCentersService,
     private categoriesService: CategoriesService,
     private orgSettingsService: OrgSettingsService,
     private platformHandlerService: PlatformHandlerService,
@@ -1227,17 +1229,11 @@ export class AddEditMileagePage implements OnInit {
     );
   }
 
-  getCostCenters(
-    orgSettings$: Observable<OrgSettings>,
-    orgUserSettings$: Observable<OrgUserSettings>
-  ): Observable<CostCenterOptions[]> {
-    return forkJoin({
-      orgSettings: orgSettings$,
-      orgUserSettings: orgUserSettings$,
-    }).pipe(
-      switchMap(({ orgSettings, orgUserSettings }) => {
+  getCostCenters(orgSettings$: Observable<OrgSettings>): Observable<CostCenterOptions[]> {
+    return orgSettings$.pipe(
+      switchMap((orgSettings) => {
         if (orgSettings.cost_centers.enabled) {
-          return this.orgUserSettingsService.getAllowedCostCenters(orgUserSettings);
+          return this.costCentersService.getAllActive();
         } else {
           return of([]);
         }
@@ -1673,7 +1669,7 @@ export class AddEditMileagePage implements OnInit {
 
     this.paymentModes$ = this.getPaymentModes();
 
-    this.costCenters$ = this.getCostCenters(orgSettings$, orgUserSettings$);
+    this.costCenters$ = this.getCostCenters(orgSettings$);
 
     this.recentlyUsedCostCenters$ = forkJoin({
       costCenters: this.costCenters$,

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem-2.page.spec.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem-2.page.spec.ts
@@ -96,6 +96,7 @@ import {
 } from 'src/app/core/mock-data/per-diem-form-value.data';
 import { platformExpenseData } from 'src/app/core/mock-data/platform/v1/expense.data';
 import { transformedExpenseData } from 'src/app/core/mock-data/transformed-expense.data';
+import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 
 export function TestCases2(getTestBed) {
   return describe('add-edit-per-diem test cases set 2', () => {
@@ -134,6 +135,7 @@ export function TestCases2(getTestBed) {
     let snackbarProperties: jasmine.SpyObj<SnackbarPropertiesService>;
     let platform: Platform;
     let paymentModesService: jasmine.SpyObj<PaymentModesService>;
+    let costCentersService: jasmine.SpyObj<CostCentersService>;
     let orgUserSettingsService: jasmine.SpyObj<OrgUserSettingsService>;
     let storageService: jasmine.SpyObj<StorageService>;
     let perDiemService: jasmine.SpyObj<PerDiemService>;
@@ -177,6 +179,7 @@ export function TestCases2(getTestBed) {
       snackbarProperties = TestBed.inject(SnackbarPropertiesService) as jasmine.SpyObj<SnackbarPropertiesService>;
       platform = TestBed.inject(Platform);
       paymentModesService = TestBed.inject(PaymentModesService) as jasmine.SpyObj<PaymentModesService>;
+      costCentersService = TestBed.inject(CostCentersService) as jasmine.SpyObj<CostCentersService>;
       orgUserSettingsService = TestBed.inject(OrgUserSettingsService) as jasmine.SpyObj<OrgUserSettingsService>;
       storageService = TestBed.inject(StorageService) as jasmine.SpyObj<StorageService>;
       perDiemService = TestBed.inject(PerDiemService) as jasmine.SpyObj<PerDiemService>;
@@ -534,7 +537,7 @@ export function TestCases2(getTestBed) {
         }));
         perDiemService.getAllowedPerDiems.and.returnValue(of(mockPerDiem));
         component.isConnected$ = of(true);
-        orgUserSettingsService.getAllowedCostCenters.and.returnValue(of(costCentersData));
+        costCentersService.getAllActive.and.returnValue(of(costCentersData));
         reportService.getAutoSubmissionReportName.and.returnValue(of('#1: Aug 2023'));
         accountsService.getAccountTypeFromPaymentMode.and.returnValue(AccountType.CCC);
         recentlyUsedItemsService.getRecentlyUsed.and.returnValue(of(recentlyUsedRes));
@@ -829,7 +832,7 @@ export function TestCases2(getTestBed) {
       it('should update the costCenters$, recentlyUsedCostCenters$ and reports$ correctly', (done) => {
         component.ionViewWillEnter();
         component.costCenters$.subscribe((res) => {
-          expect(orgUserSettingsService.getAllowedCostCenters).toHaveBeenCalledOnceWith(orgUserSettingsData);
+          expect(costCentersService.getAllActive).toHaveBeenCalledTimes(1);
           expect(res).toEqual(expectedCCdata3);
         });
 
@@ -858,7 +861,7 @@ export function TestCases2(getTestBed) {
         orgSettingsService.get.and.returnValue(of(mockOrgSettings));
         component.ionViewWillEnter();
         component.costCenters$.subscribe((res) => {
-          expect(orgUserSettingsService.getAllowedCostCenters).not.toHaveBeenCalled();
+          expect(costCentersService.getAllActive).not.toHaveBeenCalled();
           expect(res).toEqual([]);
         });
         done();
@@ -1001,7 +1004,7 @@ export function TestCases2(getTestBed) {
 
       it('should set costCenter if costCenter length is 1 and mode is add', fakeAsync(() => {
         component.getNewExpense = jasmine.createSpy().and.returnValue(of(unflattenedExpWoCostCenter));
-        orgUserSettingsService.getAllowedCostCenters.and.returnValue(of([costCentersData[0]]));
+        costCentersService.getAllActive.and.returnValue(of([costCentersData[0]]));
         activatedRoute.snapshot.params.id = undefined;
         component.ionViewWillEnter();
         tick(1000);

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.setup.spec.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.setup.spec.ts
@@ -44,6 +44,7 @@ import { TestCases2 } from './add-edit-per-diem-2.page.spec';
 import { TestCases3 } from './add-edit-per-diem-3.page.spec';
 import { TestCases4 } from './add-edit-per-diem-4.page.spec';
 import { TestCases5 } from './add-edit-per-diem-5.page.spec';
+import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 
 describe('AddEditPerDiemPage', () => {
   const getTestBed = () => {
@@ -132,6 +133,7 @@ describe('AddEditPerDiemPage', () => {
       'checkIfPaymentModeConfigurationsIsEnabled',
     ]);
     const categoriesServiceSpy = jasmine.createSpyObj('CategoriesService', ['getAll']);
+    const costCentersServiceSpy = jasmine.createSpyObj('CostCentersService', ['getAllActive']);
     const orgUserSettingsServiceSpy = jasmine.createSpyObj('OrgUserSettingsService', [
       'getAllowedPaymentModes',
       'get',
@@ -249,6 +251,10 @@ describe('AddEditPerDiemPage', () => {
         {
           provide: CategoriesService,
           useValue: categoriesServiceSpy,
+        },
+        {
+          provide: CostCentersService,
+          useValue: costCentersServiceSpy,
         },
         {
           provide: OrgUserSettingsService,

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -111,6 +111,7 @@ import { PerDiemRedirectedFrom } from 'src/app/core/models/per-diem-redirected-f
 import { ExpensesService } from 'src/app/core/services/platform/v1/spender/expenses.service';
 import { AdvanceWallet } from 'src/app/core/models/platform/v1/advance-wallet.model';
 import { AdvanceWalletsService } from 'src/app/core/services/platform/v1/spender/advance-wallets.service';
+import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 
 @Component({
   selector: 'app-add-edit-per-diem',
@@ -287,6 +288,7 @@ export class AddEditPerDiemPage implements OnInit {
     private paymentModesService: PaymentModesService,
     private perDiemService: PerDiemService,
     private categoriesService: CategoriesService,
+    private costCentersService: CostCentersService,
     private orgUserSettingsService: OrgUserSettingsService,
     private orgSettingsService: OrgSettingsService,
     private platform: Platform,
@@ -1139,13 +1141,10 @@ export class AddEditPerDiemPage implements OnInit {
 
     this.paymentModes$ = this.getPaymentModes();
 
-    this.costCenters$ = forkJoin({
-      orgSettings: orgSettings$,
-      orgUserSettings: orgUserSettings$,
-    }).pipe(
-      switchMap(({ orgSettings, orgUserSettings }) => {
+    this.costCenters$ = orgSettings$.pipe(
+      switchMap((orgSettings) => {
         if (orgSettings.cost_centers.enabled) {
-          return this.orgUserSettingsService.getAllowedCostCenters(orgUserSettings);
+          return this.costCentersService.getAllActive();
         } else {
           return of([]);
         }

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -879,7 +879,6 @@ describe('SplitExpensePage', () => {
 
       component.costCenters$.subscribe((costCenters) => {
         expect(orgSettingsService.get).toHaveBeenCalledTimes(1);
-        expect(orgUserSettingsService.get).toHaveBeenCalledTimes(1);
         expect(costCentersService.getAllActive).toHaveBeenCalledTimes(1);
         expect(costCenters).toEqual(expectedCCdata);
       });
@@ -895,8 +894,7 @@ describe('SplitExpensePage', () => {
 
       component.costCenters$.subscribe((costCenters) => {
         expect(orgSettingsService.get).toHaveBeenCalledTimes(1);
-        expect(orgUserSettingsService.get).toHaveBeenCalledTimes(1);
-        expect(costCentersService.getAllActive).not.toHaveBeenCalled();
+        expect(costCentersService.getAllActive).not.toHaveBeenCalledTimes(1);
         expect(costCenters).toEqual([]);
       });
     });

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -130,6 +130,7 @@ import { SplitExpenseMissingFieldsData } from 'src/app/core/mock-data/split-expe
 import { splitPayloadData1 } from 'src/app/core/mock-data/split-payload.data';
 import { platformExpenseWithExtractedData } from 'src/app/core/mock-data/platform/v1/expense.data';
 import { orgSettingsWithProjectCategoryRestrictions } from 'src/app/core/mock-data/org-settings.data';
+import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 
 describe('SplitExpensePage', () => {
   let component: SplitExpensePage;
@@ -149,6 +150,7 @@ describe('SplitExpensePage', () => {
   let policyService: jasmine.SpyObj<PolicyService>;
   let modalController: jasmine.SpyObj<ModalController>;
   let modalProperties: jasmine.SpyObj<ModalPropertiesService>;
+  let costCentersService: jasmine.SpyObj<CostCentersService>;
   let orgUserSettingsService: jasmine.SpyObj<OrgUserSettingsService>;
   let orgSettingsService: jasmine.SpyObj<OrgSettingsService>;
   let dependentFieldsService: jasmine.SpyObj<DependentFieldsService>;
@@ -868,7 +870,7 @@ describe('SplitExpensePage', () => {
 
     it('should set costCenters$ correctly if splitType is cost centers', () => {
       const mockCostCenters = costCentersData3.slice(0, 2);
-      orgUserSettingsService.getAllowedCostCenters.and.returnValue(of(mockCostCenters));
+      costCentersService.getAllActive.and.returnValue(of(mockCostCenters));
       activateRouteMock.snapshot.params.splitType = 'cost centers';
 
       component.ionViewWillEnter();
@@ -876,7 +878,7 @@ describe('SplitExpensePage', () => {
       component.costCenters$.subscribe((costCenters) => {
         expect(orgSettingsService.get).toHaveBeenCalledTimes(1);
         expect(orgUserSettingsService.get).toHaveBeenCalledTimes(1);
-        expect(orgUserSettingsService.getAllowedCostCenters).toHaveBeenCalledOnceWith(orgUserSettingsData);
+        expect(costCentersService.getAllActive).toHaveBeenCalledTimes(1);
         expect(costCenters).toEqual(expectedCCdata);
       });
     });
@@ -892,7 +894,7 @@ describe('SplitExpensePage', () => {
       component.costCenters$.subscribe((costCenters) => {
         expect(orgSettingsService.get).toHaveBeenCalledTimes(1);
         expect(orgUserSettingsService.get).toHaveBeenCalledTimes(1);
-        expect(orgUserSettingsService.getAllowedCostCenters).not.toHaveBeenCalled();
+        expect(costCentersService.getAllActive).not.toHaveBeenCalled();
         expect(costCenters).toEqual([]);
       });
     });

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -294,6 +294,7 @@ describe('SplitExpensePage', () => {
     policyService = TestBed.inject(PolicyService) as jasmine.SpyObj<PolicyService>;
     modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
     modalProperties = TestBed.inject(ModalPropertiesService) as jasmine.SpyObj<ModalPropertiesService>;
+    costCentersService = TestBed.inject(CostCentersService) as jasmine.SpyObj<CostCentersService>;
     orgUserSettingsService = TestBed.inject(OrgUserSettingsService) as jasmine.SpyObj<OrgUserSettingsService>;
     orgSettingsService = TestBed.inject(OrgSettingsService) as jasmine.SpyObj<OrgSettingsService>;
     dependentFieldsService = TestBed.inject(DependentFieldsService) as jasmine.SpyObj<DependentFieldsService>;

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -194,6 +194,7 @@ describe('SplitExpensePage', () => {
     const policyServiceSpy = jasmine.createSpyObj('PolicyService', ['checkIfViolationsExist']);
     const modalControllerSpy = jasmine.createSpyObj('ModalController', ['create', 'getTop']);
     const modalPropertiesSpy = jasmine.createSpyObj('ModalPropertiesService', ['getModalDefaultProperties']);
+    const costCentersServiceSpy = jasmine.createSpyObj('CostCentersService', ['getAllActive']);
     const orgUserSettingsServiceSpy = jasmine.createSpyObj('OrgUserSettingsService', ['getAllowedCostCenters', 'get']);
     const orgSettingsServiceSpy = jasmine.createSpyObj('OrgSettingsService', ['get']);
     const dependentFieldsServiceSpy = jasmine.createSpyObj('DependentFieldsService', [
@@ -241,6 +242,7 @@ describe('SplitExpensePage', () => {
         { provide: PolicyService, useValue: policyServiceSpy },
         { provide: ModalController, useValue: modalControllerSpy },
         { provide: ModalPropertiesService, useValue: modalPropertiesSpy },
+        { provide: CostCentersService, useValue: costCentersServiceSpy },
         { provide: OrgUserSettingsService, useValue: orgUserSettingsServiceSpy },
         { provide: OrgSettingsService, useValue: orgSettingsServiceSpy },
         { provide: DependentFieldsService, useValue: dependentFieldsServiceSpy },

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -1,3 +1,4 @@
+import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 import { Component } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -133,6 +134,7 @@ export class SplitExpensePage {
     private policyService: PolicyService,
     private modalController: ModalController,
     private modalProperties: ModalPropertiesService,
+    private costCentersService: CostCentersService,
     private orgUserSettingsService: OrgUserSettingsService,
     private orgSettingsService: OrgSettingsService,
     private dependentFieldsService: DependentFieldsService,
@@ -927,14 +929,10 @@ export class SplitExpensePage {
     );
 
     if (this.splitType === 'cost centers') {
-      const orgUserSettings$ = this.orgUserSettingsService.get();
-      this.costCenters$ = forkJoin({
-        orgSettings: orgSettings$,
-        orgUserSettings: orgUserSettings$,
-      }).pipe(
-        switchMap(({ orgSettings, orgUserSettings }) => {
+      this.costCenters$ = orgSettings$.pipe(
+        switchMap((orgSettings) => {
           if (orgSettings.cost_centers.enabled) {
-            return this.orgUserSettingsService.getAllowedCostCenters(orgUserSettings);
+            return this.costCentersService.getAllActive();
           } else {
             return of([]);
           }


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cwuetmm

## Code Coverage


## UI Preview
None - this PR only removes the extra filtering done via the org user settings service. Directly using cost centers service instead now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Integrated `CostCentersService` across various components for improved cost center management.
  - Simplified retrieval of active cost centers, enhancing performance and maintainability.
  - Introduced new methods in components for better handling of categories and cost centers.
  - Enhanced initialization processes in components to streamline data setup.

- **Bug Fixes**
  - Enhanced error handling in the split expense logic, ensuring better user feedback.

- **Tests**
  - Updated test suites to reflect the integration of `CostCentersService`, ensuring accurate testing of new functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->