### PR TITLE
fix: adding live update version for sentry release in build script

### DIFF
--- a/build_appflow.sh
+++ b/build_appflow.sh
@@ -1,5 +1,3 @@
 ionic capacitor sync --prod --source-map
 npm run sentry:sourcemaps
-echo "Sentry project name: $SENTRY_PROJECT_NAME"
-echo "Live update app version: $LIVE_UPDATE_APP_VERSION"
 sentry-cli releases --org fyle-technologies-private-limi -p "$SENTRY_PROJECT_NAME" files "$LIVE_UPDATE_APP_VERSION" upload-sourcemaps www

--- a/build_appflow.sh
+++ b/build_appflow.sh
@@ -1,4 +1,3 @@
-VERSION=`sentry-cli releases propose-version`
 ionic capacitor sync --prod --source-map
 npm run sentry:sourcemaps
-sentry-cli releases --org fyle-technologies-private-limi -p "$SENTRY_PROJECT_NAME" files "$VERSION" upload-sourcemaps www
+sentry-cli releases --org fyle-technologies-private-limi -p "$SENTRY_PROJECT_NAME" files "$LIVE_UPDATE_APP_VERSION" upload-sourcemaps www

--- a/build_appflow.sh
+++ b/build_appflow.sh
@@ -1,3 +1,5 @@
 ionic capacitor sync --prod --source-map
 npm run sentry:sourcemaps
+echo "Sentry project name: $SENTRY_PROJECT_NAME"
+echo "Live update app version: $LIVE_UPDATE_APP_VERSION"
 sentry-cli releases --org fyle-technologies-private-limi -p "$SENTRY_PROJECT_NAME" files "$LIVE_UPDATE_APP_VERSION" upload-sourcemaps www


### PR DESCRIPTION
## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the versioning method for uploading source maps to Sentry, now utilizing the `$LIVE_UPDATE_APP_VERSION` variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->