### PR TITLE
fix: Set custom fields based on unspecified category id if no category selected

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -2248,7 +2248,6 @@ export class AddEditExpensePage implements OnInit {
     const categoryControl = this.getFormControl('category');
 
     const customInputsFeilds$: Observable<TxnCustomProperties[]> = categoryControl.valueChanges.pipe(
-      filter((category) => !!category),
       startWith({}),
       distinctUntilChanged(),
       switchMap((category) =>
@@ -2258,6 +2257,21 @@ export class AddEditExpensePage implements OnInit {
           this.getCategoryOnEdit(category as OrgCategory)
         )
       ),
+      switchMap((category: OrgCategory) => {
+        if (!category) {
+          // set to unspecified category if no category is selected
+          return this.allCategories$.pipe(
+            map((categories) => {
+              const unspecifiedCategory = categories.find(
+                (category) => category.fyle_category?.toLowerCase() === 'unspecified'
+              );
+              return unspecifiedCategory;
+            })
+          );
+        } else {
+          return of(category);
+        }
+      }),
       switchMap((category: OrgCategory) => {
         const formValue = this.fg.value as {
           custom_inputs: CustomInput[];


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cwgw4am

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of category selection when adding or editing expenses, with a default to "unspecified" if no category is selected.

- **Bug Fixes**
	- Enhanced robustness of custom fields setup to ensure a valid category is always present, improving user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->