### PR TITLE
feat: Update HumanizeCurrencyPipe to display the exact amount

### DIFF
--- a/src/app/shared/pipes/humanize-currency.pipe.spec.ts
+++ b/src/app/shared/pipes/humanize-currency.pipe.spec.ts
@@ -22,21 +22,46 @@ describe('HumanizeCurrencyPipe', () => {
       expect(humanizeCurrencyPipe.transform(651547.297922, 'USD', false)).toEqual(expectedAmount);
     });
 
-    it('should humanize negtive amount', () => {
-      const expectedAmount = '-$122.57';
+    it('should handle negative amounts when humanized', () => {
+      const expectedAmount = '-$122.57K';
       fyCurrencyPipeSpy.transform.and.returnValue('$122.57');
-      expect(humanizeCurrencyPipe.transform(-122.57, 'USD')).toEqual(expectedAmount);
+      expect(humanizeCurrencyPipe.transform(-122570, 'USD')).toEqual(expectedAmount);
     });
 
-    it('should return amount when fraction specified', () => {
+    it('should return humanized amount with fraction specified', () => {
       const expectedAmount = '$651.547K';
       fyCurrencyPipeSpy.transform.and.returnValue('$651.547');
       expect(humanizeCurrencyPipe.transform(651547.297922, 'USD', false, 3)).toEqual(expectedAmount);
     });
-  });
 
-  it('should return amount when fraction specified', () => {
-    fyCurrencyPipeSpy.transform.and.returnValue('$0');
-    expect(humanizeCurrencyPipe.transform(0, 'USD')).toEqual('$0');
+    it('should return exact amount when humanize is false | without symbol', () => {
+      const expectedAmount = '651547.30';
+      fyCurrencyPipeSpy.transform.and.returnValue('651547.30');
+      expect(humanizeCurrencyPipe.transform(651547.297922, 'USD', true, 2, false)).toEqual(expectedAmount);
+    });
+
+    it('should return exact amount when humanize is false | with symbol', () => {
+      const expectedAmount = '$651547.30';
+      fyCurrencyPipeSpy.transform.and.returnValue('$651547.30');
+      expect(humanizeCurrencyPipe.transform(651547.297922, 'USD', false, 2, false)).toEqual(expectedAmount);
+    });
+
+    it('should handle negative amounts when humanize is false', () => {
+      const expectedAmount = '-$122.57';
+      fyCurrencyPipeSpy.transform.and.returnValue('$122.57');
+      expect(humanizeCurrencyPipe.transform(-122.57, 'USD', false, undefined, false)).toEqual(expectedAmount);
+    });
+
+    it('should return "$0" for zero amount', () => {
+      const expectedAmount = '$0';
+      fyCurrencyPipeSpy.transform.and.returnValue('$0');
+      expect(humanizeCurrencyPipe.transform(0, 'USD')).toEqual(expectedAmount);
+    });
+
+    it('should return exact zero amount when humanize is false', () => {
+      const expectedAmount = '$0.00';
+      fyCurrencyPipeSpy.transform.and.returnValue('$0.00');
+      expect(humanizeCurrencyPipe.transform(0, 'USD', false, 2, false)).toEqual(expectedAmount);
+    });
   });
 });

--- a/src/app/shared/pipes/humanize-currency.pipe.ts
+++ b/src/app/shared/pipes/humanize-currency.pipe.ts
@@ -7,18 +7,26 @@ import { FyCurrencyPipe } from './fy-currency.pipe';
 export class HumanizeCurrencyPipe implements PipeTransform {
   constructor(private fyCurrencyPipe: FyCurrencyPipe) {}
 
-  transform(value: number, currencyCode: string, skipSymbol = false, fraction?: number): string {
+  transform(value: number, currencyCode: string, skipSymbol = false, fraction?: number, humanize = true): string {
     const sign = value < 0 ? '-' : '';
     const amount = Math.abs(value) || 0;
+    // Empty string overrides the currency symbol
+    const symbolType = skipSymbol ? '' : 'symbol';
+    // We need to pass digitsInfo in this format - {minIntergers}.{minDecimal}-{maxDecimal}
+    const digitsInfo = fraction && `1.${fraction}-${fraction}`;
+
+    // If humanize is false, show exact amount
+    if (!humanize) {
+      // Exact amount formatting
+      const formattedValue = this.fyCurrencyPipe.transform(amount, currencyCode, symbolType, digitsInfo);
+
+      return sign + formattedValue;
+    }
+
+    // Humanized formatting
     const si = ['', 'K', 'M', 'B', 't', 'q', 'Q', 's', 'S', 'o', 'n'];
     const exp = Math.max(0, Math.floor(Math.log(amount) / Math.log(1000)));
     const result = amount / Math.pow(1000, exp);
-
-    // Empty string overrides the currency symbol
-    const symbolType = skipSymbol ? '' : 'symbol';
-
-    // We need to pass digitsInfo in this format - {minIntergers}.{minDecimal}-{maxDecimal}
-    const digitsInfo = fraction && `1.${fraction}-${fraction}`;
 
     let fixedResult = this.fyCurrencyPipe.transform(result, currencyCode, symbolType, digitsInfo);
     fixedResult = fixedResult + si[exp];


### PR DESCRIPTION
## Description 
As part of [#q4_mobile_app_display_exact_amount_on_stats](https://fylein.slack.com/archives/C07SY9GJ9K8) need to display the exact amount on different views.
Solution outline: https://www.notion.so/fyleuniverse/Milestone-1-Expense-view-14a2ed8bfcb3804387f1d7ab5cc429c1?pvs=4#1492ed8bfcb38014a197d9e4b06967a9 

## Clickup
[clickup link](https://app.clickup.com/t/86cx5t2pf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `HumanizeCurrencyPipe` to conditionally format currency based on a new `humanize` parameter, allowing for precise amount display.
  
- **Bug Fixes**
	- Improved test coverage for various scenarios, including handling negative amounts and zero values, ensuring robust functionality of the currency formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->