### PR TITLE
fix: Bug in personal cards initialization

### DIFF
--- a/src/app/fyle/personal-cards/personal-cards.page.spec.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.spec.ts
@@ -238,7 +238,6 @@ describe('PersonalCardsPage', () => {
   describe('mocked lifecycle', () => {
     beforeEach(() => {
       spyOn(component, 'ngOnInit');
-      spyOn(component, 'ionViewWillEnter');
       spyOn(component, 'ngAfterViewInit');
     });
 
@@ -889,6 +888,7 @@ describe('PersonalCardsPage', () => {
 
       expect(component.setupNetworkWatcher).toHaveBeenCalledTimes(1);
       expect(component.mode).toEqual('ios');
+      expect(trackingService.personalCardsViewed).toHaveBeenCalledTimes(1);
     });
 
     it('should set mode to material design and network watcher', () => {
@@ -902,16 +902,10 @@ describe('PersonalCardsPage', () => {
     });
   });
 
-  it('ionViewWillEnter(): should setup class variables', () => {
-    component.isCardsLoaded = true;
-    spyOn(component.loadData$, 'getValue').and.returnValue({});
-    spyOn(component.loadData$, 'next');
-
-    component.ionViewWillEnter();
-
-    expect(component.loadData$.next).toHaveBeenCalledTimes(1);
-    expect(component.loadData$.getValue).toHaveBeenCalledTimes(1);
-    expect(trackingService.personalCardsViewed).toHaveBeenCalledTimes(1);
+  it('ionViewWillLeave(): should set onPageExit to null', () => {
+    spyOn(component.onPageExit$, 'next');
+    component.ionViewWillLeave();
+    expect(component.onPageExit$.next).toHaveBeenCalledOnceWith(null);
   });
 
   it('loadLinkedAccounts(): should load linked accounts', (done) => {

--- a/src/app/fyle/personal-cards/personal-cards.page.spec.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.spec.ts
@@ -43,7 +43,7 @@ import { PersonalCardsPage } from './personal-cards.page';
 import { PersonalCardFilter } from 'src/app/core/models/personal-card-filters.model';
 import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 
-fdescribe('PersonalCardsPage', () => {
+describe('PersonalCardsPage', () => {
   let component: PersonalCardsPage;
   let fixture: ComponentFixture<PersonalCardsPage>;
   let personalCardsService: jasmine.SpyObj<PersonalCardsService>;

--- a/src/app/fyle/personal-cards/personal-cards.page.spec.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.spec.ts
@@ -43,7 +43,7 @@ import { PersonalCardsPage } from './personal-cards.page';
 import { PersonalCardFilter } from 'src/app/core/models/personal-card-filters.model';
 import { LaunchDarklyService } from 'src/app/core/services/launch-darkly.service';
 
-describe('PersonalCardsPage', () => {
+fdescribe('PersonalCardsPage', () => {
   let component: PersonalCardsPage;
   let fixture: ComponentFixture<PersonalCardsPage>;
   let personalCardsService: jasmine.SpyObj<PersonalCardsService>;
@@ -904,8 +904,10 @@ describe('PersonalCardsPage', () => {
 
   it('ionViewWillLeave(): should set onPageExit to null', () => {
     spyOn(component.onPageExit$, 'next');
+    spyOn(component.onPageExit$, 'complete');
     component.ionViewWillLeave();
     expect(component.onPageExit$.next).toHaveBeenCalledOnceWith(null);
+    expect(component.onPageExit$.complete).toHaveBeenCalledTimes(1);
   });
 
   it('loadLinkedAccounts(): should load linked accounts', (done) => {

--- a/src/app/fyle/personal-cards/personal-cards.page.ts
+++ b/src/app/fyle/personal-cards/personal-cards.page.ts
@@ -325,6 +325,7 @@ export class PersonalCardsPage implements OnInit, AfterViewInit {
 
   ionViewWillLeave(): void {
     this.onPageExit$.next(null);
+    this.onPageExit$.complete();
   }
 
   setupNetworkWatcher(): void {


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cx457mp

Bug in mobile app -> personal cards page
On initial load, the page fetches txns of all the personal cards instead of selected one, and fetches all txns whether they are `INITIALIZED, MATCHED or HIDDEN`  under the transactions tab only which should only show txns with `INITIALIZED` state.

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced view initialization for the Personal Cards page when linked accounts exist.
	- Improved search functionality with real-time updates based on user input.

- **Bug Fixes**
	- Streamlined control flow for loading linked accounts and transactions.
	- Updated lifecycle management to ensure proper handling of page exit events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->