### PR TITLE
fix: reduce icon size in both side

### DIFF
--- a/src/app/shared/components/footer/footer.component.scss
+++ b/src/app/shared/components/footer/footer.component.scss
@@ -41,8 +41,8 @@
   }
 
   &--icon {
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
     fill: $black-2;
     &__primary {
       fill: $pure-white;


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cxj6byk

## Code Coverage
Please add code coverage here

## UI Preview
<img width="483" alt="Screenshot 2025-01-10 at 2 20 34 AM" src="https://github.com/user-attachments/assets/2ee2552d-2843-4eec-a645-8f5ebd4a9c57" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Reduced footer icon size from 24px to 20px
  - Updated opacity for disabled footer buttons to 0.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->