### PR TITLE
fix: LIVE_UPDATE_APP_VERSION for Sentry release instead of FYLE_MOBILE_RELEASE_VERSION

### DIFF
--- a/hooks/prebuild.js
+++ b/hooks/prebuild.js
@@ -46,15 +46,6 @@ module.exports = function (ctx) {
       '/node_modules/@capacitor-community/camera-preview/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java',
   };
 
-  // Adding mobile app version for tracking the release in sentry
-  var mainPath = path.resolve(process.cwd(), 'src/main.ts');
-  var mainPathContent = fs.readFileSync(mainPath).toString();
-  fs.writeFileSync(
-    mainPath,
-    mainPathContent.replace(/please-replace-your-mobile-app-version/g, ctx.env.FYLE_MOBILE_RELEASE_VERSION),
-    'utf8'
-  );
-
   // Commenting Manifest.permission.RECORD_AUDIO on CameraPreview.java
   var cameraPreviewPath = path.resolve(process.cwd(), FILE_PATHS['android.cameraPreview']);
   var cameraPreviewContents = fs.readFileSync(cameraPreviewPath).toString();

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ Sentry.init({
   dsn: environment.SENTRY_DSN,
   integrations: [],
   tracesSampleRate: 0.1,
-  release: 'please-replace-your-mobile-app-version',
+  release: environment.LIVE_UPDATE_APP_VERSION,
   ignoreErrors: ['Non-Error exception captured', 'Non-Error promise rejection captured'],
   beforeSend(event) {
     cleanHttpExceptionUrlsForSentryGrouping(event);


### PR DESCRIPTION
## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Sentry integration by dynamically assigning the release version from environment configuration.
  
- **Bug Fixes**
	- Removed outdated code for mobile app version tracking, ensuring a cleaner pre-build process without affecting overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->