### PR TITLE
fix: Add condition to hide validation error for unmatching passwords when required condition is present

### DIFF
--- a/src/app/auth/new-password/new-password.page.html
+++ b/src/app/auth/new-password/new-password.page.html
@@ -85,7 +85,7 @@
                 Password cannot be empty
               </div>
               <div
-                *ngIf="fg.controls.confirmPassword.touched && fg.controls.confirmPassword.invalid && fg.controls.confirmPassword.errors.passwordMismatch"
+                *ngIf="fg.controls.confirmPassword.touched && fg.controls.confirmPassword.invalid && fg.controls.confirmPassword.errors.passwordMismatch && !fg.controls.confirmPassword.errors.required"
                 class="new-password__error"
               >
                 Passwords do not match


### PR DESCRIPTION
<!--app.clickup.com-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved password confirmation error message display logic to provide more precise validation feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->