### PR TITLE
feat: Add to expenses to report section (Use Exact Amount)

### DIFF
--- a/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.html
+++ b/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.html
@@ -1,5 +1,6 @@
 <ion-header>
   <div class="report-list--header">
+    <mat-icon class="fy-modal-top-bar report-list--header--handle-bar-icon" svgIcon="notch"></mat-icon>
     <ion-grid>
       <ion-row>
         <ion-col size="1" class="report-list--header--row-icon-container">
@@ -9,7 +10,7 @@
             class="report-list--header--row-icon"
           ></ion-icon>
         </ion-col>
-        <ion-col size="10" class="text-center">Add to Report</ion-col>
+        <ion-col size="10" class="report-list--header--title text-center">Add to Report</ion-col>
         <ion-col size="1" class="report-list--header--row-icon-container">
           <ion-icon
             data-testid="addIcon"
@@ -28,20 +29,23 @@
       <div data-testid="report" mat-ripple (click)="addTransactionToReport(report)">
         <div *ngIf="i > 0" class="report-list--divider"></div>
         <ion-grid class="ion-no-padding">
-          <ion-row>
-            <ion-col size="8.5" class="ion-no-padding">
+          <ion-row class="report-list--report-card">
+            <ion-col size="0.75">
+              <mat-icon class="report-list--list-icon" svgIcon="list"></mat-icon>
+            </ion-col>
+            <ion-col size="8.25" class="ion-no-padding">
               <div class="report-list--purpose">{{ report.purpose }}</div>
               <div class="report-list--count">
                 {{ report.num_expenses }} Expense{{ report.num_expenses > 1 ? 's' : '' }}
               </div>
-            </ion-col>
-            <ion-col size="3.5" class="ion-no-padding ion-text-right">
               <div class="report-list--currency-amount-container">
                 <span class="report-list--currency">{{ reportCurrencySymbol }}</span>
-                <span class="report-list--amount">{{
-                  report.amount || 0 | humanizeCurrency : report.currency : true
-                }}</span>
+                <span class="report-list--amount">
+                  {{ { value: report.amount || 0, currencyCode: report.currency, skipSymbol: true } | exactCurrency }}
+                </span>
               </div>
+            </ion-col>
+            <ion-col size="2.75" class="ion-no-padding ion-text-right">
               <div class="ion-text-right">
                 <div class="text-center report-list--state state-pill state-{{ report.state | reportState }}">
                   {{ report.state | reportState : data.isNewReportsFlowEnabled | snakeCaseToSpaceCase | titlecase }}

--- a/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.scss
+++ b/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.scss
@@ -3,16 +3,22 @@ $reports_sent_back_color: #da1e28;
 
 .report-list {
   &--header {
-    font-size: 24px;
+    font-size: 18px;
     line-height: 1.3;
     color: $black;
-    margin-bottom: 24px;
     font-weight: 500;
+    border-bottom: 1px solid $grey;
 
     &--row-icon-container {
       display: flex;
       align-items: center;
       justify-content: center;
+      font-size: 20px;
+    }
+
+    &--handle-bar-icon {
+      margin-top: 0px;
+      margin-bottom: 2px;
     }
   }
 
@@ -20,8 +26,13 @@ $reports_sent_back_color: #da1e28;
     margin-top: 10px;
   }
 
+  &--list-icon {
+    width: 16px;
+    height: 16px;
+  }
+
   &--currency-amount-container {
-    margin-bottom: 4px;
+    margin: 10px 0 4px 0;
   }
 
   &--currency {
@@ -34,7 +45,7 @@ $reports_sent_back_color: #da1e28;
 
   &--amount {
     color: $black;
-    font-size: 20px;
+    font-size: 16px;
     line-height: 1.3;
     font-weight: 500;
   }
@@ -42,19 +53,24 @@ $reports_sent_back_color: #da1e28;
   &--purpose {
     font-weight: 500;
     color: $black;
-    font-size: 18px;
+    font-size: 14px;
     line-height: 1.3;
   }
 
   &--count {
-    color: $blue-black;
+    color: $dark-grey;
+    font-size: 12px;
     line-height: 1.3;
     margin-top: 2px;
   }
 
+  &--report-card {
+    padding-top: 6px;
+  }
+
   &--divider {
     border-bottom: 1px solid $grey-lighter;
-    margin-bottom: 14px;
+    margin-bottom: 6px;
   }
 
   &--state {

--- a/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.scss
+++ b/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.scss
@@ -17,8 +17,7 @@ $reports_sent_back_color: #da1e28;
     }
 
     &--handle-bar-icon {
-      margin-top: 0px;
-      margin-bottom: 2px;
+      margin: 0 0 2px 0;
     }
   }
 

--- a/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.spec.ts
+++ b/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.spec.ts
@@ -17,7 +17,7 @@ import { AddTxnToReportDialogComponent } from './add-txn-to-report-dialog.compon
 import { expectedReportsSinglePage } from 'src/app/core/mock-data/platform-report.data';
 import { ExactCurrencyPipe } from 'src/app/shared/pipes/exact-currency.pipe';
 
-fdescribe('AddTxnToReportDialogComponent', () => {
+describe('AddTxnToReportDialogComponent', () => {
   let component: AddTxnToReportDialogComponent;
   let fixture: ComponentFixture<AddTxnToReportDialogComponent>;
   let currencyService: jasmine.SpyObj<CurrencyService>;

--- a/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.spec.ts
+++ b/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.spec.ts
@@ -15,8 +15,9 @@ import { ReportState } from 'src/app/shared/pipes/report-state.pipe';
 import { SnakeCaseToSpaceCase } from 'src/app/shared/pipes/snake-case-to-space-case.pipe';
 import { AddTxnToReportDialogComponent } from './add-txn-to-report-dialog.component';
 import { expectedReportsSinglePage } from 'src/app/core/mock-data/platform-report.data';
+import { ExactCurrencyPipe } from 'src/app/shared/pipes/exact-currency.pipe';
 
-describe('AddTxnToReportDialogComponent', () => {
+fdescribe('AddTxnToReportDialogComponent', () => {
   let component: AddTxnToReportDialogComponent;
   let fixture: ComponentFixture<AddTxnToReportDialogComponent>;
   let currencyService: jasmine.SpyObj<CurrencyService>;
@@ -32,6 +33,7 @@ describe('AddTxnToReportDialogComponent', () => {
         AddTxnToReportDialogComponent,
         FyZeroStateComponent,
         HumanizeCurrencyPipe,
+        ExactCurrencyPipe,
         ReportState,
         SnakeCaseToSpaceCase,
       ],

--- a/src/app/fyle/my-expenses/my-expenses.page.scss
+++ b/src/app/fyle/my-expenses/my-expenses.page.scss
@@ -294,8 +294,9 @@
   &--footer-conatiner {
     display: flex;
     justify-content: space-around;
-    padding: 14px 36px;
+    padding: 16px;
     position: fixed;
+    gap: 16px;
     bottom: 0;
     width: 100%;
     background-color: $pure-white;
@@ -312,10 +313,13 @@
     height: auto;
     background-color: transparent;
     color: $black;
-    font-size: 16px;
+    font-size: 14px;
     line-height: 1.25;
+    border: 1px solid $grey;
+    border-radius: 4px;
+
     &__disabled {
-      opacity: 0.2;
+      opacity: 0.6;
     }
   }
 
@@ -326,7 +330,6 @@
     font-size: 14px;
     line-height: 1.3;
     border-radius: 4px;
-    width: 100%;
 
     &__disabled {
       opacity: 0.8;

--- a/src/global.scss
+++ b/src/global.scss
@@ -87,7 +87,7 @@ ion-popover.error-popover {
 }
 
 .mat-bottom-sheet-1 {
-  padding: 24px 16px !important;
+  padding: 16px 12px 12px 12px !important;
   border-radius: 16px 16px 0px 0px !important;
 }
 


### PR DESCRIPTION
## Clickup
[clickup link](https://app.clickup.com/t/86cx5qh88)

## UI Preview
<img width="705" alt="Screenshot 2024-12-10 at 4 58 54 PM" src="https://github.com/user-attachments/assets/dbbc3fc1-98ad-4974-8690-4c857e582353">
<img width="707" alt="Screenshot 2024-12-10 at 4 58 43 PM" src="https://github.com/user-attachments/assets/77cc0c95-b937-427a-ba3c-26d43b49417a">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced visual representation in the add transaction dialog with new icons and layout adjustments.
	- Introduced a new currency formatting option for report amounts.

- **Bug Fixes**
	- Improved styling consistency across various elements in the report list and my expenses sections.

- **Documentation**
	- Updated styles for better visual hierarchy and spacing in footer and button sections.

- **Tests**
	- Added new pipe to the test suite for better currency formatting validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->