### PR TITLE
fix: navigation logic between review split expense modal and add-edit…

### DIFF
--- a/src/app/core/services/platform/v1/spender/expenses.service.ts
+++ b/src/app/core/services/platform/v1/spender/expenses.service.ts
@@ -27,6 +27,8 @@ import { CommuteDeduction } from 'src/app/core/enums/commute-deduction.enum';
   providedIn: 'root',
 })
 export class ExpensesService {
+  private splitExpensesData = null;
+
   constructor(
     @Inject(PAGINATION_SIZE) private paginationSize: number,
     private spenderService: SpenderService,
@@ -370,5 +372,20 @@ export class ExpensesService {
         },
       ],
     });
+  }
+
+  storeRecentlySplitExpenses(data): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    this.splitExpensesData = data;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/adjacent-overload-signatures, @typescript-eslint/explicit-function-return-type
+  getRecentlySplitExpenses() {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return this.splitExpensesData;
+  }
+
+  clearRecentlySplitExpenses(): void {
+    this.splitExpensesData = null;
   }
 }

--- a/src/app/core/services/platform/v1/spender/expenses.service.ts
+++ b/src/app/core/services/platform/v1/spender/expenses.service.ts
@@ -29,7 +29,6 @@ import { CommuteDeduction } from 'src/app/core/enums/commute-deduction.enum';
 export class ExpensesService {
   splitExpensesData$ = new BehaviorSubject<{
     expenses: Partial<Transaction>[];
-    fromSplitExpenseReview: boolean;
   } | null>(null);
 
   constructor(

--- a/src/app/core/services/platform/v1/spender/expenses.service.ts
+++ b/src/app/core/services/platform/v1/spender/expenses.service.ts
@@ -27,10 +27,6 @@ import { CommuteDeduction } from 'src/app/core/enums/commute-deduction.enum';
   providedIn: 'root',
 })
 export class ExpensesService {
-  private splitExpensesData$ = new BehaviorSubject<{ expenses: Transaction[]; fromSplitExpenseReview: boolean } | null>(
-    null
-  );
-
   constructor(
     @Inject(PAGINATION_SIZE) private paginationSize: number,
     private spenderService: SpenderService,
@@ -374,17 +370,5 @@ export class ExpensesService {
         },
       ],
     });
-  }
-
-  storeRecentlySplitExpenses(data: { expenses: Transaction[]; fromSplitExpenseReview: boolean }): void {
-    this.splitExpensesData$.next(data);
-  }
-
-  getRecentlySplitExpenses(): Observable<{ expenses: Transaction[]; fromSplitExpenseReview: boolean } | null> {
-    return this.splitExpensesData$.asObservable();
-  }
-
-  clearRecentlySplitExpenses(): void {
-    this.splitExpensesData$.next(null);
   }
 }

--- a/src/app/core/services/platform/v1/spender/expenses.service.ts
+++ b/src/app/core/services/platform/v1/spender/expenses.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@angular/core';
-import { BehaviorSubject, Observable, concatMap, map, of, range, reduce, switchMap } from 'rxjs';
+import { Observable, concatMap, map, of, range, reduce, switchMap } from 'rxjs';
 import { SpenderService } from '../spender/spender.service';
 import { PlatformApiResponse } from 'src/app/core/models/platform/platform-api-response.model';
 import { Expense } from 'src/app/core/models/platform/v1/expense.model';

--- a/src/app/core/services/platform/v1/spender/expenses.service.ts
+++ b/src/app/core/services/platform/v1/spender/expenses.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@angular/core';
-import { Observable, concatMap, map, of, range, reduce, switchMap } from 'rxjs';
+import { BehaviorSubject, Observable, concatMap, map, of, range, reduce, switchMap } from 'rxjs';
 import { SpenderService } from '../spender/spender.service';
 import { PlatformApiResponse } from 'src/app/core/models/platform/platform-api-response.model';
 import { Expense } from 'src/app/core/models/platform/v1/expense.model';
@@ -27,7 +27,9 @@ import { CommuteDeduction } from 'src/app/core/enums/commute-deduction.enum';
   providedIn: 'root',
 })
 export class ExpensesService {
-  private splitExpensesData = null;
+  private splitExpensesData$ = new BehaviorSubject<{ expenses: Transaction[]; fromSplitExpenseReview: boolean } | null>(
+    null
+  );
 
   constructor(
     @Inject(PAGINATION_SIZE) private paginationSize: number,
@@ -374,18 +376,15 @@ export class ExpensesService {
     });
   }
 
-  storeRecentlySplitExpenses(data): void {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    this.splitExpensesData = data;
+  storeRecentlySplitExpenses(data: { expenses: Transaction[]; fromSplitExpenseReview: boolean }): void {
+    this.splitExpensesData$.next(data);
   }
 
-  // eslint-disable-next-line @typescript-eslint/adjacent-overload-signatures, @typescript-eslint/explicit-function-return-type
-  getRecentlySplitExpenses() {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return this.splitExpensesData;
+  getRecentlySplitExpenses(): Observable<{ expenses: Transaction[]; fromSplitExpenseReview: boolean } | null> {
+    return this.splitExpensesData$.asObservable();
   }
 
   clearRecentlySplitExpenses(): void {
-    this.splitExpensesData = null;
+    this.splitExpensesData$.next(null);
   }
 }

--- a/src/app/core/services/platform/v1/spender/expenses.service.ts
+++ b/src/app/core/services/platform/v1/spender/expenses.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@angular/core';
-import { Observable, concatMap, map, of, range, reduce, switchMap } from 'rxjs';
+import { BehaviorSubject, Observable, concatMap, map, of, range, reduce, switchMap } from 'rxjs';
 import { SpenderService } from '../spender/spender.service';
 import { PlatformApiResponse } from 'src/app/core/models/platform/platform-api-response.model';
 import { Expense } from 'src/app/core/models/platform/v1/expense.model';
@@ -27,6 +27,11 @@ import { CommuteDeduction } from 'src/app/core/enums/commute-deduction.enum';
   providedIn: 'root',
 })
 export class ExpensesService {
+  splitExpensesData$ = new BehaviorSubject<{
+    expenses: Partial<Transaction>[];
+    fromSplitExpenseReview: boolean;
+  } | null>(null);
+
   constructor(
     @Inject(PAGINATION_SIZE) private paginationSize: number,
     private spenderService: SpenderService,

--- a/src/app/fyle/add-edit-expense/add-edit-expense-1.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-1.spec.ts
@@ -6,7 +6,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ActionSheetController, ModalController, NavController, Platform, PopoverController } from '@ionic/angular';
-import { Subscription, of } from 'rxjs';
+import { BehaviorSubject, Subscription, of } from 'rxjs';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
 import { actionSheetOptionsData } from 'src/app/core/mock-data/action-sheet-options.data';
 import { expectedECccResponse } from 'src/app/core/mock-data/corporate-card-expense-unflattened.data';
@@ -78,6 +78,8 @@ import { expectedProjects4 } from 'src/app/core/mock-data/extended-projects.data
 import { reportData1 } from 'src/app/core/mock-data/report.data';
 import { sortedCategory } from 'src/app/core/mock-data/org-category.data';
 import { CostCentersService } from 'src/app/core/services/cost-centers.service';
+import { ExpensesService } from 'src/app/core/services/platform/v1/spender/expenses.service';
+import { Transaction } from 'src/app/core/models/v1/transaction.model';
 
 export function TestCases1(getTestBed) {
   return describe('AddEditExpensePage-1', () => {
@@ -128,6 +130,8 @@ export function TestCases1(getTestBed) {
     let storageService: jasmine.SpyObj<StorageService>;
     let launchDarklyService: jasmine.SpyObj<LaunchDarklyService>;
     let advanceWalletsService: jasmine.SpyObj<AdvanceWalletsService>;
+    let expensesService: jasmine.SpyObj<ExpensesService>;
+    let splitExpensesData$: BehaviorSubject<{ expenses: Transaction[]; fromSplitExpenseReview: boolean } | null>;
 
     beforeEach(() => {
       const TestBed = getTestBed();
@@ -184,6 +188,7 @@ export function TestCases1(getTestBed) {
       orgUserSettingsService = TestBed.inject(OrgUserSettingsService) as jasmine.SpyObj<OrgUserSettingsService>;
       storageService = TestBed.inject(StorageService) as jasmine.SpyObj<StorageService>;
       launchDarklyService = TestBed.inject(LaunchDarklyService) as jasmine.SpyObj<LaunchDarklyService>;
+      expensesService = TestBed.inject(ExpensesService) as jasmine.SpyObj<ExpensesService>;
 
       component.fg = formBuilder.group({
         currencyObj: [, component.currencyObjValidator],
@@ -251,23 +256,56 @@ export function TestCases1(getTestBed) {
     });
 
     describe('goBack():', () => {
-      it('should go back to the report if redirected from the report page', () => {
-        component.isRedirectedFromReport = true;
-        fixture.detectChanges();
+      beforeEach(() => {
+        splitExpensesData$ = new BehaviorSubject<{ expenses: Transaction[]; fromSplitExpenseReview: boolean } | null>(
+          null
+        );
+        expensesService.getRecentlySplitExpenses.and.callFake(() => splitExpensesData$.asObservable());
+        expensesService.clearRecentlySplitExpenses.and.callFake(() => splitExpensesData$.next(null));
+      });
 
-        navController.back.and.returnValue(null);
+      it('should go back if redirected from split expense review and has stored data', () => {
+        activatedRoute.snapshot.params.fromSplitExpenseReview = true;
+        const mockData = { expenses: [], fromSplitExpenseReview: true };
+        splitExpensesData$.next(mockData);
+        component.goBack();
+        expect(navController.back).toHaveBeenCalledTimes(1);
+        expect(expensesService.clearRecentlySplitExpenses).not.toHaveBeenCalled();
+      });
 
+      it('should clear recently split expenses and navigate to my_expenses if redirected from split expense review without stored data', () => {
+        activatedRoute.snapshot.params.fromSplitExpenseReview = true;
+        component.goBack();
+        expect(expensesService.clearRecentlySplitExpenses).toHaveBeenCalled();
+        expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'my_expenses']);
+      });
+
+      it('should go back if persist_filters is true', () => {
+        activatedRoute.snapshot.params.persist_filters = true;
         component.goBack();
         expect(navController.back).toHaveBeenCalledTimes(1);
       });
 
-      it('should go back to my expenses page if it is not redirected from report and no filters are applied', () => {
-        activatedRoute.snapshot.params.persist_filters = false;
-        component.isRedirectedFromReport = false;
-        fixture.detectChanges();
-
+      it('should go back if redirected from report', () => {
+        component.isRedirectedFromReport = true;
         component.goBack();
-        expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_expenses']);
+        expect(navController.back).toHaveBeenCalledTimes(1);
+      });
+
+      it('should navigate to my_expenses with query param if mode is add', () => {
+        component.mode = 'add';
+        activatedRoute.snapshot.params = {};
+        component.goBack();
+        expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'my_expenses'], {
+          queryParams: { redirected_from_add_expense: true },
+        });
+      });
+
+      it('should navigate to my_expenses if no other conditions are met', () => {
+        component.isRedirectedFromReport = false;
+        activatedRoute.snapshot.params = {};
+        component.goBack();
+        expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'my_expenses']);
       });
     });
 
@@ -706,7 +744,7 @@ export function TestCases1(getTestBed) {
           'enterprise',
           'split_expense',
           {
-            splitConfig,
+            splitConfig: JSON.stringify(splitConfig),
             txnFields: JSON.stringify(txnFieldsMap2),
             txn: JSON.stringify(unflattenedExpData.tx),
             currencyObj: JSON.stringify(component.fg.controls.currencyObj.value),
@@ -752,7 +790,7 @@ export function TestCases1(getTestBed) {
           'enterprise',
           'split_expense',
           {
-            splitConfig,
+            splitConfig: JSON.stringify(splitConfig),
             txnFields: JSON.stringify(txnFieldsMap2),
             txn: JSON.stringify(unflattenedExpData.tx),
             currencyObj: JSON.stringify(component.fg.controls.currencyObj.value),

--- a/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
@@ -5,7 +5,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ActionSheetController, ModalController, NavController, Platform, PopoverController } from '@ionic/angular';
-import { Observable, Subscription, finalize, of, throwError } from 'rxjs';
+import { BehaviorSubject, Observable, Subscription, finalize, of, throwError } from 'rxjs';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
 import { criticalPolicyViolation2 } from 'src/app/core/mock-data/crtical-policy-violations.data';
 import { duplicateSetData1, duplicateSetData6 } from 'src/app/core/mock-data/duplicate-sets.data';
@@ -111,6 +111,7 @@ import {
 import { apiExpenses1, apiExpenses2, splitExpensesData } from 'src/app/core/mock-data/platform/v1/expense.data';
 import { SpenderReportsService } from 'src/app/core/services/platform/v1/spender/reports.service';
 import { AdvanceWalletsService } from 'src/app/core/services/platform/v1/spender/advance-wallets.service';
+import { Transaction } from 'src/app/core/models/v1/transaction.model';
 
 const properties = {
   cssClass: 'fy-modal',
@@ -173,6 +174,7 @@ export function TestCases2(getTestBed) {
     let expensesService: jasmine.SpyObj<ExpensesService>;
     let reportsService: jasmine.SpyObj<SpenderReportsService>;
     let advanceWalletsService: jasmine.SpyObj<AdvanceWalletsService>;
+    let splitExpensesData$: BehaviorSubject<{ expenses: Transaction[]; fromSplitExpenseReview: boolean } | null>;
 
     beforeEach(() => {
       const TestBed = getTestBed();
@@ -1203,10 +1205,49 @@ export function TestCases2(getTestBed) {
       expect(result).toBeCloseTo((new Date().getTime() - component.expenseStartTime) / 1000, 2);
     });
 
-    it('closeAddEditExpenses(): should close the form and navigate back to my_expenses page', () => {
-      component.closeAddEditExpenses();
+    describe('closeAddEditExpense()', () => {
+      beforeEach(() => {
+        splitExpensesData$ = new BehaviorSubject<{ expenses: Transaction[]; fromSplitExpenseReview: boolean } | null>(
+          null
+        );
+        expensesService.getRecentlySplitExpenses.and.callFake(() => splitExpensesData$.asObservable());
+        expensesService.clearRecentlySplitExpenses.and.callFake(() => splitExpensesData$.next(null));
+      });
 
-      expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_expenses']);
+      it('closeAddEditExpenses(): should navigate back if fromSplitExpenseReview is true', () => {
+        activatedRoute.snapshot.params = { fromSplitExpenseReview: true };
+        const mockData = { expenses: [], fromSplitExpenseReview: true };
+        splitExpensesData$.next(mockData);
+        component.closeAddEditExpenses();
+        expect(navController.back).toHaveBeenCalled();
+        expect(router.navigate).not.toHaveBeenCalled();
+      });
+
+      it('closeAddEditExpenses(): should clear expenses and navigate if fromSplitExpenseReview is false', () => {
+        activatedRoute.snapshot.params = { fromSplitExpenseReview: false };
+        splitExpensesData$.next(null);
+        component.closeAddEditExpenses();
+        expect(expensesService.clearRecentlySplitExpenses).toHaveBeenCalled();
+        expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'my_expenses']);
+      });
+
+      it('closeAddEditExpenses(): should clear expenses and navigate if getRecentlySplitExpenses returns null', () => {
+        activatedRoute.snapshot.params = { fromSplitExpenseReview: false };
+        const mockData = { expenses: [], fromSplitExpenseReview: true };
+        splitExpensesData$.next(mockData);
+        component.closeAddEditExpenses();
+        expect(expensesService.clearRecentlySplitExpenses).toHaveBeenCalled();
+        expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'my_expenses']);
+      });
+
+      it('closeAddEditExpenses(): should clear expenses and navigate if fromSplitExpenseReview is not present', () => {
+        activatedRoute.snapshot.params = {};
+        const mockData = { expenses: [], fromSplitExpenseReview: true };
+        splitExpensesData$.next(mockData);
+        component.closeAddEditExpenses();
+        expect(expensesService.clearRecentlySplitExpenses).toHaveBeenCalled();
+        expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'my_expenses']);
+      });
     });
 
     describe('getParsedReceipt():', () => {

--- a/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
@@ -968,7 +968,7 @@ export function TestCases2(getTestBed) {
       it('should add a new expense and close the form', () => {
         spyOn(component, 'addExpense').and.returnValue(of(Promise.resolve(outboxQueueData1[0])));
         spyOn(component, 'checkIfReceiptIsMissingAndMandatory').and.returnValue(of(false));
-        spyOn(component, 'closeAddEditExpenses');
+        spyOn(component, 'goBack');
         component.activeIndex = 0;
         component.mode = 'add';
         Object.defineProperty(component.fg, 'valid', {
@@ -979,7 +979,7 @@ export function TestCases2(getTestBed) {
         component.saveExpenseAndGotoPrev();
         expect(component.addExpense).toHaveBeenCalledOnceWith('SAVE_AND_PREV_EXPENSE');
         expect(component.checkIfReceiptIsMissingAndMandatory).toHaveBeenCalledWith('SAVE_AND_PREV_EXPENSE');
-        expect(component.closeAddEditExpenses).toHaveBeenCalledOnceWith();
+        expect(component.goBack).toHaveBeenCalledOnceWith();
       });
 
       it('should add a new expense and go to the previous expense if not the first one in list', () => {
@@ -1002,7 +1002,7 @@ export function TestCases2(getTestBed) {
       it('should save an edited expense and close the form', () => {
         spyOn(component, 'editExpense').and.returnValue(of(txnData2));
         spyOn(component, 'checkIfReceiptIsMissingAndMandatory').and.returnValue(of(false));
-        spyOn(component, 'closeAddEditExpenses');
+        spyOn(component, 'goBack');
         component.activeIndex = 0;
         component.mode = 'edit';
         Object.defineProperty(component.fg, 'valid', {
@@ -1013,7 +1013,7 @@ export function TestCases2(getTestBed) {
         component.saveExpenseAndGotoPrev();
         expect(component.editExpense).toHaveBeenCalledOnceWith('SAVE_AND_PREV_EXPENSE');
         expect(component.checkIfReceiptIsMissingAndMandatory).toHaveBeenCalledWith('SAVE_AND_PREV_EXPENSE');
-        expect(component.closeAddEditExpenses).toHaveBeenCalledOnceWith();
+        expect(component.goBack).toHaveBeenCalledOnceWith();
       });
 
       it('should save an edited expense and go to the previous expense', () => {
@@ -1048,7 +1048,7 @@ export function TestCases2(getTestBed) {
       it('should add a new expense and close the form', () => {
         spyOn(component, 'addExpense').and.returnValue(of(Promise.resolve(outboxQueueData1[0])));
         spyOn(component, 'checkIfReceiptIsMissingAndMandatory').and.returnValue(of(false));
-        spyOn(component, 'closeAddEditExpenses');
+        spyOn(component, 'goBack');
         component.activeIndex = 0;
         component.reviewList = ['id1'];
         component.mode = 'add';
@@ -1060,7 +1060,7 @@ export function TestCases2(getTestBed) {
         component.saveExpenseAndGotoNext();
         expect(component.addExpense).toHaveBeenCalledOnceWith('SAVE_AND_NEXT_EXPENSE');
         expect(component.checkIfReceiptIsMissingAndMandatory).toHaveBeenCalledOnceWith('SAVE_AND_NEXT_EXPENSE');
-        expect(component.closeAddEditExpenses).toHaveBeenCalledOnceWith();
+        expect(component.goBack).toHaveBeenCalledOnceWith();
       });
 
       it('should add a new expense and go to the next expense if not the first one in list', () => {
@@ -1084,7 +1084,7 @@ export function TestCases2(getTestBed) {
       it('should save an edited expense and close the form', () => {
         spyOn(component, 'editExpense').and.returnValue(of(txnData2));
         spyOn(component, 'checkIfReceiptIsMissingAndMandatory').and.returnValue(of(false));
-        spyOn(component, 'closeAddEditExpenses');
+        spyOn(component, 'goBack');
         component.activeIndex = 0;
         component.mode = 'edit';
         component.reviewList = ['id1'];
@@ -1096,7 +1096,7 @@ export function TestCases2(getTestBed) {
         component.saveExpenseAndGotoNext();
         expect(component.editExpense).toHaveBeenCalledOnceWith('SAVE_AND_NEXT_EXPENSE');
         expect(component.checkIfReceiptIsMissingAndMandatory).toHaveBeenCalledOnceWith('SAVE_AND_NEXT_EXPENSE');
-        expect(component.closeAddEditExpenses).toHaveBeenCalledTimes(1);
+        expect(component.goBack).toHaveBeenCalledTimes(1);
       });
 
       it('should save an edited expense and go to the next expense', () => {
@@ -1201,19 +1201,6 @@ export function TestCases2(getTestBed) {
 
       const result = component.getTimeSpentOnPage();
       expect(result).toBeCloseTo((new Date().getTime() - component.expenseStartTime) / 1000, 2);
-    });
-
-    it('closeAddEditExpenses(): should close the form and navigate back to my_expenses page', () => {
-      component.closeAddEditExpenses();
-
-      expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_expenses']);
-    });
-
-    it('closeAddEditExpenses(): should close the form and navigate back to review split expense modal if fromSplitExpenseReview is true in url', () => {
-      activatedRoute.snapshot.params.fromSplitExpenseReview = true;
-      component.closeAddEditExpenses();
-
-      expect(navController.back).toHaveBeenCalled();
     });
 
     describe('getParsedReceipt():', () => {

--- a/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense-2.spec.ts
@@ -5,7 +5,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ActionSheetController, ModalController, NavController, Platform, PopoverController } from '@ionic/angular';
-import { BehaviorSubject, Observable, Subscription, finalize, of, throwError } from 'rxjs';
+import { Observable, Subscription, finalize, of, throwError } from 'rxjs';
 import { AccountType } from 'src/app/core/enums/account-type.enum';
 import { criticalPolicyViolation2 } from 'src/app/core/mock-data/crtical-policy-violations.data';
 import { duplicateSetData1, duplicateSetData6 } from 'src/app/core/mock-data/duplicate-sets.data';
@@ -111,7 +111,6 @@ import {
 import { apiExpenses1, apiExpenses2, splitExpensesData } from 'src/app/core/mock-data/platform/v1/expense.data';
 import { SpenderReportsService } from 'src/app/core/services/platform/v1/spender/reports.service';
 import { AdvanceWalletsService } from 'src/app/core/services/platform/v1/spender/advance-wallets.service';
-import { Transaction } from 'src/app/core/models/v1/transaction.model';
 
 const properties = {
   cssClass: 'fy-modal',
@@ -174,7 +173,6 @@ export function TestCases2(getTestBed) {
     let expensesService: jasmine.SpyObj<ExpensesService>;
     let reportsService: jasmine.SpyObj<SpenderReportsService>;
     let advanceWalletsService: jasmine.SpyObj<AdvanceWalletsService>;
-    let splitExpensesData$: BehaviorSubject<{ expenses: Transaction[]; fromSplitExpenseReview: boolean } | null>;
 
     beforeEach(() => {
       const TestBed = getTestBed();
@@ -1205,49 +1203,17 @@ export function TestCases2(getTestBed) {
       expect(result).toBeCloseTo((new Date().getTime() - component.expenseStartTime) / 1000, 2);
     });
 
-    describe('closeAddEditExpense()', () => {
-      beforeEach(() => {
-        splitExpensesData$ = new BehaviorSubject<{ expenses: Transaction[]; fromSplitExpenseReview: boolean } | null>(
-          null
-        );
-        expensesService.getRecentlySplitExpenses.and.callFake(() => splitExpensesData$.asObservable());
-        expensesService.clearRecentlySplitExpenses.and.callFake(() => splitExpensesData$.next(null));
-      });
+    it('closeAddEditExpenses(): should close the form and navigate back to my_expenses page', () => {
+      component.closeAddEditExpenses();
 
-      it('closeAddEditExpenses(): should navigate back if fromSplitExpenseReview is true', () => {
-        activatedRoute.snapshot.params = { fromSplitExpenseReview: true };
-        const mockData = { expenses: [], fromSplitExpenseReview: true };
-        splitExpensesData$.next(mockData);
-        component.closeAddEditExpenses();
-        expect(navController.back).toHaveBeenCalled();
-        expect(router.navigate).not.toHaveBeenCalled();
-      });
+      expect(router.navigate).toHaveBeenCalledOnceWith(['/', 'enterprise', 'my_expenses']);
+    });
 
-      it('closeAddEditExpenses(): should clear expenses and navigate if fromSplitExpenseReview is false', () => {
-        activatedRoute.snapshot.params = { fromSplitExpenseReview: false };
-        splitExpensesData$.next(null);
-        component.closeAddEditExpenses();
-        expect(expensesService.clearRecentlySplitExpenses).toHaveBeenCalled();
-        expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'my_expenses']);
-      });
+    it('closeAddEditExpenses(): should close the form and navigate back to review split expense modal if fromSplitExpenseReview is true in url', () => {
+      activatedRoute.snapshot.params.fromSplitExpenseReview = true;
+      component.closeAddEditExpenses();
 
-      it('closeAddEditExpenses(): should clear expenses and navigate if getRecentlySplitExpenses returns null', () => {
-        activatedRoute.snapshot.params = { fromSplitExpenseReview: false };
-        const mockData = { expenses: [], fromSplitExpenseReview: true };
-        splitExpensesData$.next(mockData);
-        component.closeAddEditExpenses();
-        expect(expensesService.clearRecentlySplitExpenses).toHaveBeenCalled();
-        expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'my_expenses']);
-      });
-
-      it('closeAddEditExpenses(): should clear expenses and navigate if fromSplitExpenseReview is not present', () => {
-        activatedRoute.snapshot.params = {};
-        const mockData = { expenses: [], fromSplitExpenseReview: true };
-        splitExpensesData$.next(mockData);
-        component.closeAddEditExpenses();
-        expect(expensesService.clearRecentlySplitExpenses).toHaveBeenCalled();
-        expect(router.navigate).toHaveBeenCalledWith(['/', 'enterprise', 'my_expenses']);
-      });
+      expect(navController.back).toHaveBeenCalled();
     });
 
     describe('getParsedReceipt():', () => {

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -1299,7 +1299,7 @@
             Save and new
           </ion-button>
           <ion-button
-            (click)="closeAddEditExpenses()"
+            (click)="goBack()"
             *ngIf="mode === 'edit' && !navigateBack"
             [disabled]="saveExpenseLoader"
             class="btn-secondary"

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -543,23 +543,14 @@ export class AddEditExpensePage implements OnInit {
   }
 
   goBack(): void {
-    if (this.activatedRoute.snapshot.params.fromSplitExpenseReview) {
-      this.expensesService
-        .getRecentlySplitExpenses()
-        .pipe(take(1))
-        .subscribe((storedData) => {
-          if (storedData?.fromSplitExpenseReview) {
-            this.navController.back();
-          } else {
-            this.expensesService.clearRecentlySplitExpenses();
-            this.router.navigate(['/', 'enterprise', 'my_expenses']);
-          }
-        });
+    if (
+      this.activatedRoute.snapshot.params.persist_filters ||
+      this.activatedRoute.snapshot.params.fromSplitExpenseReview ||
+      this.isRedirectedFromReport
+    ) {
+      this.navController.back();
     } else {
-      this.expensesService.clearRecentlySplitExpenses();
-      if (this.activatedRoute.snapshot.params.persist_filters || this.isRedirectedFromReport) {
-        this.navController.back();
-      } else if (this.mode === 'add') {
+      if (this.mode === 'add') {
         this.router.navigate(['/', 'enterprise', 'my_expenses'], {
           queryParams: { redirected_from_add_expense: true },
         });
@@ -3744,7 +3735,6 @@ export class AddEditExpensePage implements OnInit {
   saveExpense(): void {
     const that = this;
     const formValues = this.getFormValues();
-    this.expensesService.clearRecentlySplitExpenses();
     forkJoin({
       invalidPaymentMode: that.checkIfInvalidPaymentMode().pipe(take(1)),
       isReceiptMissingAndMandatory: that.checkIfReceiptIsMissingAndMandatory('SAVE_EXPENSE'),
@@ -4415,16 +4405,8 @@ export class AddEditExpensePage implements OnInit {
   closeAddEditExpenses(): void {
     const params = this.activatedRoute.snapshot.params;
     if (params.fromSplitExpenseReview) {
-      this.expensesService
-        .getRecentlySplitExpenses()
-        .pipe(take(1))
-        .subscribe((storedData) => {
-          if (storedData?.fromSplitExpenseReview) {
-            this.navController.back();
-          }
-        });
+      this.navController.back();
     } else {
-      this.expensesService.clearRecentlySplitExpenses();
       this.router.navigate(['/', 'enterprise', 'my_expenses']);
     }
   }

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -4087,6 +4087,7 @@ export class AddEditExpensePage implements OnInit {
         )
       ),
       switchMap((transaction) => {
+        this.updateRecentlySplitExpenses(transaction);
         if (
           transaction.corporate_credit_card_expense_group_id &&
           this.selectedCCCTransaction &&
@@ -5225,5 +5226,23 @@ export class AddEditExpensePage implements OnInit {
       return vendor;
     }
     return this.vendorOptions?.find((option) => option.toLowerCase() === vendor.toLowerCase()) || null;
+  }
+
+  private updateRecentlySplitExpenses(updatedExpense: Partial<Transaction>): void {
+    if (!this.activatedRoute.snapshot.params.fromSplitExpenseReview) {
+      return;
+    }
+
+    const currentData = this.expensesService.splitExpensesData$.getValue();
+
+    if (currentData && currentData.expenses) {
+      const updatedExpenses = currentData.expenses.map((expense) =>
+        expense.id === updatedExpense.id ? updatedExpense : expense
+      );
+      this.expensesService.splitExpensesData$.next({
+        ...currentData,
+        expenses: updatedExpenses,
+      });
+    }
   }
 }

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -543,21 +543,23 @@ export class AddEditExpensePage implements OnInit {
   }
 
   goBack(): void {
-    const params = this.activatedRoute.snapshot.params;
-
-    if (params.fromSplitExpenseReview) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const storedData = this.expensesService.getRecentlySplitExpenses();
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (storedData?.fromSplitExpenseReview) {
-        this.navController.back();
-      } else {
-        this.expensesService.clearRecentlySplitExpenses();
-        this.router.navigate(['/', 'enterprise', 'my_expenses']);
-      }
+    if (this.activatedRoute.snapshot.params.fromSplitExpenseReview) {
+      this.expensesService
+        .getRecentlySplitExpenses()
+        .pipe(take(1))
+        .subscribe((storedData) => {
+          if (storedData?.fromSplitExpenseReview) {
+            this.navController.back();
+          } else {
+            this.expensesService.clearRecentlySplitExpenses();
+            this.router.navigate(['/', 'enterprise', 'my_expenses']);
+          }
+        });
     } else {
       this.expensesService.clearRecentlySplitExpenses();
-      if (this.mode === 'add') {
+      if (this.activatedRoute.snapshot.params.persist_filters || this.isRedirectedFromReport) {
+        this.navController.back();
+      } else if (this.mode === 'add') {
         this.router.navigate(['/', 'enterprise', 'my_expenses'], {
           queryParams: { redirected_from_add_expense: true },
         });
@@ -3742,7 +3744,7 @@ export class AddEditExpensePage implements OnInit {
   saveExpense(): void {
     const that = this;
     const formValues = this.getFormValues();
-
+    this.expensesService.clearRecentlySplitExpenses();
     forkJoin({
       invalidPaymentMode: that.checkIfInvalidPaymentMode().pipe(take(1)),
       isReceiptMissingAndMandatory: that.checkIfReceiptIsMissingAndMandatory('SAVE_EXPENSE'),
@@ -3788,7 +3790,6 @@ export class AddEditExpensePage implements OnInit {
         }
       }
     });
-    this.expensesService.clearRecentlySplitExpenses();
   }
 
   saveAndNewExpense(): void {
@@ -4414,15 +4415,17 @@ export class AddEditExpensePage implements OnInit {
   closeAddEditExpenses(): void {
     const params = this.activatedRoute.snapshot.params;
     if (params.fromSplitExpenseReview) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const storedData = this.expensesService.getRecentlySplitExpenses();
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (storedData?.fromSplitExpenseReview) {
-        this.navController.back();
-      } else {
-        this.expensesService.clearRecentlySplitExpenses();
-        this.router.navigate(['/', 'enterprise', 'my_expenses']);
-      }
+      this.expensesService
+        .getRecentlySplitExpenses()
+        .pipe(take(1))
+        .subscribe((storedData) => {
+          if (storedData?.fromSplitExpenseReview) {
+            this.navController.back();
+          }
+        });
+    } else {
+      this.expensesService.clearRecentlySplitExpenses();
+      this.router.navigate(['/', 'enterprise', 'my_expenses']);
     }
   }
 

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -545,8 +545,7 @@ export class AddEditExpensePage implements OnInit {
   goBack(): void {
     if (
       this.activatedRoute.snapshot.params.persist_filters ||
-      this.activatedRoute.snapshot.params.fromSplitExpenseReview ||
-      this.isRedirectedFromReport
+      this.activatedRoute.snapshot.params.fromSplitExpenseReview
     ) {
       this.navController.back();
     } else {
@@ -3820,7 +3819,7 @@ export class AddEditExpensePage implements OnInit {
         if (that.mode === 'add') {
           that.addExpense('SAVE_AND_PREV_EXPENSE').subscribe(() => {
             if (+this.activeIndex === 0) {
-              that.closeAddEditExpenses();
+              that.goBack();
             } else {
               that.goToPrev();
             }
@@ -3829,7 +3828,7 @@ export class AddEditExpensePage implements OnInit {
           // to do edit
           that.editExpense('SAVE_AND_PREV_EXPENSE').subscribe(() => {
             if (+this.activeIndex === 0) {
-              that.closeAddEditExpenses();
+              that.goBack();
             } else {
               that.goToPrev();
             }
@@ -3848,7 +3847,7 @@ export class AddEditExpensePage implements OnInit {
         if (that.mode === 'add') {
           that.addExpense('SAVE_AND_NEXT_EXPENSE').subscribe(() => {
             if (+this.activeIndex === this.reviewList.length - 1) {
-              that.closeAddEditExpenses();
+              that.goBack();
             } else {
               that.goToNext();
             }
@@ -3857,7 +3856,7 @@ export class AddEditExpensePage implements OnInit {
           // to do edit
           that.editExpense('SAVE_AND_NEXT_EXPENSE').subscribe(() => {
             if (+this.activeIndex === this.reviewList.length - 1) {
-              that.closeAddEditExpenses();
+              that.goBack();
             } else {
               that.goToNext();
             }
@@ -4400,15 +4399,6 @@ export class AddEditExpensePage implements OnInit {
         this.triggerNpsSurvey();
       })
     );
-  }
-
-  closeAddEditExpenses(): void {
-    const params = this.activatedRoute.snapshot.params;
-    if (params.fromSplitExpenseReview) {
-      this.navController.back();
-    } else {
-      this.router.navigate(['/', 'enterprise', 'my_expenses']);
-    }
   }
 
   async getParsedReceipt(base64Image: string, fileType: string): Promise<ParsedReceipt> {

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -543,9 +543,20 @@ export class AddEditExpensePage implements OnInit {
   }
 
   goBack(): void {
-    if (this.activatedRoute.snapshot.params.persist_filters || this.isRedirectedFromReport) {
-      this.navController.back();
+    const params = this.activatedRoute.snapshot.params;
+
+    if (params.fromSplitExpenseReview) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const storedData = this.expensesService.getRecentlySplitExpenses();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (storedData?.fromSplitExpenseReview) {
+        this.navController.back();
+      } else {
+        this.expensesService.clearRecentlySplitExpenses();
+        this.router.navigate(['/', 'enterprise', 'my_expenses']);
+      }
     } else {
+      this.expensesService.clearRecentlySplitExpenses();
       if (this.mode === 'add') {
         this.router.navigate(['/', 'enterprise', 'my_expenses'], {
           queryParams: { redirected_from_add_expense: true },
@@ -3777,6 +3788,7 @@ export class AddEditExpensePage implements OnInit {
         }
       }
     });
+    this.expensesService.clearRecentlySplitExpenses();
   }
 
   saveAndNewExpense(): void {
@@ -4400,7 +4412,18 @@ export class AddEditExpensePage implements OnInit {
   }
 
   closeAddEditExpenses(): void {
-    this.router.navigate(['/', 'enterprise', 'my_expenses']);
+    const params = this.activatedRoute.snapshot.params;
+    if (params.fromSplitExpenseReview) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const storedData = this.expensesService.getRecentlySplitExpenses();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (storedData?.fromSplitExpenseReview) {
+        this.navController.back();
+      } else {
+        this.expensesService.clearRecentlySplitExpenses();
+        this.router.navigate(['/', 'enterprise', 'my_expenses']);
+      }
+    }
   }
 
   async getParsedReceipt(base64Image: string, fileType: string): Promise<ParsedReceipt> {

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -545,7 +545,7 @@ export class AddEditExpensePage implements OnInit {
   goBack(): void {
     if (
       this.activatedRoute.snapshot.params.persist_filters ||
-      this.activatedRoute.snapshot.params.fromSplitExpenseReview
+      this.activatedRoute.snapshot.params.isRedirectedFromReport
     ) {
       this.navController.back();
     } else {

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -5235,7 +5235,7 @@ export class AddEditExpensePage implements OnInit {
 
     const currentData = this.expensesService.splitExpensesData$.getValue();
 
-    if (currentData && currentData.expenses) {
+    if (currentData && currentData?.expenses) {
       const updatedExpenses = currentData.expenses.map((expense) =>
         expense.id === updatedExpense.id ? updatedExpense : expense
       );

--- a/src/app/fyle/add-edit-expense/add-edit-expense.setup.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.setup.spec.ts
@@ -226,6 +226,9 @@ describe('AddEditExpensePage', () => {
       'getSplitExpenses',
       'attachReceiptToExpense',
       'post',
+      'getRecentlySplitExpenses',
+      'clearRecentlySplitExpenses',
+      'storeRecentlySplitExpenses',
     ]);
     const advanceWalletsServiceSpy = jasmine.createSpyObj('AdvanceWalletsService', ['getAllAdvanceWallets']);
     const spenderServiceSpy = jasmine.createSpyObj('SpenderService', ['get', 'post']);

--- a/src/app/fyle/add-edit-expense/add-edit-expense.setup.spec.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.setup.spec.ts
@@ -226,9 +226,6 @@ describe('AddEditExpensePage', () => {
       'getSplitExpenses',
       'attachReceiptToExpense',
       'post',
-      'getRecentlySplitExpenses',
-      'clearRecentlySplitExpenses',
-      'storeRecentlySplitExpenses',
     ]);
     const advanceWalletsServiceSpy = jasmine.createSpyObj('AdvanceWalletsService', ['getAllAdvanceWallets']);
     const spenderServiceSpy = jasmine.createSpyObj('SpenderService', ['get', 'post']);

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -863,114 +863,118 @@ export class SplitExpensePage implements OnDestroy {
   }
 
   ionViewWillEnter(): void {
-    this.getRecentlySplitExpenses().subscribe((splitExpData) => {
-      if (splitExpData?.fromSplitExpenseReview && !this.isReviewModalOpen) {
-        this.openReviewSplitExpenseModal(splitExpData.expenses);
-      } else {
-        const currencyObj = JSON.parse(this.activatedRoute.snapshot.params.currencyObj as string) as CurrencyObj;
-        const orgSettings$ = this.orgSettingsService.get();
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        this.splitConfig = JSON.parse(this.activatedRoute.snapshot.params.splitConfig as string);
-        this.txnFields = JSON.parse(
-          this.activatedRoute.snapshot.params.txnFields as string
-        ) as Partial<ExpenseFieldsObj>;
-        this.fileUrls = JSON.parse(this.activatedRoute.snapshot.params.fileObjs as string) as FileObject[];
-        this.selectedCCCTransaction = JSON.parse(
-          this.activatedRoute.snapshot.params.selectedCCCTransaction as string
-        ) as MatchedCCCTransaction;
-        this.reportId = JSON.parse(this.activatedRoute.snapshot.params.selectedReportId as string) as string;
-        this.transaction = JSON.parse(this.activatedRoute.snapshot.params.txn as string) as Transaction;
-        this.selectedProject = JSON.parse(this.activatedRoute.snapshot.params.selectedProject as string) as ProjectV2;
-        this.expenseFields = JSON.parse(this.activatedRoute.snapshot.params.expenseFields as string) as ExpenseField[];
-        // Set max and min date for form
-        const today = new Date();
-        this.minDate = dayjs(new Date('Jan 1, 2001')).format('YYYY-MM-D');
-        this.maxDate = dayjs(this.dateService.addDaysToDate(today, 1)).format('YYYY-MM-D');
+    if (!this.isReviewModalOpen) {
+      this.getRecentlySplitDataAndOpenReviewModal();
+    } else {
+      const currencyObj = JSON.parse(this.activatedRoute.snapshot.params.currencyObj as string) as CurrencyObj;
+      const orgSettings$ = this.orgSettingsService.get();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      this.splitConfig = JSON.parse(this.activatedRoute.snapshot.params.splitConfig as string);
+      this.txnFields = JSON.parse(this.activatedRoute.snapshot.params.txnFields as string) as Partial<ExpenseFieldsObj>;
+      this.fileUrls = JSON.parse(this.activatedRoute.snapshot.params.fileObjs as string) as FileObject[];
+      this.selectedCCCTransaction = JSON.parse(
+        this.activatedRoute.snapshot.params.selectedCCCTransaction as string
+      ) as MatchedCCCTransaction;
+      this.reportId = JSON.parse(this.activatedRoute.snapshot.params.selectedReportId as string) as string;
+      this.transaction = JSON.parse(this.activatedRoute.snapshot.params.txn as string) as Transaction;
+      this.selectedProject = JSON.parse(this.activatedRoute.snapshot.params.selectedProject as string) as ProjectV2;
+      this.expenseFields = JSON.parse(this.activatedRoute.snapshot.params.expenseFields as string) as ExpenseField[];
+      // Set max and min date for form
+      const today = new Date();
+      this.minDate = dayjs(new Date('Jan 1, 2001')).format('YYYY-MM-D');
+      this.maxDate = dayjs(this.dateService.addDaysToDate(today, 1)).format('YYYY-MM-D');
 
-        this.isProjectCategoryRestrictionsEnabled$ = orgSettings$.pipe(
-          map(
-            (orgSettings) =>
-              orgSettings.advanced_projects.allowed && orgSettings.advanced_projects.enable_category_restriction
-          )
-        );
+      this.isProjectCategoryRestrictionsEnabled$ = orgSettings$.pipe(
+        map(
+          (orgSettings) =>
+            orgSettings.advanced_projects.allowed && orgSettings.advanced_projects.enable_category_restriction
+        )
+      );
 
-        this.categories$ = this.getActiveCategories().pipe(
-          switchMap((activeCategories) =>
-            this.launchDarklyService.getVariation('show_project_mapped_categories_in_split_expense', false).pipe(
-              switchMap((showProjectMappedCategories) => {
-                if (showProjectMappedCategories && this.transaction.project_id) {
-                  return combineLatest([
-                    this.projectsService.getbyId(this.transaction.project_id),
-                    this.isProjectCategoryRestrictionsEnabled$,
-                  ]).pipe(
-                    map(([project, isProjectCategoryRestrictionsEnabled]) =>
-                      this.projectsService.getAllowedOrgCategoryIds(
-                        project,
-                        activeCategories,
-                        isProjectCategoryRestrictionsEnabled
-                      )
+      this.categories$ = this.getActiveCategories().pipe(
+        switchMap((activeCategories) =>
+          this.launchDarklyService.getVariation('show_project_mapped_categories_in_split_expense', false).pipe(
+            switchMap((showProjectMappedCategories) => {
+              if (showProjectMappedCategories && this.transaction.project_id) {
+                return combineLatest([
+                  this.projectsService.getbyId(this.transaction.project_id),
+                  this.isProjectCategoryRestrictionsEnabled$,
+                ]).pipe(
+                  map(([project, isProjectCategoryRestrictionsEnabled]) =>
+                    this.projectsService.getAllowedOrgCategoryIds(
+                      project,
+                      activeCategories,
+                      isProjectCategoryRestrictionsEnabled
                     )
-                  );
-                }
-
-                return of(activeCategories);
-              }),
-              map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
-            )
-          )
-        );
-
-        this.getCategoryList();
-
-        let parentFieldId: number;
-        if (this.splitConfig.project.is_visible || this.splitConfig.costCenter.is_visible) {
-          parentFieldId = this.splitConfig.project.is_visible
-            ? this.txnFields.project_id.id
-            : this.txnFields.cost_center_id?.id;
-        }
-
-        this.dependentCustomProperties$ = iif(
-          () => !!parentFieldId,
-          this.dependentFieldsService.getDependentFieldValuesForBaseField(
-            this.transaction.custom_properties,
-            parentFieldId
-          ),
-          of(null)
-        );
-
-        if (this.splitConfig.costCenter.is_visible) {
-          this.costCenters$ = orgSettings$.pipe(
-            switchMap((orgSettings) => {
-              if (orgSettings.cost_centers.enabled) {
-                return this.costCentersService.getAllActive();
-              } else {
-                return of([]);
+                  )
+                );
               }
-            }),
-            map((costCenters: CostCenter[]) =>
-              costCenters.map((costCenter) => ({
-                label: costCenter.name,
-                value: costCenter,
-              }))
-            )
-          );
-        }
 
-        this.isCorporateCardsEnabled$ = orgSettings$.pipe(
-          map(
-            (orgSettings) =>
-              orgSettings.corporate_credit_card_settings && orgSettings.corporate_credit_card_settings.enabled
+              return of(activeCategories);
+            }),
+            map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
+          )
+        )
+      );
+
+      this.getCategoryList();
+
+      let parentFieldId: number;
+      if (this.splitConfig.project.is_visible || this.splitConfig.costCenter.is_visible) {
+        parentFieldId = this.splitConfig.project.is_visible
+          ? this.txnFields.project_id.id
+          : this.txnFields.cost_center_id?.id;
+      }
+
+      this.dependentCustomProperties$ = iif(
+        () => !!parentFieldId,
+        this.dependentFieldsService.getDependentFieldValuesForBaseField(
+          this.transaction.custom_properties,
+          parentFieldId
+        ),
+        of(null)
+      );
+
+      if (this.splitConfig.costCenter.is_visible) {
+        this.costCenters$ = orgSettings$.pipe(
+          switchMap((orgSettings) => {
+            if (orgSettings.cost_centers.enabled) {
+              return this.costCentersService.getAllActive();
+            } else {
+              return of([]);
+            }
+          }),
+          map((costCenters: CostCenter[]) =>
+            costCenters.map((costCenter) => ({
+              label: costCenter.name,
+              value: costCenter,
+            }))
           )
         );
+      }
 
-        this.getUnspecifiedCategory();
+      this.isCorporateCardsEnabled$ = orgSettings$.pipe(
+        map(
+          (orgSettings) =>
+            orgSettings.corporate_credit_card_settings && orgSettings.corporate_credit_card_settings.enabled
+        )
+      );
 
-        forkJoin({
-          homeCurrency: this.currencyService.getHomeCurrency(),
-          isCorporateCardsEnabled: this.isCorporateCardsEnabled$,
-        }).subscribe(({ homeCurrency, isCorporateCardsEnabled }) =>
-          this.setValuesForCCC(currencyObj, homeCurrency, isCorporateCardsEnabled)
-        );
+      this.getUnspecifiedCategory();
+
+      forkJoin({
+        homeCurrency: this.currencyService.getHomeCurrency(),
+        isCorporateCardsEnabled: this.isCorporateCardsEnabled$,
+      }).subscribe(({ homeCurrency, isCorporateCardsEnabled }) =>
+        this.setValuesForCCC(currencyObj, homeCurrency, isCorporateCardsEnabled)
+      );
+    }
+  }
+
+  getRecentlySplitDataAndOpenReviewModal(): void {
+    this.getRecentlySplitExpenses().subscribe((splitExpData) => {
+      if (splitExpData) {
+        this.openReviewSplitExpenseModal(splitExpData.expenses);
       }
     });
   }
@@ -1344,7 +1348,6 @@ export class SplitExpensePage implements OnDestroy {
 
     this.setRecentlySplitExpenses({
       expenses: expense,
-      fromSplitExpenseReview: true,
     });
 
     await reviewModal.present();
@@ -1357,14 +1360,11 @@ export class SplitExpensePage implements OnDestroy {
     }
   }
 
-  private setRecentlySplitExpenses(data: { expenses: Partial<Transaction>[]; fromSplitExpenseReview: boolean }): void {
+  private setRecentlySplitExpenses(data: { expenses: Partial<Transaction>[] }): void {
     this.expensesService.splitExpensesData$.next(data);
   }
 
-  private getRecentlySplitExpenses(): Observable<{
-    expenses: Partial<Transaction>[];
-    fromSplitExpenseReview: boolean;
-  } | null> {
+  private getRecentlySplitExpenses(): Observable<{ expenses: Partial<Transaction>[] } | null> {
     return this.expensesService.splitExpensesData$.asObservable();
   }
 

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -861,108 +861,116 @@ export class SplitExpensePage implements OnDestroy {
   }
 
   ionViewWillEnter(): void {
-    const currencyObj = JSON.parse(this.activatedRoute.snapshot.params.currencyObj as string) as CurrencyObj;
-    const orgSettings$ = this.orgSettingsService.get();
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    this.splitConfig = JSON.parse(this.activatedRoute.snapshot.params.splitConfig as string);
-    this.txnFields = JSON.parse(this.activatedRoute.snapshot.params.txnFields as string) as Partial<ExpenseFieldsObj>;
-    this.fileUrls = JSON.parse(this.activatedRoute.snapshot.params.fileObjs as string) as FileObject[];
-    this.selectedCCCTransaction = JSON.parse(
-      this.activatedRoute.snapshot.params.selectedCCCTransaction as string
-    ) as MatchedCCCTransaction;
-    this.reportId = JSON.parse(this.activatedRoute.snapshot.params.selectedReportId as string) as string;
-    this.transaction = JSON.parse(this.activatedRoute.snapshot.params.txn as string) as Transaction;
-    this.selectedProject = JSON.parse(this.activatedRoute.snapshot.params.selectedProject as string) as ProjectV2;
-    this.expenseFields = JSON.parse(this.activatedRoute.snapshot.params.expenseFields as string) as ExpenseField[];
-    // Set max and min date for form
-    const today = new Date();
-    this.minDate = dayjs(new Date('Jan 1, 2001')).format('YYYY-MM-D');
-    this.maxDate = dayjs(this.dateService.addDaysToDate(today, 1)).format('YYYY-MM-D');
+    const storedData = this.expensesService.getRecentlySplitExpenses();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (storedData?.fromSplitExpenseReview) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+      this.openReviewSplitExpenseModal(storedData.expenses);
+    } else {
+      const currencyObj = JSON.parse(this.activatedRoute.snapshot.params.currencyObj as string) as CurrencyObj;
+      const orgSettings$ = this.orgSettingsService.get();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      this.splitConfig = JSON.parse(this.activatedRoute.snapshot.params.splitConfig as string);
+      this.txnFields = JSON.parse(this.activatedRoute.snapshot.params.txnFields as string) as Partial<ExpenseFieldsObj>;
+      this.fileUrls = JSON.parse(this.activatedRoute.snapshot.params.fileObjs as string) as FileObject[];
+      this.selectedCCCTransaction = JSON.parse(
+        this.activatedRoute.snapshot.params.selectedCCCTransaction as string
+      ) as MatchedCCCTransaction;
+      this.reportId = JSON.parse(this.activatedRoute.snapshot.params.selectedReportId as string) as string;
+      this.transaction = JSON.parse(this.activatedRoute.snapshot.params.txn as string) as Transaction;
+      this.selectedProject = JSON.parse(this.activatedRoute.snapshot.params.selectedProject as string) as ProjectV2;
+      this.expenseFields = JSON.parse(this.activatedRoute.snapshot.params.expenseFields as string) as ExpenseField[];
+      // Set max and min date for form
+      const today = new Date();
+      this.minDate = dayjs(new Date('Jan 1, 2001')).format('YYYY-MM-D');
+      this.maxDate = dayjs(this.dateService.addDaysToDate(today, 1)).format('YYYY-MM-D');
 
-    this.isProjectCategoryRestrictionsEnabled$ = orgSettings$.pipe(
-      map(
-        (orgSettings) =>
-          orgSettings.advanced_projects.allowed && orgSettings.advanced_projects.enable_category_restriction
-      )
-    );
-
-    this.categories$ = this.getActiveCategories().pipe(
-      switchMap((activeCategories) =>
-        this.launchDarklyService.getVariation('show_project_mapped_categories_in_split_expense', false).pipe(
-          switchMap((showProjectMappedCategories) => {
-            if (showProjectMappedCategories && this.transaction.project_id) {
-              return combineLatest([
-                this.projectsService.getbyId(this.transaction.project_id),
-                this.isProjectCategoryRestrictionsEnabled$,
-              ]).pipe(
-                map(([project, isProjectCategoryRestrictionsEnabled]) =>
-                  this.projectsService.getAllowedOrgCategoryIds(
-                    project,
-                    activeCategories,
-                    isProjectCategoryRestrictionsEnabled
-                  )
-                )
-              );
-            }
-
-            return of(activeCategories);
-          }),
-          map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
-        )
-      )
-    );
-
-    this.getCategoryList();
-
-    let parentFieldId: number;
-    if (this.splitConfig.project.is_visible || this.splitConfig.costCenter.is_visible) {
-      parentFieldId = this.splitConfig.project.is_visible
-        ? this.txnFields.project_id.id
-        : this.txnFields.cost_center_id?.id;
-    }
-
-    this.dependentCustomProperties$ = iif(
-      () => !!parentFieldId,
-      this.dependentFieldsService.getDependentFieldValuesForBaseField(
-        this.transaction.custom_properties,
-        parentFieldId
-      ),
-      of(null)
-    );
-
-    if (this.splitConfig.costCenter.is_visible) {
-      this.costCenters$ = orgSettings$.pipe(
-        switchMap((orgSettings) => {
-          if (orgSettings.cost_centers.enabled) {
-            return this.costCentersService.getAllActive();
-          } else {
-            return of([]);
-          }
-        }),
-        map((costCenters: CostCenter[]) =>
-          costCenters.map((costCenter) => ({
-            label: costCenter.name,
-            value: costCenter,
-          }))
+      this.isProjectCategoryRestrictionsEnabled$ = orgSettings$.pipe(
+        map(
+          (orgSettings) =>
+            orgSettings.advanced_projects.allowed && orgSettings.advanced_projects.enable_category_restriction
         )
       );
+
+      this.categories$ = this.getActiveCategories().pipe(
+        switchMap((activeCategories) =>
+          this.launchDarklyService.getVariation('show_project_mapped_categories_in_split_expense', false).pipe(
+            switchMap((showProjectMappedCategories) => {
+              if (showProjectMappedCategories && this.transaction.project_id) {
+                return combineLatest([
+                  this.projectsService.getbyId(this.transaction.project_id),
+                  this.isProjectCategoryRestrictionsEnabled$,
+                ]).pipe(
+                  map(([project, isProjectCategoryRestrictionsEnabled]) =>
+                    this.projectsService.getAllowedOrgCategoryIds(
+                      project,
+                      activeCategories,
+                      isProjectCategoryRestrictionsEnabled
+                    )
+                  )
+                );
+              }
+
+              return of(activeCategories);
+            }),
+            map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
+          )
+        )
+      );
+
+      this.getCategoryList();
+
+      let parentFieldId: number;
+      if (this.splitConfig.project.is_visible || this.splitConfig.costCenter.is_visible) {
+        parentFieldId = this.splitConfig.project.is_visible
+          ? this.txnFields.project_id.id
+          : this.txnFields.cost_center_id?.id;
+      }
+
+      this.dependentCustomProperties$ = iif(
+        () => !!parentFieldId,
+        this.dependentFieldsService.getDependentFieldValuesForBaseField(
+          this.transaction.custom_properties,
+          parentFieldId
+        ),
+        of(null)
+      );
+
+      if (this.splitConfig.costCenter.is_visible) {
+        this.costCenters$ = orgSettings$.pipe(
+          switchMap((orgSettings) => {
+            if (orgSettings.cost_centers.enabled) {
+              return this.costCentersService.getAllActive();
+            } else {
+              return of([]);
+            }
+          }),
+          map((costCenters: CostCenter[]) =>
+            costCenters.map((costCenter) => ({
+              label: costCenter.name,
+              value: costCenter,
+            }))
+          )
+        );
+      }
+
+      this.isCorporateCardsEnabled$ = orgSettings$.pipe(
+        map(
+          (orgSettings) =>
+            orgSettings.corporate_credit_card_settings && orgSettings.corporate_credit_card_settings.enabled
+        )
+      );
+
+      this.getUnspecifiedCategory();
+
+      forkJoin({
+        homeCurrency: this.currencyService.getHomeCurrency(),
+        isCorporateCardsEnabled: this.isCorporateCardsEnabled$,
+      }).subscribe(({ homeCurrency, isCorporateCardsEnabled }) =>
+        this.setValuesForCCC(currencyObj, homeCurrency, isCorporateCardsEnabled)
+      );
     }
-
-    this.isCorporateCardsEnabled$ = orgSettings$.pipe(
-      map(
-        (orgSettings) =>
-          orgSettings.corporate_credit_card_settings && orgSettings.corporate_credit_card_settings.enabled
-      )
-    );
-
-    this.getUnspecifiedCategory();
-
-    forkJoin({
-      homeCurrency: this.currencyService.getHomeCurrency(),
-      isCorporateCardsEnabled: this.isCorporateCardsEnabled$,
-    }).subscribe(({ homeCurrency, isCorporateCardsEnabled }) =>
-      this.setValuesForCCC(currencyObj, homeCurrency, isCorporateCardsEnabled)
-    );
   }
 
   setValuesForCCC(currencyObj: CurrencyObj, homeCurrency: string, isCorporateCardsEnabled: boolean): void {
@@ -1289,6 +1297,7 @@ export class SplitExpensePage implements OnDestroy {
 
   handleNavigationAfterReview(action: string, expense?: PlatformExpense): void {
     if (action === 'close') {
+      this.expensesService.clearRecentlySplitExpenses();
       this.router.navigate([
         '/',
         'enterprise',
@@ -1305,7 +1314,12 @@ export class SplitExpensePage implements OnDestroy {
       const category = expense?.category?.system_category.toLowerCase();
       const route = routeMap[category] || routeMap.default;
 
-      this.router.navigate(['/', 'enterprise', route, { id: expense.id, persist_filters: true }]);
+      this.router.navigate([
+        '/',
+        'enterprise',
+        route,
+        { id: expense.id, persist_filters: true, fromSplitExpenseReview: true },
+      ]);
     }
   }
 
@@ -1320,6 +1334,11 @@ export class SplitExpensePage implements OnDestroy {
       ...this.modalProperties.getModalDefaultProperties(),
       cssClass: 'review-split-expense-modal',
       showBackdrop: false,
+    });
+
+    this.expensesService.storeRecentlySplitExpenses({
+      expenses: expense,
+      fromSplitExpenseReview: true,
     });
 
     await reviewModal.present();

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -863,9 +863,9 @@ export class SplitExpensePage implements OnDestroy {
   }
 
   ionViewWillEnter(): void {
-    this.getRecentlySplitExpenses().subscribe((storedData) => {
-      if (storedData?.fromSplitExpenseReview && !this.isReviewModalOpen) {
-        this.openReviewSplitExpenseModal(storedData.expenses);
+    this.getRecentlySplitExpenses().subscribe((splitExpData) => {
+      if (splitExpData?.fromSplitExpenseReview && !this.isReviewModalOpen) {
+        this.openReviewSplitExpenseModal(splitExpData.expenses);
       } else {
         const currencyObj = JSON.parse(this.activatedRoute.snapshot.params.currencyObj as string) as CurrencyObj;
         const orgSettings$ = this.orgSettingsService.get();
@@ -1313,7 +1313,7 @@ export class SplitExpensePage implements OnDestroy {
         default: 'add_edit_expense',
       };
 
-      const category = expense?.category?.system_category ? expense.category.system_category.toLowerCase() : 'default';
+      const category = expense?.category?.system_category?.toLowerCase();
       const route = routeMap[category] || routeMap.default;
 
       this.router.navigate([
@@ -1342,7 +1342,7 @@ export class SplitExpensePage implements OnDestroy {
       showBackdrop: false,
     });
 
-    this.storeRecentlySplitExpenses({
+    this.setRecentlySplitExpenses({
       expenses: expense,
       fromSplitExpenseReview: true,
     });
@@ -1357,10 +1357,7 @@ export class SplitExpensePage implements OnDestroy {
     }
   }
 
-  private storeRecentlySplitExpenses(data: {
-    expenses: Partial<Transaction>[];
-    fromSplitExpenseReview: boolean;
-  }): void {
+  private setRecentlySplitExpenses(data: { expenses: Partial<Transaction>[]; fromSplitExpenseReview: boolean }): void {
     this.expensesService.splitExpensesData$.next(data);
   }
 

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -131,6 +131,8 @@ export class SplitExpensePage implements OnDestroy {
 
   splitExpenseHeader: string;
 
+  private isReviewModalOpen = false;
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private formBuilder: FormBuilder,
@@ -861,116 +863,116 @@ export class SplitExpensePage implements OnDestroy {
   }
 
   ionViewWillEnter(): void {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const storedData = this.expensesService.getRecentlySplitExpenses();
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (storedData?.fromSplitExpenseReview) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-      this.openReviewSplitExpenseModal(storedData.expenses);
-    } else {
-      const currencyObj = JSON.parse(this.activatedRoute.snapshot.params.currencyObj as string) as CurrencyObj;
-      const orgSettings$ = this.orgSettingsService.get();
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      this.splitConfig = JSON.parse(this.activatedRoute.snapshot.params.splitConfig as string);
-      this.txnFields = JSON.parse(this.activatedRoute.snapshot.params.txnFields as string) as Partial<ExpenseFieldsObj>;
-      this.fileUrls = JSON.parse(this.activatedRoute.snapshot.params.fileObjs as string) as FileObject[];
-      this.selectedCCCTransaction = JSON.parse(
-        this.activatedRoute.snapshot.params.selectedCCCTransaction as string
-      ) as MatchedCCCTransaction;
-      this.reportId = JSON.parse(this.activatedRoute.snapshot.params.selectedReportId as string) as string;
-      this.transaction = JSON.parse(this.activatedRoute.snapshot.params.txn as string) as Transaction;
-      this.selectedProject = JSON.parse(this.activatedRoute.snapshot.params.selectedProject as string) as ProjectV2;
-      this.expenseFields = JSON.parse(this.activatedRoute.snapshot.params.expenseFields as string) as ExpenseField[];
-      // Set max and min date for form
-      const today = new Date();
-      this.minDate = dayjs(new Date('Jan 1, 2001')).format('YYYY-MM-D');
-      this.maxDate = dayjs(this.dateService.addDaysToDate(today, 1)).format('YYYY-MM-D');
+    this.expensesService.getRecentlySplitExpenses().subscribe((storedData) => {
+      if (storedData?.fromSplitExpenseReview && !this.isReviewModalOpen) {
+        this.openReviewSplitExpenseModal(storedData.expenses);
+      } else {
+        const currencyObj = JSON.parse(this.activatedRoute.snapshot.params.currencyObj as string) as CurrencyObj;
+        const orgSettings$ = this.orgSettingsService.get();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        this.splitConfig = JSON.parse(this.activatedRoute.snapshot.params.splitConfig as string);
+        this.txnFields = JSON.parse(
+          this.activatedRoute.snapshot.params.txnFields as string
+        ) as Partial<ExpenseFieldsObj>;
+        this.fileUrls = JSON.parse(this.activatedRoute.snapshot.params.fileObjs as string) as FileObject[];
+        this.selectedCCCTransaction = JSON.parse(
+          this.activatedRoute.snapshot.params.selectedCCCTransaction as string
+        ) as MatchedCCCTransaction;
+        this.reportId = JSON.parse(this.activatedRoute.snapshot.params.selectedReportId as string) as string;
+        this.transaction = JSON.parse(this.activatedRoute.snapshot.params.txn as string) as Transaction;
+        this.selectedProject = JSON.parse(this.activatedRoute.snapshot.params.selectedProject as string) as ProjectV2;
+        this.expenseFields = JSON.parse(this.activatedRoute.snapshot.params.expenseFields as string) as ExpenseField[];
+        // Set max and min date for form
+        const today = new Date();
+        this.minDate = dayjs(new Date('Jan 1, 2001')).format('YYYY-MM-D');
+        this.maxDate = dayjs(this.dateService.addDaysToDate(today, 1)).format('YYYY-MM-D');
 
-      this.isProjectCategoryRestrictionsEnabled$ = orgSettings$.pipe(
-        map(
-          (orgSettings) =>
-            orgSettings.advanced_projects.allowed && orgSettings.advanced_projects.enable_category_restriction
-        )
-      );
-
-      this.categories$ = this.getActiveCategories().pipe(
-        switchMap((activeCategories) =>
-          this.launchDarklyService.getVariation('show_project_mapped_categories_in_split_expense', false).pipe(
-            switchMap((showProjectMappedCategories) => {
-              if (showProjectMappedCategories && this.transaction.project_id) {
-                return combineLatest([
-                  this.projectsService.getbyId(this.transaction.project_id),
-                  this.isProjectCategoryRestrictionsEnabled$,
-                ]).pipe(
-                  map(([project, isProjectCategoryRestrictionsEnabled]) =>
-                    this.projectsService.getAllowedOrgCategoryIds(
-                      project,
-                      activeCategories,
-                      isProjectCategoryRestrictionsEnabled
-                    )
-                  )
-                );
-              }
-
-              return of(activeCategories);
-            }),
-            map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
-          )
-        )
-      );
-
-      this.getCategoryList();
-
-      let parentFieldId: number;
-      if (this.splitConfig.project.is_visible || this.splitConfig.costCenter.is_visible) {
-        parentFieldId = this.splitConfig.project.is_visible
-          ? this.txnFields.project_id.id
-          : this.txnFields.cost_center_id?.id;
-      }
-
-      this.dependentCustomProperties$ = iif(
-        () => !!parentFieldId,
-        this.dependentFieldsService.getDependentFieldValuesForBaseField(
-          this.transaction.custom_properties,
-          parentFieldId
-        ),
-        of(null)
-      );
-
-      if (this.splitConfig.costCenter.is_visible) {
-        this.costCenters$ = orgSettings$.pipe(
-          switchMap((orgSettings) => {
-            if (orgSettings.cost_centers.enabled) {
-              return this.costCentersService.getAllActive();
-            } else {
-              return of([]);
-            }
-          }),
-          map((costCenters: CostCenter[]) =>
-            costCenters.map((costCenter) => ({
-              label: costCenter.name,
-              value: costCenter,
-            }))
+        this.isProjectCategoryRestrictionsEnabled$ = orgSettings$.pipe(
+          map(
+            (orgSettings) =>
+              orgSettings.advanced_projects.allowed && orgSettings.advanced_projects.enable_category_restriction
           )
         );
+
+        this.categories$ = this.getActiveCategories().pipe(
+          switchMap((activeCategories) =>
+            this.launchDarklyService.getVariation('show_project_mapped_categories_in_split_expense', false).pipe(
+              switchMap((showProjectMappedCategories) => {
+                if (showProjectMappedCategories && this.transaction.project_id) {
+                  return combineLatest([
+                    this.projectsService.getbyId(this.transaction.project_id),
+                    this.isProjectCategoryRestrictionsEnabled$,
+                  ]).pipe(
+                    map(([project, isProjectCategoryRestrictionsEnabled]) =>
+                      this.projectsService.getAllowedOrgCategoryIds(
+                        project,
+                        activeCategories,
+                        isProjectCategoryRestrictionsEnabled
+                      )
+                    )
+                  );
+                }
+
+                return of(activeCategories);
+              }),
+              map((categories) => categories.map((category) => ({ label: category.displayName, value: category })))
+            )
+          )
+        );
+
+        this.getCategoryList();
+
+        let parentFieldId: number;
+        if (this.splitConfig.project.is_visible || this.splitConfig.costCenter.is_visible) {
+          parentFieldId = this.splitConfig.project.is_visible
+            ? this.txnFields.project_id.id
+            : this.txnFields.cost_center_id?.id;
+        }
+
+        this.dependentCustomProperties$ = iif(
+          () => !!parentFieldId,
+          this.dependentFieldsService.getDependentFieldValuesForBaseField(
+            this.transaction.custom_properties,
+            parentFieldId
+          ),
+          of(null)
+        );
+
+        if (this.splitConfig.costCenter.is_visible) {
+          this.costCenters$ = orgSettings$.pipe(
+            switchMap((orgSettings) => {
+              if (orgSettings.cost_centers.enabled) {
+                return this.costCentersService.getAllActive();
+              } else {
+                return of([]);
+              }
+            }),
+            map((costCenters: CostCenter[]) =>
+              costCenters.map((costCenter) => ({
+                label: costCenter.name,
+                value: costCenter,
+              }))
+            )
+          );
+        }
+
+        this.isCorporateCardsEnabled$ = orgSettings$.pipe(
+          map(
+            (orgSettings) =>
+              orgSettings.corporate_credit_card_settings && orgSettings.corporate_credit_card_settings.enabled
+          )
+        );
+
+        this.getUnspecifiedCategory();
+
+        forkJoin({
+          homeCurrency: this.currencyService.getHomeCurrency(),
+          isCorporateCardsEnabled: this.isCorporateCardsEnabled$,
+        }).subscribe(({ homeCurrency, isCorporateCardsEnabled }) =>
+          this.setValuesForCCC(currencyObj, homeCurrency, isCorporateCardsEnabled)
+        );
       }
-
-      this.isCorporateCardsEnabled$ = orgSettings$.pipe(
-        map(
-          (orgSettings) =>
-            orgSettings.corporate_credit_card_settings && orgSettings.corporate_credit_card_settings.enabled
-        )
-      );
-
-      this.getUnspecifiedCategory();
-
-      forkJoin({
-        homeCurrency: this.currencyService.getHomeCurrency(),
-        isCorporateCardsEnabled: this.isCorporateCardsEnabled$,
-      }).subscribe(({ homeCurrency, isCorporateCardsEnabled }) =>
-        this.setValuesForCCC(currencyObj, homeCurrency, isCorporateCardsEnabled)
-      );
-    }
+    });
   }
 
   setValuesForCCC(currencyObj: CurrencyObj, homeCurrency: string, isCorporateCardsEnabled: boolean): void {
@@ -1013,7 +1015,7 @@ export class SplitExpensePage implements OnDestroy {
     const splitForm = this.splitExpensesFormArray.at(index);
     const projectControl = splitForm.get('project');
 
-    if (!projectControl) {
+    if (!projectControl || projectControl.value === null) {
       return;
     }
 
@@ -1311,7 +1313,7 @@ export class SplitExpensePage implements OnDestroy {
         default: 'add_edit_expense',
       };
 
-      const category = expense?.category?.system_category.toLowerCase();
+      const category = expense?.category?.system_category ? expense.category.system_category.toLowerCase() : 'default';
       const route = routeMap[category] || routeMap.default;
 
       this.router.navigate([
@@ -1324,6 +1326,10 @@ export class SplitExpensePage implements OnDestroy {
   }
 
   async openReviewSplitExpenseModal(expense: Transaction[]): Promise<void> {
+    if (this.isReviewModalOpen) {
+      return;
+    }
+    this.isReviewModalOpen = true;
     const reviewModal = await this.modalController.create({
       component: ReviewSplitExpenseComponent,
       componentProps: {
@@ -1345,7 +1351,7 @@ export class SplitExpensePage implements OnDestroy {
 
     const { data }: { data?: { dismissed: boolean; action: string; expense?: PlatformExpense } } =
       await reviewModal.onWillDismiss();
-
+    this.isReviewModalOpen = false;
     if (data) {
       this.handleNavigationAfterReview(data.action, data.expense);
     }

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -1320,12 +1320,7 @@ export class SplitExpensePage implements OnDestroy {
       const category = expense?.category?.system_category ? expense.category.system_category.toLowerCase() : 'default';
       const route = routeMap[category] || routeMap.default;
 
-      this.router.navigate([
-        '/',
-        'enterprise',
-        route,
-        { id: expense.id, persist_filters: true, fromSplitExpenseReview: true },
-      ]);
+      this.router.navigate(['/', 'enterprise', route, { id: expense.id, persist_filters: true }]);
     }
   }
 


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cxube86

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced navigation in expense editing for users returning from a split expense review.
  - Introduced a review modal that displays recent split expense details when applicable.
  - Updated button functionality to streamline user navigation when canceling edits.
  - Added a new property to manage and emit state related to split expenses.

- **Bug Fixes**
  - Improved control flow for navigating back from the expense editing page, especially for split expenses.

- **Tests**
  - Enhanced test coverage for navigation logic related to expense editing and saving scenarios, ensuring consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->