### PR TITLE
feat: My Advance list view display exact amount

### DIFF
--- a/src/app/fyle/my-advances/my-advances-card/my-advances-card.component.html
+++ b/src/app/fyle/my-advances/my-advances-card/my-advances-card.component.html
@@ -1,33 +1,47 @@
 <div *ngIf="!showDate" class="advance-card--date">
-  {{ advanceRequest.created_at | date: 'MMM dd, YYYY' }}
+  {{ advanceRequest.created_at | date : 'MMM dd, YYYY' }}
 </div>
 
 <div class="advance-card" (click)="onAdvanceClick()" [ngClass]="{ 'advance-card__with-border': showDate }">
   <div class="advance-card--divider" *ngIf="showDate"></div>
   <div class="advance-card--main-info">
-    <div class="advance-card--purpose-amount-block">
-      <div class="advance-card--purpose">
-        <span>{{ advanceRequest.purpose | ellipsis: 30 }}</span>
+    <div class="advance-card--purpose-amount-date-block">
+      <!-- Icon -->
+      <div class="advance-card--icon-container">
+        <mat-icon class="advance-card--list-icon" svgIcon="list"></mat-icon>
       </div>
-      <div class="advance-card--amount-block">
-        <span class="advance-card--currency">{{ currencySymbol }}</span>
-        <span class="advance-card--amount"
-          >{{ advanceRequest.orig_amount || advanceRequest.amount | humanizeCurrency: advanceRequest.currency:true }}
-        </span>
-      </div>
-    </div>
-  </div>
 
-  <div class="advance-card--secondary-info">
-    <div class="advance-card--secondary-info-block">
-      <div class="advance-card--approval">
-        <div *ngIf="advanceRequest.areq_approved_at">
-          <span>Approved on {{ advanceRequest.areq_approved_at | date: 'MMM dd, YYYY' }}</span>
+      <div class="advance-card--purpose-amount-date-container">
+        <!-- Purpose -->
+        <div class="advance-card--purpose">
+          <span>{{ advanceRequest.purpose | ellipsis : 30 }}</span>
+        </div>
+
+        <!-- Amount -->
+        <div class="advance-card--amount-block">
+          <span class="advance-card--currency">{{ currencySymbol }}</span>
+          <span class="advance-card--amount">
+            {{
+              {
+                value: advanceRequest.orig_amount || advanceRequest.amount || 0,
+                currencyCode: advanceRequest.currency,
+                skipSymbol: true
+              } | exactCurrency
+            }}
+          </span>
+        </div>
+
+        <!-- Approval date -->
+        <div class="advance-card--approval">
+          <div *ngIf="advanceRequest.areq_approved_at">
+            <span>Approved on {{ advanceRequest.areq_approved_at | date : 'MMM dd, YYYY' }}</span>
+          </div>
         </div>
       </div>
-      <div class="state-pill" [class]="'state-' + internalState.state">
-        {{ internalState.name }}
-      </div>
+    </div>
+
+    <div class="state-pill" [class]="'state-' + internalState.state">
+      {{ internalState.name }}
     </div>
   </div>
 </div>

--- a/src/app/fyle/my-advances/my-advances-card/my-advances-card.component.scss
+++ b/src/app/fyle/my-advances/my-advances-card/my-advances-card.component.scss
@@ -8,7 +8,7 @@ $advance_paid_color: darken(#5cb85c, 15%);
 $advance_rejected_color: #d50000;
 
 .advance-card {
-  padding: 16px;
+  padding: 12px 12px 0 12px;
   background-color: $pure-white;
 
   &__with-border {
@@ -21,7 +21,7 @@ $advance_rejected_color: #d50000;
   }
 
   &--date {
-    color: $grey-light;
+    color: $black-light;
     padding: 16px 0 12px 16px;
     background-color: $white;
     font-weight: 500;
@@ -29,33 +29,49 @@ $advance_rejected_color: #d50000;
 
   &--main-info {
     margin-bottom: 6px;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &--list-icon {
+    width: 16px;
+    padding-top: 2px;
   }
 
   &--purpose {
     line-height: 23px;
     color: $black-2;
-    font-size: 18px;
+    font-size: 14px;
     font-weight: 500;
-    max-width: 60%;
+    max-width: 70%;
+    white-space: nowrap;
   }
 
-  &--purpose-amount-block {
+  &--purpose-amount-date-block {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: 8px;
+    width: 70%;
+  }
+
+  &--purpose-amount-date-container {
+    width: 100%;
+  }
+
+  &--amount-block {
+    margin-top: 10px;
   }
 
   &--currency {
     color: $black-light;
     font-weight: 500;
     font-size: 16px;
-    line-height: 1.25;
   }
 
   &--amount {
     color: $black;
-    font-size: 20px;
-    line-height: 1.3;
-    margin-right: 6px;
+    font-size: 16px;
     font-weight: 500;
   }
 

--- a/src/app/fyle/my-advances/my-advances-card/my-advances-card.component.spec.ts
+++ b/src/app/fyle/my-advances/my-advances-card/my-advances-card.component.spec.ts
@@ -6,6 +6,7 @@ import { AdvanceRequestService } from 'src/app/core/services/advance-request.ser
 import { EllipsisPipe } from 'src/app/shared/pipes/ellipses.pipe';
 import { FyCurrencyPipe } from 'src/app/shared/pipes/fy-currency.pipe';
 import { HumanizeCurrencyPipe } from 'src/app/shared/pipes/humanize-currency.pipe';
+import { ExactCurrencyPipe } from 'src/app/shared/pipes/exact-currency.pipe';
 import { MyAdvancesCardComponent } from './my-advances-card.component';
 import * as dayjs from 'dayjs';
 import { click, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
@@ -19,7 +20,7 @@ describe('MyAdvancesCardComponent', () => {
   beforeEach(waitForAsync(() => {
     const advanceRequestServiceSpy = jasmine.createSpyObj('AdvanceRequestService', ['getInternalStateAndDisplayName']);
     TestBed.configureTestingModule({
-      declarations: [MyAdvancesCardComponent, EllipsisPipe, HumanizeCurrencyPipe, DatePipe],
+      declarations: [MyAdvancesCardComponent, EllipsisPipe, HumanizeCurrencyPipe, ExactCurrencyPipe, DatePipe],
       imports: [IonicModule.forRoot()],
       providers: [
         FyCurrencyPipe,

--- a/src/app/fyle/my-advances/my-advances.page.html
+++ b/src/app/fyle/my-advances/my-advances.page.html
@@ -36,7 +36,7 @@
     </div>
   </ng-container>
 
-  <app-fy-loading-screen *ngIf="isLoading"></app-fy-loading-screen>
+  <app-fy-loading-screen *ngIf="isLoading" [isNewLoaderEnabled]="true"></app-fy-loading-screen>
   <div class="my-advances--body" [ngClass]="{'my-advances--zero-state-body': (advances$|async)?.length === 0 }">
     <ion-refresher slot="fixed" (ionRefresh)="doRefresh($event)">
       <ion-refresher-content></ion-refresher-content>


### PR DESCRIPTION
## Clickup
[clickup link](https://app.clickup.com/t/86cxaxf1b)

## UI Preview
<img width="790" alt="Screenshot 2024-12-13 at 6 04 55 PM" src="https://github.com/user-attachments/assets/7ae9234d-8679-47d8-b0b6-8d3b41b1b374" />
<img width="790" alt="Screenshot 2024-12-13 at 6 05 00 PM" src="https://github.com/user-attachments/assets/c7a91bbb-ef0c-435c-86ab-0e816d44b60e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced layout for the advance card component, consolidating purpose, amount, and approval date into a unified block.
	- Introduced a new loading screen feature in the my advances page.

- **Bug Fixes**
	- Adjusted date formatting for improved clarity.

- **Style**
	- Updated styles for the advance card, including padding, colors, and font sizes for a more compact layout.

- **Tests**
	- Added `ExactCurrencyPipe` to the test suite for the advance card component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->