### PR TITLE
fix: migrate delete personal card api to platform

### DIFF
--- a/src/app/core/mock-data/personal-cards.data.ts
+++ b/src/app/core/mock-data/personal-cards.data.ts
@@ -72,6 +72,27 @@ export const deletePersonalCardRes: PersonalCard = deepFreeze({
   updated_at: new Date('2022-05-31T07:40:58.190907'),
 });
 
+export const deletePersonalCardPlatformRes: PlatformApiResponse<PersonalCardPlatform> = deepFreeze({
+  data: {
+    account_type: 'SAVINGS',
+    bank_name: 'Dag Site',
+    card_number: 'xxxx3235',
+    created_at: new Date('2024-11-11T06:20:18.061281+00:00'),
+    currency: 'USD',
+    id: 'bacc0By33NqhnS',
+    org_id: 'orrb8EW1zZsy',
+    updated_at: new Date('2024-11-11T06:20:18.061281+00:00'),
+    user_id: 'us2KhpQLpzX4',
+    yodlee_account_id: 'yacQm13ONl3q1',
+    yodlee_fastlink_params: null,
+    yodlee_is_credential_update_required: false,
+    yodlee_is_mfa_required: false,
+    yodlee_last_synced_at: null,
+    yodlee_login_id: 'ou6kAM3CXV7d',
+    yodlee_provider_account_id: '10287107',
+  },
+});
+
 export const linkedAccountsRes: PersonalCard[] = deepFreeze([
   {
     account_number: 'xxxx4227',

--- a/src/app/core/models/platform/platform-api-response.model.ts
+++ b/src/app/core/models/platform/platform-api-response.model.ts
@@ -1,5 +1,5 @@
 export interface PlatformApiResponse<T> {
-  count: number;
-  offset: number;
+  count?: number;
+  offset?: number;
   data: T;
 }

--- a/src/app/core/services/personal-cards.service.ts
+++ b/src/app/core/services/personal-cards.service.ts
@@ -132,7 +132,7 @@ export class PersonalCardsService {
     };
     return this.spenderPlatformV1ApiService
       .post<PlatformApiResponse<PersonalCardPlatform>>('/personal_cards/delete', payload)
-      .pipe(map((res) => res.data));
+      .pipe(map((response) => response.data));
   }
 
   deleteAccount(accountId: string, usePlatformApi: boolean): Observable<PersonalCard | PersonalCardPlatform> {

--- a/src/app/core/services/personal-cards.service.ts
+++ b/src/app/core/services/personal-cards.service.ts
@@ -124,7 +124,21 @@ export class PersonalCardsService {
     });
   }
 
-  deleteAccount(accountId: string): Observable<PersonalCard> {
+  deleteAccountPlatform(accountId: string): Observable<PersonalCardPlatform> {
+    const payload = {
+      data: {
+        id: accountId,
+      },
+    };
+    return this.spenderPlatformV1ApiService
+      .post<PlatformApiResponse<PersonalCardPlatform>>('/personal_cards/delete', payload)
+      .pipe(map((res) => res.data));
+  }
+
+  deleteAccount(accountId: string, usePlatformApi: boolean): Observable<PersonalCard | PersonalCardPlatform> {
+    if (usePlatformApi) {
+      return this.deleteAccountPlatform(accountId);
+    }
     return this.expenseAggregationService.delete('/bank_accounts/' + accountId) as Observable<PersonalCard>;
   }
 

--- a/src/app/shared/components/bank-account-cards/bank-account-card/bank-account-card.component.spec.ts
+++ b/src/app/shared/components/bank-account-cards/bank-account-card/bank-account-card.component.spec.ts
@@ -15,7 +15,7 @@ import { DeleteButtonComponent } from './delete-button/delete-button-component';
 import { click, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
 import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 
-fdescribe('BankAccountCardComponent', () => {
+describe('BankAccountCardComponent', () => {
   let component: BankAccountCardComponent;
   let fixture: ComponentFixture<BankAccountCardComponent>;
   let personalCardsService: jasmine.SpyObj<PersonalCardsService>;

--- a/src/app/shared/components/bank-account-cards/bank-account-card/bank-account-card.component.ts
+++ b/src/app/shared/components/bank-account-cards/bank-account-card/bank-account-card.component.ts
@@ -42,7 +42,7 @@ export class BankAccountCardComponent implements OnInit {
     }
   }
 
-  async presentPopover(ev: any) {
+  async presentPopover(ev: PointerEvent): Promise<void> {
     const deleteCardPopOver = await this.popoverController.create({
       component: DeleteButtonComponent,
       cssClass: 'delete-button-class',
@@ -50,14 +50,14 @@ export class BankAccountCardComponent implements OnInit {
     });
     await deleteCardPopOver.present();
 
-    const { data } = await deleteCardPopOver.onDidDismiss();
+    const { data } = await deleteCardPopOver.onDidDismiss<string>();
 
     if (data === 'delete') {
       this.confirmPopup();
     }
   }
 
-  async deleteAccount() {
+  async deleteAccount(): Promise<void> {
     from(this.loaderService.showLoader('Deleting your card...', 5000))
       .pipe(
         switchMap(() => this.personalCardsService.deleteAccount(this.accountDetails.id)),
@@ -73,7 +73,7 @@ export class BankAccountCardComponent implements OnInit {
       .subscribe(() => this.deleted.emit());
   }
 
-  async confirmPopup() {
+  async confirmPopup(): Promise<void> {
     const deleteCardPopOver = await this.popoverController.create({
       component: PopupAlertComponent,
       componentProps: {
@@ -93,7 +93,7 @@ export class BankAccountCardComponent implements OnInit {
 
     await deleteCardPopOver.present();
 
-    const { data } = await deleteCardPopOver.onWillDismiss();
+    const { data } = await deleteCardPopOver.onWillDismiss<{ action: string }>();
 
     if (data && data.action === 'delete') {
       this.deleteAccount();

--- a/src/app/shared/components/bank-account-cards/bank-account-card/bank-account-card.component.ts
+++ b/src/app/shared/components/bank-account-cards/bank-account-card/bank-account-card.component.ts
@@ -11,6 +11,7 @@ import { SnackbarPropertiesService } from '../../../../core/services/snackbar-pr
 import { ToastMessageComponent } from 'src/app/shared/components/toast-message/toast-message.component';
 import { DeleteButtonComponent } from './delete-button/delete-button-component';
 import { DateService } from 'src/app/core/services/date.service';
+import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 @Component({
   selector: 'app-bank-account-card',
   templateUrl: './bank-account-card.component.html',
@@ -33,7 +34,8 @@ export class BankAccountCardComponent implements OnInit {
     private popoverController: PopoverController,
     private matSnackBar: MatSnackBar,
     private snackbarProperties: SnackbarPropertiesService,
-    private dateService: DateService
+    private dateService: DateService,
+    private launchDarklyService: LaunchDarklyService
   ) {}
 
   ngOnInit(): void {
@@ -60,7 +62,15 @@ export class BankAccountCardComponent implements OnInit {
   async deleteAccount(): Promise<void> {
     from(this.loaderService.showLoader('Deleting your card...', 5000))
       .pipe(
-        switchMap(() => this.personalCardsService.deleteAccount(this.accountDetails.id)),
+        switchMap(() =>
+          this.launchDarklyService
+            .getVariation('personal_cards_platform', false)
+            .pipe(
+              switchMap((usePlatformApi) =>
+                this.personalCardsService.deleteAccount(this.accountDetails.id, usePlatformApi)
+              )
+            )
+        ),
         finalize(async () => {
           await this.loaderService.hideLoader();
           const message = 'Card successfully deleted.';


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cwm1x50

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a feature flag management system via `LaunchDarklyService` for account deletion.
	- Enhanced account deletion method to support both public and platform APIs.
  
- **Bug Fixes**
	- Improved type safety for event handling in the `presentPopover` method.

- **Tests**
	- Added new test cases for the `deleteAccount()` method to ensure proper functionality with both APIs.
	- Updated test suite for `BankAccountCardComponent` to reflect changes in method signatures and dependencies.

- **Documentation**
	- Clarified asynchronous return types for several methods in the `BankAccountCardComponent`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->