### PR TITLE
feat: add category-costcenter mapping in split expense

### DIFF
--- a/src/app/fyle/split-expense/split-expense.page.html
+++ b/src/app/fyle/split-expense/split-expense.page.html
@@ -164,6 +164,7 @@
                 [touchedInParent]="splitExpenseForm.controls.category.touched"
                 [validInParent]="splitExpenseForm.controls.category.valid"
                 [disabled]="categories.length === 0"
+                (valueChange)="splitConfig.costCenter.is_visible ? onCategoryChange(i) : null"
               >
               </app-fy-select>
             </div>
@@ -187,6 +188,7 @@
                 [cacheName]="'splitExpenseCostCenterCache'"
                 [touchedInParent]="splitExpenseForm.controls.cost_center.touched"
                 [validInParent]="splitExpenseForm.controls.cost_center.valid"
+                [disabled]="costCenterDisabledStates[i]"
               >
               </app-fy-select>
             </div>

--- a/src/app/fyle/split-expense/split-expense.page.html
+++ b/src/app/fyle/split-expense/split-expense.page.html
@@ -164,7 +164,7 @@
                 [touchedInParent]="splitExpenseForm.controls.category.touched"
                 [validInParent]="splitExpenseForm.controls.category.valid"
                 [disabled]="categories.length === 0"
-                (valueChange)="splitConfig.costCenter.is_visible ? onCategoryChange(i) : null"
+                (valueChange)="onCategoryChange(i)"
               >
               </app-fy-select>
             </div>

--- a/src/app/fyle/split-expense/split-expense.page.html
+++ b/src/app/fyle/split-expense/split-expense.page.html
@@ -167,6 +167,11 @@
                 (valueChange)="onCategoryChange(i)"
               >
               </app-fy-select>
+              <div
+                *ngIf="categories.length === 0"
+                (click)="showDisabledMessage('category')"
+                class="split-expense--internal-block-overlay"
+              ></div>
             </div>
             <div
               *ngIf="splitExpenseForm.controls.category.touched && !splitExpenseForm.controls.category.valid"
@@ -191,6 +196,11 @@
                 [disabled]="costCenterDisabledStates[i]"
               >
               </app-fy-select>
+              <div
+                *ngIf="costCenterDisabledStates[i]"
+                (click)="showDisabledMessage('cost center')"
+                class="split-expense--internal-block-overlay"
+              ></div>
             </div>
             <div
               *ngIf="splitExpenseForm.controls.cost_center.touched && !splitExpenseForm.controls.cost_center.valid"

--- a/src/app/fyle/split-expense/split-expense.page.scss
+++ b/src/app/fyle/split-expense/split-expense.page.scss
@@ -64,6 +64,7 @@ $background-color: #fff;
     border: 0;
     line-height: 1;
     height: 80px;
+    position: relative;
 
     &:only-child {
       width: 100%;
@@ -74,6 +75,14 @@ $background-color: #fff;
       width: 48%;
       flex-grow: 0;
     }
+  }
+
+  &--internal-block-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
   }
 
   &--error {

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -2,7 +2,7 @@ import { CostCentersService } from 'src/app/core/services/cost-centers.service';
 import { Component, OnDestroy } from '@angular/core';
 import { AbstractControl, FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ModalController, NavController } from '@ionic/angular';
+import { ModalController, NavController, PopoverController } from '@ionic/angular';
 import { isEmpty, isNumber } from 'lodash';
 import * as dayjs from 'dayjs';
 import { combineLatest, forkJoin, from, iif, Observable, of, Subject, throwError } from 'rxjs';
@@ -51,6 +51,7 @@ import { Expense as PlatformExpense } from 'src/app/core/models/platform/v1/expe
 import { PlatformFile } from 'src/app/core/models/platform/platform-file.model';
 import { SplitConfig } from 'src/app/core/models/split-config.model';
 import { ReviewSplitExpenseComponent } from 'src/app/shared/components/review-split-expense/review-split-expense.component';
+import { FyMsgPopoverComponent } from 'src/app/shared/components/fy-msg-popover/fy-msg-popover.component';
 
 @Component({
   selector: 'app-split-expense',
@@ -145,6 +146,7 @@ export class SplitExpensePage implements OnDestroy {
     private trackingService: TrackingService,
     private policyService: PolicyService,
     private modalController: ModalController,
+    private popoverController: PopoverController,
     private modalProperties: ModalPropertiesService,
     private costCentersService: CostCentersService,
     private orgUserSettingsService: OrgUserSettingsService,
@@ -1261,6 +1263,28 @@ export class SplitExpensePage implements OnDestroy {
 
     // Recalculate the total split amount and remaining amount
     this.getTotalSplitAmount();
+  }
+
+  showDisabledMessage(type: string): void {
+    let msg = '';
+    if (type === 'category') {
+      msg = 'No category is available for the selected project.';
+    } else {
+      msg = 'No cost center is available for the selected category.';
+    }
+    this.showPopoverModal(msg);
+  }
+
+  async showPopoverModal(msg: string): Promise<void> {
+    const Popover = await this.popoverController.create({
+      component: FyMsgPopoverComponent,
+      componentProps: {
+        msg,
+      },
+      cssClass: 'fy-dialog-popover',
+    });
+
+    await Popover.present();
   }
 
   handleNavigationAfterReview(action: string, expense?: PlatformExpense): void {

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -1114,6 +1114,9 @@ export class SplitExpensePage implements OnDestroy {
   }
 
   onCategoryChange(index: number): void {
+    if (!this.splitConfig.costCenter.is_visible) {
+      return;
+    }
     const splitForm = this.splitExpensesFormArray.at(index);
     const categoryControl = splitForm.get('category').value as OrgCategory;
 
@@ -1123,6 +1126,10 @@ export class SplitExpensePage implements OnDestroy {
 
     const isCostCenterAllowed = this.txnFields.cost_center_id?.org_category_ids?.includes(categoryControl.id);
     this.costCenterDisabledStates[index] = !isCostCenterAllowed;
+
+    if (!isCostCenterAllowed) {
+      splitForm.get('cost_center').reset();
+    }
   }
 
   // eslint-disable-next-line complexity

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -1185,7 +1185,12 @@ export class SplitExpensePage implements OnDestroy {
     }
 
     this.splitExpensesFormArray.push(fg);
+    this.handleInitialconfig(isFirstSplit);
 
+    this.getTotalSplitAmount();
+  }
+
+  handleInitialconfig(isFirstSplit: boolean): void {
     if (isFirstSplit && this.splitConfig.category.is_visible) {
       const firstSplitCategory = this.splitExpensesFormArray.at(0)?.get('category')?.value as OrgCategory | null;
       if (!firstSplitCategory) {
@@ -1209,7 +1214,6 @@ export class SplitExpensePage implements OnDestroy {
         this.costCenterDisabledStates.push(false);
       }
     }
-    this.getTotalSplitAmount();
   }
 
   remove(index: number): void {

--- a/src/app/shared/components/fy-msg-popover/fy-msg-popover.component.html
+++ b/src/app/shared/components/fy-msg-popover/fy-msg-popover.component.html
@@ -1,0 +1,14 @@
+<ion-content>
+  <div class="fy-popover--content-wrapper">
+    <div class="fy-popover--icon-container">
+      <ion-buttons slot="start">
+        <ion-button (click)="dismiss()">
+          <mat-icon class="fy-icon-close" svgIcon="cross"></mat-icon>
+        </ion-button>
+      </ion-buttons>
+    </div>
+    <div class="fy-popover--msg-container">
+      <div class="fy-popover--message-text">{{ msg }}</div>
+    </div>
+  </div>
+</ion-content>

--- a/src/app/shared/components/fy-msg-popover/fy-msg-popover.component.scss
+++ b/src/app/shared/components/fy-msg-popover/fy-msg-popover.component.scss
@@ -1,0 +1,16 @@
+.fy-popover {
+  &--content-wrapper {
+    padding: 32px 16px;
+  }
+  &--msg-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  &--message-text {
+    font-size: 12px;
+    line-height: 18px;
+    width: 50%;
+    text-align: center;
+  }
+}

--- a/src/app/shared/components/fy-msg-popover/fy-msg-popover.component.spec.ts
+++ b/src/app/shared/components/fy-msg-popover/fy-msg-popover.component.spec.ts
@@ -1,0 +1,40 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule, PopoverController } from '@ionic/angular';
+import { FyMsgPopoverComponent } from './fy-msg-popover.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
+describe('FyMsgPopoverComponent', () => {
+  let component: FyMsgPopoverComponent;
+  let fixture: ComponentFixture<FyMsgPopoverComponent>;
+  let popoverControllerSpy: jasmine.SpyObj<PopoverController>;
+
+  beforeEach(waitForAsync(() => {
+    popoverControllerSpy = jasmine.createSpyObj('PopoverController', ['dismiss']);
+
+    TestBed.configureTestingModule({
+      declarations: [FyMsgPopoverComponent],
+      imports: [IonicModule.forRoot()],
+      providers: [{ provide: PopoverController, useValue: popoverControllerSpy }],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FyMsgPopoverComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set message input', () => {
+    component.msg = 'No category is available for the selected project.';
+    fixture.detectChanges();
+    expect(component.msg).toBe('No category is available for the selected project.');
+  });
+
+  it('should call popoverController.dismiss() when dismiss() is called', () => {
+    component.dismiss();
+    expect(popoverControllerSpy.dismiss).toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/components/fy-msg-popover/fy-msg-popover.component.ts
+++ b/src/app/shared/components/fy-msg-popover/fy-msg-popover.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+import { PopoverController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-fy-msg-popover',
+  templateUrl: './fy-msg-popover.component.html',
+  styleUrls: ['./fy-msg-popover.component.scss'],
+})
+export class FyMsgPopoverComponent {
+  @Input() msg = '';
+
+  constructor(private popoverController: PopoverController) {}
+
+  dismiss(): void {
+    this.popoverController.dismiss();
+  }
+}

--- a/src/app/shared/components/fy-select/fy-select.component.ts
+++ b/src/app/shared/components/fy-select/fy-select.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, Input, TemplateRef } from '@angular/core';
+import { Component, EventEmitter, forwardRef, Input, Output, TemplateRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { noop } from 'rxjs';
 import { ModalController } from '@ionic/angular';
@@ -56,6 +56,8 @@ export class FySelectComponent implements ControlValueAccessor {
 
   @Input() isCustomSelect?: boolean;
 
+  @Output() valueChange = new EventEmitter<string | Value>();
+
   displayValue: string | number | boolean;
 
   innerValue: string | Value;
@@ -95,6 +97,7 @@ export class FySelectComponent implements ControlValueAccessor {
       }
 
       this.onChangeCallback(v);
+      this.valueChange.emit(v);
     }
   }
 

--- a/src/app/shared/components/fy-select/fy-select.component.ts
+++ b/src/app/shared/components/fy-select/fy-select.component.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { Component, EventEmitter, forwardRef, Input, Output, TemplateRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { noop } from 'rxjs';
@@ -101,7 +103,7 @@ export class FySelectComponent implements ControlValueAccessor {
     }
   }
 
-  async openModal() {
+  async openModal(): Promise<void> {
     let cssClass: string;
 
     if (this.label === 'Payment mode') {
@@ -167,11 +169,11 @@ export class FySelectComponent implements ControlValueAccessor {
     }
   }
 
-  registerOnChange(fn: any) {
+  registerOnChange(fn: any): void {
     this.onChangeCallback = fn;
   }
 
-  registerOnTouched(fn: any) {
+  registerOnTouched(fn: any): void {
     this.onTouchedCallback = fn;
   }
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -155,6 +155,7 @@ import { MobileNumberCardComponent } from './components/mobile-number-card/mobil
 import { PasswordCheckTooltipComponent } from './components/password-check-tooltip/password-check-tooltip.component';
 import { ExactCurrencyPipe } from './pipes/exact-currency.pipe';
 import { CCExpenseMerchantInfoModalComponent } from './components/cc-expense-merchant-info-modal/cc-expense-merchant-info-modal.component';
+import { FyMsgPopoverComponent } from './components/fy-msg-popover/fy-msg-popover.component';
 
 @NgModule({
   declarations: [
@@ -229,6 +230,7 @@ import { CCExpenseMerchantInfoModalComponent } from './components/cc-expense-mer
     PersonalCardTransactionComponent,
     FyInputPopoverComponent,
     FyPopoverComponent,
+    FyMsgPopoverComponent,
     SidemenuComponent,
     SidemenuHeaderComponent,
     SidemenuFooterComponent,
@@ -372,6 +374,7 @@ import { CCExpenseMerchantInfoModalComponent } from './components/cc-expense-mer
     BankAccountCardsComponent,
     PersonalCardTransactionComponent,
     FyPopoverComponent,
+    FyMsgPopoverComponent,
     SidemenuComponent,
     FyNavFooterComponent,
     SendEmailComponent,


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cy1m5aq

## UI Preview
<img width="400" alt="Screenshot 2025-02-19 at 7 56 17 PM" src="https://github.com/user-attachments/assets/77e5882e-9e6f-4891-b73c-0be4c4f54b8e" />
<img width="400" alt="Screenshot 2025-02-19 at 7 56 28 PM" src="https://github.com/user-attachments/assets/1920ca7d-c9ad-4b9c-9a1f-c4f1a4d2a786" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the expense splitting interface with dynamic updates: selecting a category now conditionally updates the associated cost center options.
	- Improved dropdown controls to instantly reflect changes, dynamically enabling or disabling cost center selections for a more responsive form experience.
	- Introduced an event emission feature in the selection component to notify parent components of value changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->