### PR TITLE
fix: Switch to macOS 2024.04 for prod internal release

### DIFF
--- a/.github/workflows/appflow-release-branch.yml
+++ b/.github/workflows/appflow-release-branch.yml
@@ -43,6 +43,7 @@ jobs:
           app-id: 32316914
           platform: iOS
           build-type: development
+          build-stack: macOS - 2024.04
           certificate: Fyle signing
           environment: staging
           native-config: prod


### PR DESCRIPTION
## Clickup
https://app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated iOS build environment to macOS - 2024.04 for improved compatibility.
	- Set iOS build type to development for enhanced testing capabilities.

- **Bug Fixes**
	- Adjusted native configuration to production for more stable releases.

- **Chores**
	- Maintained existing workflow structure for building and deploying Android and iOS applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->