### PR TITLE
fix: amount error msg and autocoded msg alignment

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.scss
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.scss
@@ -643,7 +643,7 @@
   &--amount-error {
     color: $red;
     font-size: 12px;
-    margin: -8px 0 0 33%;
+    margin: -14px 0 0 53%;
   }
 
   &--orig-amount-error {


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cy42zpp

## UI Preview
<img width="473" alt="Screenshot 2025-02-27 at 10 32 21 AM" src="https://github.com/user-attachments/assets/fe1e8182-ef72-4c8c-ae97-b4ec901e2d83" />
<img width="473" alt="Screenshot 2025-02-27 at 10 33 19 AM" src="https://github.com/user-attachments/assets/1e8b8116-6567-4a97-b169-91340e4375b1" />
<img width="473" alt="Screenshot 2025-02-27 at 10 33 53 AM" src="https://github.com/user-attachments/assets/33f2dd69-1d52-43d1-9622-2d5582c57559" />
<img width="473" alt="Screenshot 2025-02-27 at 10 34 17 AM" src="https://github.com/user-attachments/assets/55b3f310-8eb7-4d89-ab62-592ad6ed5b61" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the error message positioning on the expense form for improved visual clarity and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->