### PR TITLE
fix: Poilcy violation logic

### DIFF
--- a/src/app/core/models/filtered-missing-fields-violations.model.ts
+++ b/src/app/core/models/filtered-missing-fields-violations.model.ts
@@ -3,6 +3,7 @@ export interface FilteredMissingFieldsViolations {
   type: string;
   name: string;
   currency: string;
+  inputFieldInfo?: { [key: string]: string };
   amount: number;
   isExpanded?: boolean;
 }

--- a/src/app/core/models/filtered-split-policy-violations.model.ts
+++ b/src/app/core/models/filtered-split-policy-violations.model.ts
@@ -8,6 +8,7 @@ export interface FilteredSplitPolicyViolations {
     final_desired_state: FinalExpensePolicyState;
   };
   type: string;
+  inputFieldInfo?: { [key: string]: string };
   name: string;
   currency: string;
   amount: number;

--- a/src/app/core/models/policy-violation.model.ts
+++ b/src/app/core/models/policy-violation.model.ts
@@ -9,6 +9,7 @@ export interface PolicyViolation {
   amount?: number;
   currency?: string;
   name?: string;
+  inputFieldInfo?: { [key: string]: string };
   type?: string;
   isExpanded?: boolean;
 }

--- a/src/app/core/models/splitting-expense-properties.model.ts
+++ b/src/app/core/models/splitting-expense-properties.model.ts
@@ -1,7 +1,6 @@
 import { SplitPayload } from './platform/v1/split-payload.model';
 
 export interface SplittingExpenseProperties {
-  Type: string;
   'Is Evenly Split': boolean;
   Asset: string;
   'Is part of report': boolean;

--- a/src/app/core/models/transformed-split-expense-missing-fields.model.ts
+++ b/src/app/core/models/transformed-split-expense-missing-fields.model.ts
@@ -4,6 +4,7 @@ export interface TransformedSplitExpenseMissingFields {
   amount: number;
   currency: string;
   name: string;
+  inputFieldInfo?: { [key: string]: string };
   type: string;
   data: PlatformMissingMandatoryFields;
 }

--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -365,6 +365,7 @@ export class SplitExpenseService {
           action: violations[key].data,
           type: violations[key].type,
           name: violations[key].name,
+          inputFieldInfo: violations[key].inputFieldInfo,
           currency: violations[key].currency,
           amount: violations[key].amount,
           isCriticalPolicyViolation,
@@ -386,6 +387,7 @@ export class SplitExpenseService {
           isMissingFields: mandatoryFields[key].data && this.isMissingFields(mandatoryFields[key]),
           type: mandatoryFields[key].type,
           name: mandatoryFields[key].name,
+          inputFieldInfo: mandatoryFields[key].inputFieldInfo,
           currency: mandatoryFields[key].currency,
           amount: mandatoryFields[key].amount,
         };

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -452,6 +452,10 @@ export class AddEditExpensePage implements OnInit {
 
   selectedCategory$: Observable<OrgCategory>;
 
+  isProjectEnabled: boolean;
+
+  isCostCenterEnabled: boolean;
+
   vendorOptions: string[] = [];
 
   constructor(
@@ -789,12 +793,12 @@ export class AddEditExpensePage implements OnInit {
             is_mandatory: res.txnFields.org_category_id?.is_mandatory || false,
           },
           project: {
-            is_visible: !!res.txnFields.project_id,
+            is_visible: !!res.txnFields.project_id || this.isProjectEnabled,
             value: formValue.project,
             is_mandatory: res.txnFields.project_id?.is_mandatory || false,
           },
           costCenter: {
-            is_visible: !!res.txnFields.cost_center_id,
+            is_visible: !!res.txnFields.cost_center_id || this.isCostCenterEnabled,
             value: formValue.costCenter,
             is_mandatory: res.txnFields.cost_center_id?.is_mandatory || false,
           },
@@ -3073,6 +3077,9 @@ export class AddEditExpensePage implements OnInit {
       this.isCorporateCreditCardEnabled = this.getCCCSettings(orgSettings);
 
       this.isNewReportsFlowEnabled = orgSettings?.simplified_report_closure_settings?.enabled || false;
+
+      this.isProjectEnabled = orgSettings?.projects.enabled || false;
+      this.isCostCenterEnabled = orgSettings?.cost_centers.enabled || false;
 
       this.isDraftExpenseEnabled =
         orgSettings.ccc_draft_expense_settings &&

--- a/src/app/fyle/split-expense/split-expense.page.html
+++ b/src/app/fyle/split-expense/split-expense.page.html
@@ -183,7 +183,7 @@
         </div>
 
         <div *ngIf="splitConfig.costCenter.is_visible || txnFields?.purpose" class="split-expense--main-block">
-          <div class="split-expense--internal-block" *ngIf="splitConfig.costCenter.is_visible">
+          <div *ngIf="splitConfig.costCenter.is_visible" class="split-expense--internal-block">
             <div *ngIf="costCenters$|async as costCenters">
               <app-fy-select
                 [label]="txnFields?.cost_center_id?.field_name"

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -63,8 +63,6 @@ export class SplitExpensePage implements OnDestroy {
 
   fg: FormGroup;
 
-  splitType = 'projects';
-
   splitConfig: SplitConfig;
 
   destroy$ = new Subject<void>();
@@ -128,8 +126,6 @@ export class SplitExpensePage implements OnDestroy {
   formattedSplitExpense: Transaction[];
 
   unspecifiedCategory: OrgCategory = null;
-
-  splitExpenseHeader: string;
 
   constructor(
     private activatedRoute: ActivatedRoute,

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -6,7 +6,17 @@ import { ModalController, NavController, PopoverController } from '@ionic/angula
 import { isEmpty, isNumber } from 'lodash';
 import * as dayjs from 'dayjs';
 import { combineLatest, forkJoin, from, iif, Observable, of, Subject, throwError } from 'rxjs';
-import { catchError, concatMap, finalize, map, shareReplay, startWith, switchMap, takeUntil } from 'rxjs/operators';
+import {
+  catchError,
+  concatMap,
+  finalize,
+  map,
+  shareReplay,
+  startWith,
+  switchMap,
+  takeUntil,
+  tap,
+} from 'rxjs/operators';
 import { CategoriesService } from 'src/app/core/services/categories.service';
 import { DateService } from 'src/app/core/services/date.service';
 import { SplitExpenseService } from 'src/app/core/services/split-expense.service';
@@ -63,7 +73,7 @@ export class SplitExpensePage implements OnDestroy {
 
   fg: FormGroup;
 
-  splitType: string;
+  splitType = 'projects';
 
   splitConfig: SplitConfig;
 
@@ -535,15 +545,23 @@ export class SplitExpensePage implements OnDestroy {
     this.trackingService.showToastMessage({ ToastContent: message });
   }
 
-  getViolationName(index: number): string {
+  generateInputFieldInfo(index: number): { [key: string]: string } {
     const splitExpenseFormValue = this.splitExpensesFormArray.at(index).value as SplitExpense;
-    if (this.splitType === 'projects') {
-      return splitExpenseFormValue.project.project_name;
-    } else if (this.splitType === 'cost centers') {
-      return splitExpenseFormValue.cost_center.name;
-    } else {
-      return splitExpenseFormValue.category.name;
+    const inputFieldInfo: { [key: string]: string } = {};
+
+    if (this.splitConfig.category.is_visible) {
+      inputFieldInfo.Category = splitExpenseFormValue.category.name;
     }
+
+    if (this.splitConfig.costCenter.is_visible) {
+      inputFieldInfo[this.txnFields?.cost_center_id?.field_name] = splitExpenseFormValue.cost_center.name;
+    }
+
+    if (this.splitConfig.project.is_visible) {
+      inputFieldInfo[this.txnFields?.project_id?.field_name] = splitExpenseFormValue.project.project_name;
+    }
+
+    return inputFieldInfo;
   }
 
   transformViolationData(etxns: Transaction[], violations: SplitExpensePolicy): { [id: number]: PolicyViolation } {
@@ -554,8 +572,7 @@ export class SplitExpensePage implements OnDestroy {
         if (violations.hasOwnProperty(key)) {
           violationData[index].amount = etxn.orig_amount || etxn.amount;
           violationData[index].currency = etxn.orig_currency || etxn.currency;
-          violationData[index].name = this.getViolationName(index);
-          violationData[index].type = this.splitType;
+          violationData[index].inputFieldInfo = this.generateInputFieldInfo(index);
           violationData[index].data = violations.data[index];
         }
       }
@@ -574,8 +591,6 @@ export class SplitExpensePage implements OnDestroy {
         if (mandatoryFields.hasOwnProperty(key)) {
           mandatoryFieldsData[index].amount = etxn.orig_amount || etxn.amount;
           mandatoryFieldsData[index].currency = etxn.orig_currency || etxn.currency;
-          mandatoryFieldsData[index].name = this.getViolationName(index);
-          mandatoryFieldsData[index].type = this.splitType;
           mandatoryFieldsData[index].data = mandatoryFields.data[index];
           break;
         }
@@ -725,7 +740,10 @@ export class SplitExpensePage implements OnDestroy {
                 return throwError(err);
               })
             )
-            .subscribe(() => this.showSuccessToast());
+            .subscribe(() => {
+              this.openReviewSplitExpenseModal(txns.data);
+              this.showSuccessToast();
+            });
         }
         this.openReviewSplitExpenseModal(txns.data);
         return this.showSuccessToast();
@@ -748,9 +766,8 @@ export class SplitExpensePage implements OnDestroy {
 
   getSplitExpensePoperties(): SplittingExpenseProperties {
     return {
-      Type: this.splitType,
-      'Is Evenly Split': this.isEvenlySplit(),
       Asset: 'Mobile',
+      'Is Evenly Split': this.isEvenlySplit(),
       'Is part of report': !!this.reportId,
       'Report ID': this.reportId || null,
       'Expense State': this.transaction.state,
@@ -1123,6 +1140,7 @@ export class SplitExpensePage implements OnDestroy {
     const categoryControl = splitForm.get('category').value as OrgCategory;
 
     if (!categoryControl) {
+      this.costCenterDisabledStates[index] = false;
       return;
     }
 

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -6,17 +6,7 @@ import { ModalController, NavController, PopoverController } from '@ionic/angula
 import { isEmpty, isNumber } from 'lodash';
 import * as dayjs from 'dayjs';
 import { combineLatest, forkJoin, from, iif, Observable, of, Subject, throwError } from 'rxjs';
-import {
-  catchError,
-  concatMap,
-  finalize,
-  map,
-  shareReplay,
-  startWith,
-  switchMap,
-  takeUntil,
-  tap,
-} from 'rxjs/operators';
+import { catchError, concatMap, finalize, map, shareReplay, startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { CategoriesService } from 'src/app/core/services/categories.service';
 import { DateService } from 'src/app/core/services/date.service';
 import { SplitExpenseService } from 'src/app/core/services/split-expense.service';
@@ -550,17 +540,16 @@ export class SplitExpensePage implements OnDestroy {
     const inputFieldInfo: { [key: string]: string } = {};
 
     if (this.splitConfig.category.is_visible) {
-      inputFieldInfo.Category = splitExpenseFormValue.category.name;
+      inputFieldInfo.Category = splitExpenseFormValue?.category.name || '-';
     }
 
     if (this.splitConfig.costCenter.is_visible) {
-      inputFieldInfo[this.txnFields?.cost_center_id?.field_name] = splitExpenseFormValue.cost_center.name;
+      inputFieldInfo[this.txnFields?.cost_center_id?.field_name] = splitExpenseFormValue?.cost_center?.name || '-';
     }
 
     if (this.splitConfig.project.is_visible) {
-      inputFieldInfo[this.txnFields?.project_id?.field_name] = splitExpenseFormValue.project.project_name;
+      inputFieldInfo[this.txnFields?.project_id?.field_name] = splitExpenseFormValue?.project.project_name || '-';
     }
-
     return inputFieldInfo;
   }
 
@@ -591,6 +580,7 @@ export class SplitExpensePage implements OnDestroy {
         if (mandatoryFields.hasOwnProperty(key)) {
           mandatoryFieldsData[index].amount = etxn.orig_amount || etxn.amount;
           mandatoryFieldsData[index].currency = etxn.orig_currency || etxn.currency;
+          mandatoryFieldsData[index].inputFieldInfo = this.generateInputFieldInfo(index);
           mandatoryFieldsData[index].data = mandatoryFields.data[index];
           break;
         }

--- a/src/app/shared/components/split-expense-policy-violation/split-expense-policy-violation.component.html
+++ b/src/app/shared/components/split-expense-policy-violation/split-expense-policy-violation.component.html
@@ -31,17 +31,17 @@
           </div>
           <div class="split-expense-policy-violation--sub-header-slot">
             <div class="split-expense-policy-violation--split-by-type-container">
-              @for (item of policyViolations[transaction].inputFieldInfo | keyvalue; track item.key) {
-              <div class="split-expense-policy-violation--placeholder">
-                {{ item.key | uppercase }} :
-                <span class="split-expense-policy-violation--value">
-                  {{ item.value }}
-                </span>
+              <div *ngIf="policyViolations[transaction]?.inputFieldInfo">
+                <div
+                  *ngFor="let input of policyViolations[transaction].inputFieldInfo | keyvalue"
+                  class="split-expense-policy-violation--placeholder"
+                >
+                  {{ input.key | uppercase }} :
+                  <span class="split-expense-policy-violation--value">{{ input.value }}</span>
+                </div>
               </div>
-              }
             </div>
             <div class="split-expense-policy-violation--policy-amount-container">
-              <div class="split-expense-policy-violation--placeholder">SPLIT AMOUNT</div>
               <div class="split-expense-policy-violation--value text-right">
                 {{
                   policyViolations[transaction].amount
@@ -122,13 +122,18 @@
           </div>
           <div class="split-expense-policy-violation--sub-header-slot">
             <div class="split-expense-policy-violation--split-by-type-container">
-              <div class="split-expense-policy-violation--placeholder">
-                {{ missingFieldsViolations[missingField].type | uppercase }}
+              <div *ngIf="missingFieldsViolations[missingField]?.inputFieldInfo">
+                <div
+                  *ngFor="let input of missingFieldsViolations[missingField].inputFieldInfo | keyvalue"
+                  class="split-expense-policy-violation--placeholder"
+                >
+                  {{ input.key | uppercase }} :
+                  <span class="split-expense-policy-violation--value">{{ input.value }}</span>
+                </div>
               </div>
               <div class="split-expense-policy-violation--value">{{ missingFieldsViolations[missingField].name }}</div>
             </div>
             <div class="split-expense-policy-violation--policy-amount-container">
-              <div class="split-expense-policy-violation--placeholder">SPLIT AMOUNT</div>
               <div class="split-expense-policy-violation--value text-right">
                 {{
                   missingFieldsViolations[missingField].amount

--- a/src/app/shared/components/split-expense-policy-violation/split-expense-policy-violation.component.html
+++ b/src/app/shared/components/split-expense-policy-violation/split-expense-policy-violation.component.html
@@ -31,10 +31,14 @@
           </div>
           <div class="split-expense-policy-violation--sub-header-slot">
             <div class="split-expense-policy-violation--split-by-type-container">
+              @for (item of policyViolations[transaction].inputFieldInfo | keyvalue; track item.key) {
               <div class="split-expense-policy-violation--placeholder">
-                {{ policyViolations[transaction].type | uppercase }}
+                {{ item.key | uppercase }} :
+                <span class="split-expense-policy-violation--value">
+                  {{ item.value }}
+                </span>
               </div>
-              <div class="split-expense-policy-violation--value">{{ policyViolations[transaction].name }}</div>
+              }
             </div>
             <div class="split-expense-policy-violation--policy-amount-container">
               <div class="split-expense-policy-violation--placeholder">SPLIT AMOUNT</div>

--- a/src/app/shared/components/split-expense-policy-violation/split-expense-policy-violation.component.scss
+++ b/src/app/shared/components/split-expense-policy-violation/split-expense-policy-violation.component.scss
@@ -25,11 +25,12 @@
     font-size: 12px;
     line-height: 14px;
     color: $grey-light;
+    margin-bottom: 6px;
   }
 
   &--value {
-    margin-top: 2px;
     font-weight: 500;
+    color: $grey-light-2;
   }
 
   &--content-container {


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cy3fapq

## Description

**This PR covers** 
- the new updated UI showing all 3 dimensions (Project, cost center, category) inside the policy violation modal
- adding the condition of showing project and cost center if enabled in orgsettings inside add-edit expense page ( For sending it by `splitConfig` through router URL to split expense page
- removing unused variable `splitType` & `splitExpenseHeader`


## UI Preview
<img width="460" alt="Screenshot 2025-02-26 at 1 21 52 AM" src="https://github.com/user-attachments/assets/10ba6281-385a-4fb0-a875-d19b1ccd79b5" />



<!-- end of auto-generated comment: release notes by coderabbit.ai -->