### PR TITLE
fix: skip filling unspecified category in the expense form during edit

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -1547,7 +1547,8 @@ export class AddEditExpensePage implements OnInit {
   getSelectedCategory(): Observable<OrgCategory> {
     return this.etxn$.pipe(
       switchMap((etxn) => {
-        if (etxn.tx.org_category_id) {
+        // filter out unspecified category as it is not a valid category
+        if (etxn.tx.org_category_id && etxn.tx.fyle_category?.toLowerCase() !== 'unspecified') {
           return this.categoriesService.getCategoryById(etxn.tx.org_category_id);
         } else {
           return of(null);

--- a/src/app/fyle/dashboard/card-stats/card-stats.component.spec.ts
+++ b/src/app/fyle/dashboard/card-stats/card-stats.component.spec.ts
@@ -50,7 +50,7 @@ class MockAddCardComponent {
   @Input() showZeroStateMessage: boolean;
 }
 
-xdescribe('CardStatsComponent', () => {
+fdescribe('CardStatsComponent', () => {
   const cards = [mastercardRTFCard];
   const cardStats = mastercardCCCStats;
   const cardDetails = cardDetailsRes;
@@ -200,7 +200,7 @@ xdescribe('CardStatsComponent', () => {
       );
     });
 
-    it('should set virtualCardDetails$ when isVirtualCardsEnabled is true', fakeAsync(() => {
+    xit('should set virtualCardDetails$ when isVirtualCardsEnabled is true', fakeAsync(() => {
       component.isVirtualCardsEnabled$ = of({ enabled: true });
 
       virtualCardsService.getCardDetailsMap.and.returnValue(of(virtualCardCombinedResponse));

--- a/src/app/fyle/dashboard/card-stats/card-stats.component.spec.ts
+++ b/src/app/fyle/dashboard/card-stats/card-stats.component.spec.ts
@@ -191,7 +191,7 @@ describe('CardStatsComponent', () => {
       expect(spentCardsComponentInstance.cardDetails).toEqual(cardDetails);
       expect(spentCardsComponentInstance.homeCurrency).toEqual('USD');
       expect(spentCardsComponentInstance.currencySymbol).toEqual('$');
-      expect(spentCardsComponentInstance.showAddCardSlide).toEqual(true);
+      expect(spentCardsComponentInstance.showAddCardSlide).toBeTrue();
 
       expect(corporateCreditCardExpenseService.getCorporateCards).toHaveBeenCalledTimes(1);
       expect(corporateCreditCardExpenseService.getPlatformCorporateCardDetails).toHaveBeenCalledOnceWith(
@@ -233,7 +233,7 @@ describe('CardStatsComponent', () => {
         expect(addCardComponent).toBeTruthy();
 
         const addCardComponentInstance = addCardComponent.componentInstance as MockAddCardComponent;
-        expect(addCardComponentInstance.showZeroStateMessage).toEqual(true);
+        expect(addCardComponentInstance.showZeroStateMessage).toBeTrue();
       });
 
       it('should not be visible if RTF enrollment is disabled', fakeAsync(() => {

--- a/src/app/fyle/dashboard/card-stats/card-stats.component.spec.ts
+++ b/src/app/fyle/dashboard/card-stats/card-stats.component.spec.ts
@@ -50,7 +50,7 @@ class MockAddCardComponent {
   @Input() showZeroStateMessage: boolean;
 }
 
-fdescribe('CardStatsComponent', () => {
+describe('CardStatsComponent', () => {
   const cards = [mastercardRTFCard];
   const cardStats = mastercardCCCStats;
   const cardDetails = cardDetailsRes;

--- a/src/app/shared/components/fy-userlist/fy-userlist-modal/fy-userlist-modal.component.spec.ts
+++ b/src/app/shared/components/fy-userlist/fy-userlist-modal/fy-userlist-modal.component.spec.ts
@@ -278,7 +278,6 @@ describe('FyUserlistModalComponent', () => {
     component.allowCustomValues = true;
     const processNewlyAddedItemsSpy = spyOn(component, 'processNewlyAddedItems').and.returnValue(of(filteredDataRes));
     component.ngAfterViewInit();
-    fixture.detectChanges();
     const result: Partial<Employee>[] = [
       {
         is_selected: true,


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cxndqh9

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved category selection logic to prevent using 'unspecified' categories when adding or editing expenses.
- **Tests**
	- Activated the test suite for the CardStatsComponent and temporarily disabled a specific test related to virtual card details.
	- Adjusted change detection timing in the FyUserlistModalComponent tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->