### PR TITLE
fix: remove unmatch personal card feature

### DIFF
--- a/src/app/core/services/personal-cards.service.spec.ts
+++ b/src/app/core/services/personal-cards.service.spec.ts
@@ -928,22 +928,6 @@ describe('PersonalCardsService', () => {
     });
   });
 
-  it('unmatchExpense(): should unmatch an expense', (done) => {
-    apiService.post.and.returnValue(of(null));
-
-    const txnSplitGroupID = 'tx2ZttMRItRx';
-    const externalId = 'btxntEdVJeYyyx';
-
-    personalCardsService.unmatchExpense(txnSplitGroupID, externalId).subscribe((res) => {
-      expect(res).toBeNull();
-      expect(apiService.post).toHaveBeenCalledOnceWith('/transactions/external_expense/unmatch', {
-        transaction_split_group_id: txnSplitGroupID,
-        external_expense_id: externalId,
-      });
-      done();
-    });
-  });
-
   it('hideTransactions(): should hide transactions', (done) => {
     expenseAggregationService.post.and.returnValue(of(apiExpenseRes));
 

--- a/src/app/core/services/personal-cards.service.ts
+++ b/src/app/core/services/personal-cards.service.ts
@@ -198,13 +198,6 @@ export class PersonalCardsService {
     }) as Observable<Expense[]>;
   }
 
-  unmatchExpense(transactionSplitGroupId: string, externalExpenseId: string): Observable<void> {
-    return this.apiService.post('/transactions/external_expense/unmatch', {
-      transaction_split_group_id: transactionSplitGroupId,
-      external_expense_id: externalExpenseId,
-    });
-  }
-
   generateDateParams(
     data: { range: string; endDate?: string; startDate?: string },
     currentParams: Partial<SortFiltersParams>

--- a/src/app/core/services/tracking.service.ts
+++ b/src/app/core/services/tracking.service.ts
@@ -563,10 +563,6 @@ export class TrackingService {
     this.eventTrack('Expense matched created from personal card transaction', properties);
   }
 
-  unmatchedExpensesFromPersonalCard(properties = {}): void {
-    this.eventTrack('Expense matched created from personal card transaction', properties);
-  }
-
   transactionsHiddenOnPersonalCards(properties = {}): void {
     this.eventTrack('Transactions hidden on personal cards', properties);
   }

--- a/src/app/fyle/personal-cards-matched-expenses/expense-preview/expense-preview.component.html
+++ b/src/app/fyle/personal-cards-matched-expenses/expense-preview/expense-preview.component.html
@@ -9,7 +9,7 @@
     <ion-title>
       <div class="expense-preview--toolbar__title">
         <ng-container *ngIf="type === 'match'"> Confirm Matching Expense </ng-container>
-        <ng-container *ngIf="type === 'unmatch'"> View matching Expense </ng-container>
+        <ng-container *ngIf="type === 'preview'"> View matching Expense </ng-container>
       </div>
     </ion-title>
   </ion-toolbar>
@@ -134,20 +134,8 @@
           Confirm Match
         </ion-button>
       </ion-buttons>
-      <ion-buttons *ngIf="type === 'unmatch'">
-        <ion-button
-          (click)="unmatchExpense()"
-          [disabled]="unMatching"
-          [loadingText]="'Unmatching'"
-          [loading]="unMatching"
-          appFormButtonValidation
-          class="btn-secondary"
-        >
-          Unmatch
-        </ion-button>
-        <ion-button (click)="editExpense()" [disabled]="unMatching" appFormButtonValidation class="btn-primary">
-          Edit
-        </ion-button>
+      <ion-buttons *ngIf="type === 'preview'">
+        <ion-button (click)="editExpense()" appFormButtonValidation class="btn-primary"> Edit </ion-button>
       </ion-buttons>
     </div>
   </ion-toolbar>

--- a/src/app/fyle/personal-cards-matched-expenses/expense-preview/expense-preview.component.html
+++ b/src/app/fyle/personal-cards-matched-expenses/expense-preview/expense-preview.component.html
@@ -9,7 +9,7 @@
     <ion-title>
       <div class="expense-preview--toolbar__title">
         <ng-container *ngIf="type === 'match'"> Confirm Matching Expense </ng-container>
-        <ng-container *ngIf="type === 'preview'"> View matching Expense </ng-container>
+        <ng-container *ngIf="type === 'edit'"> View matching Expense </ng-container>
       </div>
     </ion-title>
   </ion-toolbar>
@@ -134,7 +134,7 @@
           Confirm Match
         </ion-button>
       </ion-buttons>
-      <ion-buttons *ngIf="type === 'preview'">
+      <ion-buttons *ngIf="type === 'edit'">
         <ion-button (click)="editExpense()" appFormButtonValidation class="btn-primary"> Edit </ion-button>
       </ion-buttons>
     </div>

--- a/src/app/fyle/personal-cards-matched-expenses/expense-preview/expense-preview.component.spec.ts
+++ b/src/app/fyle/personal-cards-matched-expenses/expense-preview/expense-preview.component.spec.ts
@@ -32,16 +32,9 @@ describe('ExpensePreviewComponent', () => {
     const matSnackBarSpy = jasmine.createSpyObj('MatSnackBar', ['openFromComponent']);
     const snackbarPropertiesServiceSpy = jasmine.createSpyObj('SnackbarPropertiesService', ['setSnackbarProperties']);
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
-    const personalCardsServiceSpy = jasmine.createSpyObj('PersonalCardsService', [
-      'getExpenseDetails',
-      'matchExpense',
-      'unmatchExpense',
-    ]);
+    const personalCardsServiceSpy = jasmine.createSpyObj('PersonalCardsService', ['getExpenseDetails', 'matchExpense']);
     const platformSpy = jasmine.createSpyObj('Platform', ['is']);
-    const trackingServiceSpy = jasmine.createSpyObj('TrackingService', [
-      'oldExpensematchedFromPersonalCard',
-      'unmatchedExpensesFromPersonalCard',
-    ]);
+    const trackingServiceSpy = jasmine.createSpyObj('TrackingService', ['oldExpensematchedFromPersonalCard']);
     const expensesServiceSpy = jasmine.createSpyObj('ExpensesService', ['getExpenses']);
     TestBed.configureTestingModule({
       declarations: [ExpensePreviewComponent, ExpensePreviewShimmerComponent],
@@ -137,25 +130,5 @@ describe('ExpensePreviewComponent', () => {
     expect(modalController.dismiss).toHaveBeenCalledTimes(1);
     expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'personal_cards']);
     expect(trackingService.oldExpensematchedFromPersonalCard).toHaveBeenCalledTimes(1);
-  });
-
-  it('unmatchExpense(): should unmatch the expenses', () => {
-    component.unMatching = true;
-    personalCardsService.unmatchExpense.and.returnValue(of(null));
-    component.expenseId = 'tx2ZttMRItRx';
-    component.cardTxnId = 'btxntEdVJeYyyx';
-
-    component.unmatchExpense();
-    expect(component.unMatching).toBeFalsy();
-
-    fixture.detectChanges();
-    expect(personalCardsService.unmatchExpense).toHaveBeenCalledOnceWith(component.expenseId, component.cardTxnId);
-    expect(modalController.dismiss).toHaveBeenCalledTimes(1);
-    expect(matSnackBar.openFromComponent).toHaveBeenCalledWith(ToastMessageComponent, {
-      ...snackbarProperties.setSnackbarProperties('success', { message: 'Successfully unmatched the expense.' }),
-      panelClass: ['msb-success'],
-    });
-    expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'personal_cards']);
-    expect(trackingService.unmatchedExpensesFromPersonalCard).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/fyle/personal-cards-matched-expenses/expense-preview/expense-preview.component.ts
+++ b/src/app/fyle/personal-cards-matched-expenses/expense-preview/expense-preview.component.ts
@@ -27,8 +27,6 @@ export class ExpensePreviewComponent implements OnInit {
 
   loading = false;
 
-  unMatching = false;
-
   type: string;
 
   isIos = false;
@@ -73,24 +71,6 @@ export class ExpensePreviewComponent implements OnInit {
         });
         this.router.navigate(['/', 'enterprise', 'personal_cards']);
         this.trackingService.oldExpensematchedFromPersonalCard();
-      });
-  }
-
-  unmatchExpense(): void {
-    this.unMatching = true;
-    this.personalCardsService
-      .unmatchExpense(this.expenseId, this.cardTxnId)
-      .pipe(finalize(() => (this.unMatching = false)))
-      .subscribe(() => {
-        this.modalController.dismiss();
-        this.matSnackBar.openFromComponent(ToastMessageComponent, {
-          ...this.snackbarProperties.setSnackbarProperties('success', {
-            message: 'Successfully unmatched the expense.',
-          }),
-          panelClass: ['msb-success'],
-        });
-        this.router.navigate(['/', 'enterprise', 'personal_cards']);
-        this.trackingService.unmatchedExpensesFromPersonalCard();
       });
   }
 

--- a/src/app/fyle/personal-cards/personal-cards.page.spec.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.spec.ts
@@ -748,7 +748,7 @@ describe('PersonalCardsPage', () => {
           expenseId: matchedPersonalCardTxn.txn_details[0]?.id,
           card: matchedPersonalCardTxn.ba_account_number,
           cardTxnId: matchedPersonalCardTxn.btxn_id,
-          type: 'unmatch',
+          type: 'preview',
         },
         ...properties,
       });

--- a/src/app/fyle/personal-cards/personal-cards.page.spec.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.spec.ts
@@ -748,7 +748,7 @@ describe('PersonalCardsPage', () => {
           expenseId: matchedPersonalCardTxn.txn_details[0]?.id,
           card: matchedPersonalCardTxn.ba_account_number,
           cardTxnId: matchedPersonalCardTxn.btxn_id,
-          type: 'preview',
+          type: 'edit',
         },
         ...properties,
       });

--- a/src/app/fyle/personal-cards/personal-cards.page.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.ts
@@ -776,7 +776,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
         expenseId: txn_details[0]?.id,
         card: txnDetails.ba_account_number,
         cardTxnId: txnDetails.btxn_id,
-        type: 'unmatch',
+        type: 'preview',
       },
       ...this.modalProperties.getModalDefaultProperties('expense-preview-modal'),
     });

--- a/src/app/fyle/personal-cards/personal-cards.page.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.ts
@@ -776,7 +776,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
         expenseId: txn_details[0]?.id,
         card: txnDetails.ba_account_number,
         cardTxnId: txnDetails.btxn_id,
-        type: 'preview',
+        type: 'edit',
       },
       ...this.modalProperties.getModalDefaultProperties('expense-preview-modal'),
     });


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cwm4m73

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new method to update user profile data in tracking services.
	- Updated the expense preview functionality to reflect an 'edit' state instead of 'unmatch'.

- **Bug Fixes**
	- Removed outdated unmatching functionality from the PersonalCardsService and related components.

- **Documentation**
	- Adjusted test cases to validate new behavior of the expense preview and ensure accurate service interactions.

- **Refactor**
	- Simplified the logic for rendering components based on the updated 'edit' state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->