### PR TITLE
fix: view expense page broken design

### DIFF
--- a/src/app/fyle/view-expense/view-expense.page.html
+++ b/src/app/fyle/view-expense/view-expense.page.html
@@ -91,14 +91,6 @@
               {{ expense.foreign_amount | humanizeCurrency: expense.foreign_currency }} at {{ expense.amount /
               expense.foreign_amount | currency: expense.currency: 'symbol-narrow' }}
             </div>
-
-            <div *ngIf="isProjectShown" class="view-expense--card-container__project">
-              {{ projectFieldName | titlecase }}: {{ expense.project?.name || '-' }}
-            </div>
-            <div *ngIf="isCCCTransaction && cardNumber">
-              Card ending in... {{ cardNumber | maskNumber }}
-              <span *ngIf="cardNickname">{{'(' + cardNickname + ')'}}</span>
-            </div>
           </div>
 
           <div class="ion-text-right view-expense--card-container__block">

--- a/src/app/fyle/view-expense/view-expense.page.scss
+++ b/src/app/fyle/view-expense/view-expense.page.scss
@@ -88,8 +88,7 @@
     &__amount-section {
       display: flex;
       justify-content: flex-start;
-      width: 90%;
-      padding-top: 10px;
+      width: 100%;
       align-items: center;
     }
 
@@ -99,7 +98,7 @@
     }
 
     &__merchant {
-      font-size: 12px;
+      font-size: 14px;
       color: $dark-grey;
     }
 
@@ -120,7 +119,7 @@
     }
 
     &__amount {
-      font-size: 16px;
+      font-size: 14px;
       font-weight: 500;
       color: $black;
       margin-right: 4px;


### PR DESCRIPTION
## Clickup
[link](https://app.clickup.com/)

## UI Preview
<img width="832" alt="Screenshot 2025-02-18 at 4 24 12 PM" src="https://github.com/user-attachments/assets/3d3b16e9-b7c1-48c7-a5f3-8f8a79489b76" />

<img width="832" alt="Screenshot 2025-02-18 at 4 24 53 PM" src="https://github.com/user-attachments/assets/5a77bf26-a990-450d-9f0a-0a6c8260eb95" />

<img width="832" alt="Screenshot 2025-02-18 at 4 25 08 PM" src="https://github.com/user-attachments/assets/f7a85269-a265-4377-90b4-9d9c578d7eda" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the expense view by removing the display of project and card details.
- **Style**
	- Enhanced layout responsiveness and readability with updated section widths and adjusted typography for key expense details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->