### PR TITLE
fix: migrate personalCards:getLinkedAccounts to platform

### DIFF
--- a/src/app/core/mock-data/personal-cards.data.ts
+++ b/src/app/core/mock-data/personal-cards.data.ts
@@ -2,6 +2,8 @@ import deepFreeze from 'deep-freeze-strict';
 
 import { ApiV2Response } from '../models/api-v2.model';
 import { PersonalCard } from '../models/personal_card.model';
+import { PlatformApiResponse } from '../models/platform/platform-api-response.model';
+import { PersonalCardPlatform } from '../models/personal_card_platform.model';
 
 export const apiLinkedAccRes: ApiV2Response<PersonalCard> = deepFreeze({
   count: 11,
@@ -110,3 +112,77 @@ export const linkedAccountsRes: PersonalCard[] = deepFreeze([
     updated_at: new Date('2023-01-12T15:57:47.178727'),
   },
 ]);
+
+export const linkedAccountRes2: PersonalCard[] = deepFreeze([
+  {
+    id: 'baccT14CjCJJ7H',
+    bank_name: 'Dag Site',
+    account_number: 'xxxx3201',
+    created_at: new Date('2024-11-11T09:43:39.530Z'),
+    updated_at: new Date('2024-11-11T09:43:39.530Z'),
+    currency: 'USD',
+    fastlink_params: null,
+    mfa_enabled: false,
+    update_credentials: false,
+    last_synced_at: null,
+    mask: '3201',
+    account_type: 'SAVINGS',
+  },
+  {
+    id: 'baccCqRv6YdSqZ',
+    bank_name: 'Dag Site',
+    account_number: 'xxxx8791',
+    created_at: new Date('2024-11-11T09:43:39.518Z'),
+    updated_at: new Date('2024-11-11T09:43:39.518Z'),
+    currency: 'USD',
+    fastlink_params: null,
+    mfa_enabled: false,
+    update_credentials: false,
+    last_synced_at: null,
+    mask: '8791',
+    account_type: 'SAVINGS',
+  },
+]);
+
+export const platformApiLinkedAccRes: PlatformApiResponse<PersonalCardPlatform[]> = deepFreeze({
+  count: 2,
+  data: [
+    {
+      account_type: 'SAVINGS',
+      bank_name: 'Dag Site',
+      card_number: 'xxxx3201',
+      created_at: new Date('2024-11-11T09:43:39.530942+00:00'),
+      currency: 'USD',
+      id: 'baccT14CjCJJ7H',
+      org_id: 'orrb8EW1zZsy',
+      updated_at: new Date('2024-11-11T09:43:39.530942+00:00'),
+      user_id: 'us2KhpQLpzX4',
+      yodlee_account_id: 'yacmuKWsN1arS',
+      yodlee_fastlink_params: null,
+      yodlee_is_credential_update_required: false,
+      yodlee_is_mfa_required: false,
+      yodlee_last_synced_at: null,
+      yodlee_login_id: 'ou6kAM3CXV7d',
+      yodlee_provider_account_id: '10287109',
+    },
+    {
+      account_type: 'SAVINGS',
+      bank_name: 'Dag Site',
+      card_number: 'xxxx8791',
+      created_at: new Date('2024-11-11T09:43:39.518572+00:00'),
+      currency: 'USD',
+      id: 'baccCqRv6YdSqZ',
+      org_id: 'orrb8EW1zZsy',
+      updated_at: new Date('2024-11-11T09:43:39.518572+00:00'),
+      user_id: 'us2KhpQLpzX4',
+      yodlee_account_id: 'yacOjVeY4Ex0s',
+      yodlee_fastlink_params: null,
+      yodlee_is_credential_update_required: false,
+      yodlee_is_mfa_required: false,
+      yodlee_last_synced_at: null,
+      yodlee_login_id: 'ou6kAM3CXV7d',
+      yodlee_provider_account_id: '10287109',
+    },
+  ],
+  offset: 0,
+});

--- a/src/app/core/models/personal_card.model.ts
+++ b/src/app/core/models/personal_card.model.ts
@@ -9,11 +9,11 @@ export interface PersonalCard {
   last_synced_at: Date;
   mask: string;
   mfa_enabled?: boolean;
-  nickname: string;
-  official_name: string;
-  sync_type: string;
+  nickname?: string;
+  official_name?: string;
+  sync_type?: string;
   update_credentials?: boolean;
-  unclassified_amount: number;
-  unclassified_count: number;
+  unclassified_amount?: number;
+  unclassified_count?: number;
   updated_at: Date;
 }

--- a/src/app/core/models/personal_card_platform.model.ts
+++ b/src/app/core/models/personal_card_platform.model.ts
@@ -1,0 +1,18 @@
+export interface PersonalCardPlatform {
+  account_type: string;
+  bank_name: string;
+  card_number: string;
+  created_at: Date;
+  currency: string;
+  id: string;
+  org_id: string;
+  updated_at: Date;
+  user_id: string;
+  yodlee_account_id: string;
+  yodlee_fastlink_params?: string;
+  yodlee_is_credential_update_required: boolean;
+  yodlee_is_mfa_required: boolean;
+  yodlee_last_synced_at: Date | null;
+  yodlee_login_id: string;
+  yodlee_provider_account_id: string;
+}

--- a/src/app/core/services/personal-cards.service.spec.ts
+++ b/src/app/core/services/personal-cards.service.spec.ts
@@ -21,7 +21,7 @@ import { apiToken } from '../mock-data/yoodle-token.data';
 import * as dayjs from 'dayjs';
 import { SpenderPlatformV1ApiService } from './spender-platform-v1-api.service';
 
-fdescribe('PersonalCardsService', () => {
+describe('PersonalCardsService', () => {
   let personalCardsService: PersonalCardsService;
   let apiV2Service: jasmine.SpyObj<ApiV2Service>;
   let apiService: jasmine.SpyObj<ApiService>;

--- a/src/app/core/services/personal-cards.service.spec.ts
+++ b/src/app/core/services/personal-cards.service.spec.ts
@@ -19,10 +19,9 @@ import { DateFilters } from 'src/app/shared/components/fy-filters/date-filters.e
 import { apiExpenseRes, etxncData } from '../mock-data/expense.data';
 import { apiToken } from '../mock-data/yoodle-token.data';
 import * as dayjs from 'dayjs';
-import { LaunchDarklyService } from './launch-darkly.service';
 import { SpenderPlatformV1ApiService } from './spender-platform-v1-api.service';
 
-describe('PersonalCardsService', () => {
+fdescribe('PersonalCardsService', () => {
   let personalCardsService: PersonalCardsService;
   let apiV2Service: jasmine.SpyObj<ApiV2Service>;
   let apiService: jasmine.SpyObj<ApiService>;
@@ -71,12 +70,12 @@ describe('PersonalCardsService', () => {
     expect(personalCardsService).toBeTruthy();
   });
 
-  describe('getLinkedAccounts()', () => {
+  describe('getPersonalCards()', () => {
     it('should get linked personal cards when using public api', (done) => {
       const usePlatformApi = false;
       apiV2Service.get.and.returnValue(of(apiLinkedAccRes));
 
-      personalCardsService.getLinkedAccounts(usePlatformApi).subscribe((res) => {
+      personalCardsService.getPersonalCards(usePlatformApi).subscribe((res) => {
         expect(spenderPlatformV1ApiService.get).not.toHaveBeenCalled();
         expect(res).toEqual(apiLinkedAccRes.data);
         expect(apiV2Service.get).toHaveBeenCalledOnceWith('/personal_bank_accounts', {
@@ -93,7 +92,7 @@ describe('PersonalCardsService', () => {
       spenderPlatformV1ApiService.get.and.returnValue(of(platformApiLinkedAccRes));
       spyOn(personalCardsService, 'transformPersonalCardPlatformArray').and.callThrough();
 
-      personalCardsService.getLinkedAccounts(usePlatformApi).subscribe((res) => {
+      personalCardsService.getPersonalCards(usePlatformApi).subscribe((res) => {
         expect(res).toEqual(linkedAccountRes2);
         expect(personalCardsService.transformPersonalCardPlatformArray).toHaveBeenCalledWith(
           platformApiLinkedAccRes.data
@@ -105,12 +104,12 @@ describe('PersonalCardsService', () => {
     });
   });
 
-  describe('getLinkedAccountsCount()', () => {
+  describe('getPersonalCardsCount()', () => {
     it('should get linked personal cards count when using public api', (done) => {
       const usePlatformApi = false;
       apiV2Service.get.and.returnValue(of(apiLinkedAccRes));
 
-      personalCardsService.getLinkedAccountsCount(usePlatformApi).subscribe((res) => {
+      personalCardsService.getPersonalCardsCount(usePlatformApi).subscribe((res) => {
         expect(spenderPlatformV1ApiService.get).not.toHaveBeenCalled();
         expect(res).toEqual(apiLinkedAccRes.count);
         expect(apiV2Service.get).toHaveBeenCalledOnceWith('/personal_bank_accounts', {
@@ -126,7 +125,7 @@ describe('PersonalCardsService', () => {
       const usePlatformApi = true;
       spenderPlatformV1ApiService.get.and.returnValue(of(platformApiLinkedAccRes));
 
-      personalCardsService.getLinkedAccountsCount(usePlatformApi).subscribe((res) => {
+      personalCardsService.getPersonalCardsCount(usePlatformApi).subscribe((res) => {
         expect(res).toEqual(platformApiLinkedAccRes.count);
         expect(spenderPlatformV1ApiService.get).toHaveBeenCalledOnceWith('/personal_cards');
         expect(apiV2Service.get).not.toHaveBeenCalled();

--- a/src/app/core/services/personal-cards.service.spec.ts
+++ b/src/app/core/services/personal-cards.service.spec.ts
@@ -27,7 +27,6 @@ describe('PersonalCardsService', () => {
   let apiV2Service: jasmine.SpyObj<ApiV2Service>;
   let apiService: jasmine.SpyObj<ApiService>;
   let expenseAggregationService: jasmine.SpyObj<ExpenseAggregationService>;
-  let launchDarklyService: jasmine.SpyObj<LaunchDarklyService>;
   let spenderPlatformV1ApiService: jasmine.SpyObj<SpenderPlatformV1ApiService>;
   let dateService: DateService;
 
@@ -35,7 +34,6 @@ describe('PersonalCardsService', () => {
     const apiV2ServiceSpy = jasmine.createSpyObj('ApiV2Service', ['get']);
     const apiServiceSpy = jasmine.createSpyObj('ApiService', ['post', 'get']);
     const expenseAggregationServiceSpy = jasmine.createSpyObj('ExpenseAggregationService', ['get', 'post', 'delete']);
-    const launchDarklyServiceSpy = jasmine.createSpyObj('LaunchDarklyService', ['getVariation']);
     const spenderPlatformV1ApiServiceSpy = jasmine.createSpyObj('SpenderPlatformV1ApiService', ['get']);
     TestBed.configureTestingModule({
       providers: [
@@ -54,17 +52,11 @@ describe('PersonalCardsService', () => {
           useValue: expenseAggregationServiceSpy,
         },
         {
-          provide: LaunchDarklyService,
-          useValue: launchDarklyServiceSpy,
-        },
-        {
           provide: SpenderPlatformV1ApiService,
           useValue: spenderPlatformV1ApiServiceSpy,
         },
       ],
     });
-    launchDarklyService = TestBed.inject(LaunchDarklyService) as jasmine.SpyObj<LaunchDarklyService>;
-    launchDarklyService.getVariation.and.returnValue(of(false));
     personalCardsService = TestBed.inject(PersonalCardsService);
     dateService = TestBed.inject(DateService);
     apiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
@@ -81,10 +73,10 @@ describe('PersonalCardsService', () => {
 
   describe('getLinkedAccounts()', () => {
     it('should get linked personal cards when using public api', (done) => {
-      personalCardsService.usePlatformApi = false;
+      const usePlatformApi = false;
       apiV2Service.get.and.returnValue(of(apiLinkedAccRes));
 
-      personalCardsService.getLinkedAccounts().subscribe((res) => {
+      personalCardsService.getLinkedAccounts(usePlatformApi).subscribe((res) => {
         expect(spenderPlatformV1ApiService.get).not.toHaveBeenCalled();
         expect(res).toEqual(apiLinkedAccRes.data);
         expect(apiV2Service.get).toHaveBeenCalledOnceWith('/personal_bank_accounts', {
@@ -97,11 +89,11 @@ describe('PersonalCardsService', () => {
     });
 
     it('should get linked personal cards when using platform api', (done) => {
-      personalCardsService.usePlatformApi = true;
+      const usePlatformApi = true;
       spenderPlatformV1ApiService.get.and.returnValue(of(platformApiLinkedAccRes));
       spyOn(personalCardsService, 'transformPersonalCardPlatformArray').and.callThrough();
 
-      personalCardsService.getLinkedAccounts().subscribe((res) => {
+      personalCardsService.getLinkedAccounts(usePlatformApi).subscribe((res) => {
         expect(res).toEqual(linkedAccountRes2);
         expect(personalCardsService.transformPersonalCardPlatformArray).toHaveBeenCalledWith(
           platformApiLinkedAccRes.data
@@ -115,10 +107,10 @@ describe('PersonalCardsService', () => {
 
   describe('getLinkedAccountsCount()', () => {
     it('should get linked personal cards count when using public api', (done) => {
-      personalCardsService.usePlatformApi = false;
+      const usePlatformApi = false;
       apiV2Service.get.and.returnValue(of(apiLinkedAccRes));
 
-      personalCardsService.getLinkedAccountsCount().subscribe((res) => {
+      personalCardsService.getLinkedAccountsCount(usePlatformApi).subscribe((res) => {
         expect(spenderPlatformV1ApiService.get).not.toHaveBeenCalled();
         expect(res).toEqual(apiLinkedAccRes.count);
         expect(apiV2Service.get).toHaveBeenCalledOnceWith('/personal_bank_accounts', {
@@ -131,10 +123,10 @@ describe('PersonalCardsService', () => {
     });
 
     it('should get linked personal cards count when using platform api', (done) => {
-      personalCardsService.usePlatformApi = true;
+      const usePlatformApi = true;
       spenderPlatformV1ApiService.get.and.returnValue(of(platformApiLinkedAccRes));
 
-      personalCardsService.getLinkedAccountsCountPlatform().subscribe((res) => {
+      personalCardsService.getLinkedAccountsCount(usePlatformApi).subscribe((res) => {
         expect(res).toEqual(platformApiLinkedAccRes.count);
         expect(spenderPlatformV1ApiService.get).toHaveBeenCalledOnceWith('/personal_cards');
         expect(apiV2Service.get).not.toHaveBeenCalled();

--- a/src/app/core/services/personal-cards.service.ts
+++ b/src/app/core/services/personal-cards.service.ts
@@ -20,6 +20,7 @@ import { SortFiltersParams } from '../models/sort-filters-params.model';
 import { SpenderPlatformV1ApiService } from './spender-platform-v1-api.service';
 import { LaunchDarklyService } from './launch-darkly.service';
 import { PersonalCardPlatform } from '../models/personal_card_platform.model';
+import { PlatformApiResponse } from '../models/platform/platform-api-response.model';
 
 @Injectable({
   providedIn: 'root',
@@ -62,7 +63,7 @@ export class PersonalCardsService {
 
   getLinkedAccountsPlatform(): Observable<PersonalCard[]> {
     return this.spenderPlatformV1ApiService
-      .get<{ data: PersonalCardPlatform[] }>('/personal_cards')
+      .get<PlatformApiResponse<PersonalCardPlatform[]>>('/personal_cards')
       .pipe(map((res) => this.transformPersonalCardPlatformArray(res.data)));
   }
 
@@ -103,7 +104,16 @@ export class PersonalCardsService {
     }) as Observable<string[]>;
   }
 
+  getLinkedAccountsCountPlatform(): Observable<number> {
+    return this.spenderPlatformV1ApiService
+      .get<PlatformApiResponse<PersonalCardPlatform[]>>('/personal_cards')
+      .pipe(map((res) => res.count));
+  }
+
   getLinkedAccountsCount(): Observable<number> {
+    if (this.usePlatformApi) {
+      return this.getLinkedAccountsCountPlatform();
+    }
     return this.apiv2Service
       .get('/personal_bank_accounts', {
         params: {

--- a/src/app/core/services/personal-cards.service.ts
+++ b/src/app/core/services/personal-cards.service.ts
@@ -18,7 +18,6 @@ import { PersonalCardTxn } from '../models/personal_card_txn.model';
 import { PersonalCardDateFilter } from '../models/personal-card-date-filter.model';
 import { SortFiltersParams } from '../models/sort-filters-params.model';
 import { SpenderPlatformV1ApiService } from './spender-platform-v1-api.service';
-import { LaunchDarklyService } from './launch-darkly.service';
 import { PersonalCardPlatform } from '../models/personal_card_platform.model';
 import { PlatformApiResponse } from '../models/platform/platform-api-response.model';
 
@@ -26,20 +25,13 @@ import { PlatformApiResponse } from '../models/platform/platform-api-response.mo
   providedIn: 'root',
 })
 export class PersonalCardsService {
-  usePlatformApi = false;
-
   constructor(
     private apiv2Service: ApiV2Service,
     private expenseAggregationService: ExpenseAggregationService,
     private apiService: ApiService,
     private dateService: DateService,
-    private spenderPlatformV1ApiService: SpenderPlatformV1ApiService,
-    private launchDarklyService: LaunchDarklyService
-  ) {
-    this.launchDarklyService.getVariation('personal_cards_platform', false).subscribe((usePlatformApi) => {
-      this.usePlatformApi = usePlatformApi;
-    });
-  }
+    private spenderPlatformV1ApiService: SpenderPlatformV1ApiService
+  ) {}
 
   transformPersonalCardPlatformArray(cards: PersonalCardPlatform[]): PersonalCard[] {
     return cards.map((card) => {
@@ -67,8 +59,8 @@ export class PersonalCardsService {
       .pipe(map((res) => this.transformPersonalCardPlatformArray(res.data)));
   }
 
-  getLinkedAccounts(): Observable<PersonalCard[]> {
-    if (this.usePlatformApi) {
+  getLinkedAccounts(usePlatformApi: boolean): Observable<PersonalCard[]> {
+    if (usePlatformApi) {
       return this.getLinkedAccountsPlatform();
     }
     return this.apiv2Service
@@ -110,8 +102,8 @@ export class PersonalCardsService {
       .pipe(map((res) => res.count));
   }
 
-  getLinkedAccountsCount(): Observable<number> {
-    if (this.usePlatformApi) {
+  getLinkedAccountsCount(usePlatformApi: boolean): Observable<number> {
+    if (usePlatformApi) {
       return this.getLinkedAccountsCountPlatform();
     }
     return this.apiv2Service

--- a/src/app/core/services/personal-cards.service.ts
+++ b/src/app/core/services/personal-cards.service.ts
@@ -53,15 +53,15 @@ export class PersonalCardsService {
     });
   }
 
-  getLinkedAccountsPlatform(): Observable<PersonalCard[]> {
+  getPersonalCardsPlatform(): Observable<PersonalCard[]> {
     return this.spenderPlatformV1ApiService
       .get<PlatformApiResponse<PersonalCardPlatform[]>>('/personal_cards')
       .pipe(map((res) => this.transformPersonalCardPlatformArray(res.data)));
   }
 
-  getLinkedAccounts(usePlatformApi: boolean): Observable<PersonalCard[]> {
+  getPersonalCards(usePlatformApi: boolean): Observable<PersonalCard[]> {
     if (usePlatformApi) {
-      return this.getLinkedAccountsPlatform();
+      return this.getPersonalCardsPlatform();
     }
     return this.apiv2Service
       .get<PersonalCard, { params: { order: string } }>('/personal_bank_accounts', {
@@ -96,15 +96,15 @@ export class PersonalCardsService {
     }) as Observable<string[]>;
   }
 
-  getLinkedAccountsCountPlatform(): Observable<number> {
+  getPersonalCardsCountPlatform(): Observable<number> {
     return this.spenderPlatformV1ApiService
       .get<PlatformApiResponse<PersonalCardPlatform[]>>('/personal_cards')
       .pipe(map((res) => res.count));
   }
 
-  getLinkedAccountsCount(usePlatformApi: boolean): Observable<number> {
+  getPersonalCardsCount(usePlatformApi: boolean): Observable<number> {
     if (usePlatformApi) {
-      return this.getLinkedAccountsCountPlatform();
+      return this.getPersonalCardsCountPlatform();
     }
     return this.apiv2Service
       .get('/personal_bank_accounts', {

--- a/src/app/fyle/personal-cards/personal-cards.page.spec.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.spec.ts
@@ -43,7 +43,7 @@ import { PersonalCardsPage } from './personal-cards.page';
 import { PersonalCardFilter } from 'src/app/core/models/personal-card-filters.model';
 import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 
-fdescribe('PersonalCardsPage', () => {
+describe('PersonalCardsPage', () => {
   let component: PersonalCardsPage;
   let fixture: ComponentFixture<PersonalCardsPage>;
   let personalCardsService: jasmine.SpyObj<PersonalCardsService>;

--- a/src/app/fyle/personal-cards/personal-cards.page.spec.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.spec.ts
@@ -43,7 +43,7 @@ import { PersonalCardsPage } from './personal-cards.page';
 import { PersonalCardFilter } from 'src/app/core/models/personal-card-filters.model';
 import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 
-describe('PersonalCardsPage', () => {
+fdescribe('PersonalCardsPage', () => {
   let component: PersonalCardsPage;
   let fixture: ComponentFixture<PersonalCardsPage>;
   let personalCardsService: jasmine.SpyObj<PersonalCardsService>;
@@ -64,8 +64,8 @@ describe('PersonalCardsPage', () => {
 
   beforeEach(waitForAsync(() => {
     const personalCardsServiceSpy = jasmine.createSpyObj('PersonalCardsService', [
-      'getLinkedAccountsCount',
-      'getLinkedAccounts',
+      'getPersonalCardsCount',
+      'getPersonalCards',
       'getBankTransactionsCount',
       'getBankTransactions',
       'generateFilterPills',
@@ -210,8 +210,8 @@ describe('PersonalCardsPage', () => {
     launchDarklyService = TestBed.inject(LaunchDarklyService) as jasmine.SpyObj<LaunchDarklyService>;
 
     launchDarklyService.getVariation.and.returnValue(of(false));
-    personalCardsService.getLinkedAccountsCount.and.returnValue(of(2));
-    personalCardsService.getLinkedAccounts.and.returnValue(of(linkedAccountsRes));
+    personalCardsService.getPersonalCardsCount.and.returnValue(of(2));
+    personalCardsService.getPersonalCards.and.returnValue(of(linkedAccountsRes));
     component.loadData$ = new BehaviorSubject({
       pageNumber: 1,
     });
@@ -394,7 +394,7 @@ describe('PersonalCardsPage', () => {
     }));
 
     it('segmentChanged(): should change segment', () => {
-      component.selectedTrasactionType = 'INITIALIZED';
+      component.selectedTransactionType = 'INITIALIZED';
       component.selectionMode = true;
       spyOn(component.loadData$, 'getValue').and.returnValue({});
       spyOn(component.loadData$, 'next');
@@ -507,7 +507,7 @@ describe('PersonalCardsPage', () => {
 
     describe('switchSelectionMode():', () => {
       it('should switch mode if expense is of type INITIALIZED', () => {
-        component.selectedTrasactionType = 'INITIALIZED';
+        component.selectedTransactionType = 'INITIALIZED';
         component.selectionMode = true;
         spyOn(component, 'toggleExpense');
 
@@ -519,7 +519,7 @@ describe('PersonalCardsPage', () => {
       });
 
       it('should switch mode and select an expense if provided', () => {
-        component.selectedTrasactionType = 'INITIALIZED';
+        component.selectedTransactionType = 'INITIALIZED';
         component.selectionMode = false;
         spyOn(component, 'toggleExpense');
 
@@ -817,7 +817,7 @@ describe('PersonalCardsPage', () => {
 
     it('addNewFiltersToParams(): should new filters to params', () => {
       spyOn(component.loadData$, 'getValue').and.returnValue({});
-      component.selectedTrasactionType = 'DEBIT';
+      component.selectedTransactionType = 'DEBIT';
       component.selectedAccount = 'baccLesaRlyvLY';
 
       const result = component.addNewFiltersToParams();
@@ -915,13 +915,13 @@ describe('PersonalCardsPage', () => {
   });
 
   it('loadLinkedAccounts(): should load linked accounts', (done) => {
-    personalCardsService.getLinkedAccounts.and.returnValue(of(apiLinkedAccRes.data));
+    personalCardsService.getPersonalCards.and.returnValue(of(apiLinkedAccRes.data));
 
     component.loadLinkedAccounts();
 
     component.linkedAccounts$.subscribe((res) => {
       expect(res).toEqual(apiLinkedAccRes.data);
-      expect(personalCardsService.getLinkedAccounts).toHaveBeenCalledTimes(1);
+      expect(personalCardsService.getPersonalCards).toHaveBeenCalledTimes(1);
       done();
     });
   });
@@ -953,7 +953,7 @@ describe('PersonalCardsPage', () => {
   });
 
   it('loadAccountCount(): should load accounts count and clear filters', (done) => {
-    personalCardsService.getLinkedAccountsCount.and.returnValue(of(0));
+    personalCardsService.getPersonalCardsCount.and.returnValue(of(0));
     spyOn(component, 'clearFilters');
 
     component.loadAccountCount();

--- a/src/app/fyle/personal-cards/personal-cards.page.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.ts
@@ -104,7 +104,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
 
   isInfiniteScrollRequired$: Observable<boolean>;
 
-  selectedTrasactionType = 'INITIALIZED';
+  selectedTransactionType = 'INITIALIZED';
 
   selectedAccount: string;
 
@@ -187,7 +187,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
     this.linkedAccounts$ = this.loadCardData$.pipe(
       tap(() => (this.isLoading = true)),
       switchMap(() =>
-        this.personalCardsService.getLinkedAccounts(this.usePlatformApi).pipe(
+        this.personalCardsService.getPersonalCards(this.usePlatformApi).pipe(
           tap(() => {
             this.isCardsLoaded = true;
           }),
@@ -219,7 +219,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
 
   loadAccountCount(): void {
     this.linkedAccountsCount$ = this.loadCardData$.pipe(
-      switchMap(() => this.personalCardsService.getLinkedAccountsCount(this.usePlatformApi)),
+      switchMap(() => this.personalCardsService.getPersonalCardsCount(this.usePlatformApi)),
       tap((count) => {
         if (count === 0) {
           this.clearFilters();
@@ -407,7 +407,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
     this.acc = [];
     const params = this.loadData$.getValue();
     const queryParams = params.queryParams || {};
-    queryParams.btxn_status = `in.(${this.selectedTrasactionType})`;
+    queryParams.btxn_status = `in.(${this.selectedTransactionType})`;
     queryParams.ba_id = 'eq.' + this.selectedAccount;
     params.queryParams = queryParams;
     params.pageNumber = 1;
@@ -463,11 +463,11 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
     if (this.selectionMode) {
       this.switchSelectionMode();
     }
-    this.selectedTrasactionType = event.detail.value;
+    this.selectedTransactionType = event.detail.value;
     this.acc = [];
     const params = this.loadData$.getValue();
     const queryParams = params.queryParams || {};
-    queryParams.btxn_status = `in.(${this.selectedTrasactionType})`;
+    queryParams.btxn_status = `in.(${this.selectedTransactionType})`;
     params.queryParams = queryParams;
     params.pageNumber = 1;
     this.zone.run(() => {
@@ -528,7 +528,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
   }
 
   switchSelectionMode(txnId?: string): void {
-    if (this.selectedTrasactionType === 'INITIALIZED') {
+    if (this.selectedTransactionType === 'INITIALIZED') {
       this.selectionMode = !this.selectionMode;
       this.selectedElements = [];
       if (txnId) {
@@ -664,7 +664,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
     const newQueryParams: { or: string[]; btxn_status?: string; ba_id?: string } = {
       or: [],
     };
-    newQueryParams.btxn_status = `in.(${this.selectedTrasactionType})`;
+    newQueryParams.btxn_status = `in.(${this.selectedTransactionType})`;
     newQueryParams.ba_id = 'eq.' + this.selectedAccount;
     const filters = this.filters;
     this.personalCardsService.generateTxnDateParams(newQueryParams, filters, 'createdOn');

--- a/src/app/fyle/personal-cards/personal-cards.page.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.ts
@@ -452,7 +452,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
     if (this.selectionMode) {
       this.switchSelectionMode();
     }
-    this.selectedTrasactionType = event.detail.value as string;
+    this.selectedTrasactionType = event.detail.value;
     this.acc = [];
     const params = this.loadData$.getValue();
     const queryParams = params.queryParams || {};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -21,6 +21,7 @@ export const environment = {
   MIXPANEL_PROJECT_TOKEN: '',
   USE_MIXPANEL_PROXY: '',
   ENABLE_MIXPANEL: '',
+  YODLEE_FAST_LINK_URL: '',
 };
 
 /*


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cwm1x6j

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new interface for managing personal card platform data.
	- Added a feature flag to manage API usage dynamically.
	- New methods to transform and fetch linked account data.

- **Improvements**
	- Made several properties optional in the PersonalCard interface for enhanced flexibility.
	- Simplified type handling in the PersonalCardsPage component.
	- Enhanced mock data structure with new response formats and entries.

- **Chores**
	- Added a new environment property for Yodlee fast link integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->