### PR TITLE
feat: Removing url query params from Http exception for correct grouping of issues in Sentry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,11 +16,12 @@ GlobalCacheConfig.maxCacheCount = 100;
 
 // To modify the exception values for Http errors to remove query params from the URL so that grouping is done properly in Sentry
 const cleanHttpExceptionUrlsForSentryGrouping = (event: Sentry.Event): void => {
+  // exceptionValue looks like: 'Http failure response for https://staging.fyle.tech/platform/v1/common/currency/exchange_rate?from=null&to=USD&date=2024-10-01: 400 OK'
+  const exceptionValue = event.exception?.values?.[0].value;
   const prefix = 'Http failure response for ';
   const suffixIndicator = ': ';
-  if (event.exception?.values?.[0].value?.startsWith(prefix)) {
-    // exceptionValue looks like: 'Http failure response for https://staging.fyle.tech/platform/v1/common/currency/exchange_rate?from=null&to=USD&date=2024-10-01: 400 OK'
-    const exceptionValue = event.exception?.values?.[0].value;
+
+  if (exceptionValue && exceptionValue.startsWith(prefix)) {
     // Finding the position of the last occurrence of ': '
     const suffixIndex = exceptionValue.lastIndexOf(suffixIndicator);
     if (suffixIndex !== -1) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,12 +14,35 @@ import { GlobalCacheConfig } from 'ts-cacheable';
 GlobalCacheConfig.maxAge = 10 * 60 * 1000;
 GlobalCacheConfig.maxCacheCount = 100;
 
+// To modify the exception values for Http errors to remove query params from the URL so that grouping is done properly in Sentry
+const cleanHttpExceptionUrlsForSentryGrouping = (event: Sentry.Event): void => {
+  const prefix = 'Http failure response for ';
+  const suffixIndicator = ': ';
+  if (event.exception?.values?.[0].value?.startsWith(prefix)) {
+    // exceptionValue looks like: 'Http failure response for https://staging.fyle.tech/platform/v1/common/currency/exchange_rate?from=null&to=USD&date=2024-10-01: 400 OK'
+    const exceptionValue = event.exception?.values?.[0].value;
+    // Finding the position of the last occurrence of ': '
+    const suffixIndex = exceptionValue.lastIndexOf(suffixIndicator);
+    if (suffixIndex !== -1) {
+      const urlWithQuery = exceptionValue.slice(prefix.length, suffixIndex);
+      const urlWithoutQuery = urlWithQuery.split('?')[0];
+      const suffix = exceptionValue.slice(suffixIndex + suffixIndicator.length);
+      // Updating the exception message
+      event.exception.values[0].value = `${prefix}${urlWithoutQuery}${suffixIndicator}${suffix}`;
+    }
+  }
+};
+
 Sentry.init({
   dsn: environment.SENTRY_DSN,
   integrations: [],
   tracesSampleRate: 0.1,
   release: 'please-replace-your-git-commit-version',
   ignoreErrors: ['Non-Error exception captured', 'Non-Error promise rejection captured'],
+  beforeSend(event) {
+    cleanHttpExceptionUrlsForSentryGrouping(event);
+    return event;
+  },
 });
 
 if (environment.production) {


### PR DESCRIPTION
I have added new fingerprint rule in Sentry: https://fyle-technologies-private-limi.sentry.io/settings/projects/fyle-mobile-app-prod/issue-grouping/

```
# New issue should be created for unique API endpoint
error.value:"Http failure response for*" -> http-error, {{error.value}}
```
this will create grouping of issues based on api endpoints for all http failure errors, but url query params were messing up this grouping hence removing them from the exception value - they would be still visible in stack trace

## Clickup
https://app.clickup.com/t/86cwy4tvn

Webapp PR: https://github.com/fylein/fyle-app/pull/8921

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error reporting for HTTP exceptions by excluding query parameters from URLs before sending to Sentry.
- **Bug Fixes**
	- Improved clarity and grouping of similar HTTP errors in error tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->