### PR TITLE
fix:replacing page title from Dashboard to Home

### DIFF
--- a/src/app/core/mock-data/sidemenu-item.data.ts
+++ b/src/app/core/mock-data/sidemenu-item.data.ts
@@ -3,7 +3,7 @@ import deepFreeze from 'deep-freeze-strict';
 import { SidemenuItem } from '../models/sidemenu-item.model';
 
 export const sidemenuItemData1: SidemenuItem = deepFreeze({
-  title: 'Dashboard',
+  title: 'Home',
   isVisible: true,
   icon: 'dashboard',
   route: ['/', 'enterprise', 'my_dashboard'],

--- a/src/app/core/mock-data/sidemenu.data.ts
+++ b/src/app/core/mock-data/sidemenu.data.ts
@@ -4,7 +4,7 @@ import { SidemenuItem } from '../models/sidemenu-item.model';
 
 export const sidemenuData1 = deepFreeze([
   {
-    title: 'Dashboard',
+    title: 'Home',
     isVisible: true,
     icon: 'dashboard',
     route: ['/', 'enterprise', 'my_dashboard'],
@@ -25,7 +25,7 @@ export const sidemenuData1 = deepFreeze([
 
 export const PrimaryOptionsRes1: Partial<SidemenuItem>[] = deepFreeze([
   {
-    title: 'Dashboard',
+    title: 'Home',
     isVisible: true,
     icon: 'dashboard',
     route: ['/', 'enterprise', 'my_dashboard'],
@@ -91,7 +91,7 @@ export const PrimaryOptionsRes2: Partial<SidemenuItem>[] = deepFreeze([
 
 export const getPrimarySidemenuOptionsRes1 = deepFreeze([
   {
-    title: 'Dashboard',
+    title: 'Home',
     isVisible: true,
     icon: 'dashboard',
     route: ['/', 'enterprise', 'my_dashboard'],
@@ -158,7 +158,7 @@ export const getSecondarySidemenuOptionsRes1 = deepFreeze([
 
 export const setSideMenuRes: Partial<SidemenuItem>[] = deepFreeze([
   {
-    title: 'Dashboard',
+    title: 'Home',
     isVisible: true,
     icon: 'dashboard',
     route: ['/', 'enterprise', 'my_dashboard'],

--- a/src/app/shared/components/sidemenu/sidemenu.component.spec.ts
+++ b/src/app/shared/components/sidemenu/sidemenu.component.spec.ts
@@ -312,7 +312,7 @@ describe('SidemenuComponent', () => {
       component.orgSettings.advance_requests.enabled = true;
       const resData = [
         {
-          title: 'Dashboard',
+          title: 'Home',
           isVisible: true,
           icon: 'dashboard',
           route: ['/', 'enterprise', 'my_dashboard'],

--- a/src/app/shared/components/sidemenu/sidemenu.component.ts
+++ b/src/app/shared/components/sidemenu/sidemenu.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 import * as Sentry from '@sentry/angular';
 import { Observable, from, forkJoin, concat, combineLatest } from 'rxjs';
-import { map, shareReplay } from 'rxjs/operators';
+import { shareReplay } from 'rxjs/operators';
 import { DeviceService } from 'src/app/core/services/device.service';
 import { RouterAuthService } from 'src/app/core/services/router-auth.service';
 import { OrgUserService } from 'src/app/core/services/org-user.service';
@@ -217,7 +217,7 @@ export class SidemenuComponent implements OnInit {
 
     const primaryOptions = [
       {
-        title: 'Dashboard',
+        title: 'Home',
         isVisible: true,
         icon: 'dashboard',
         route: ['/', 'enterprise', 'my_dashboard'],
@@ -296,7 +296,7 @@ export class SidemenuComponent implements OnInit {
   getPrimarySidemenuOptionsOffline(): Partial<SidemenuItem>[] {
     return [
       {
-        title: 'Dashboard',
+        title: 'Home',
         isVisible: true,
         icon: 'dashboard',
         route: ['/', 'enterprise', 'my_dashboard'],


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cx2whpg

## Code Coverage
Please add code coverage here

## UI Preview
<img width="377" alt="Screenshot 2024-11-19 at 4 44 52 PM" src="https://github.com/user-attachments/assets/a6f48229-4b00-4e1d-a1ba-c067bd7f8fd8">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the title of the first item in the side menu from "Dashboard" to "Home" across various components and data structures.
  
- **Bug Fixes**
	- Enhanced the logic for displaying sidemenu options based on user status and organizational settings.

- **Tests**
	- Expanded test cases for the `SidemenuComponent` to verify the correct display and behavior of sidemenu options under different conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->