### PR TITLE
fix: currency amount spacing issue in cc stats

### DIFF
--- a/src/app/shared/components/spent-cards/card-detail/card-detail.component.html
+++ b/src/app/shared/components/spent-cards/card-detail/card-detail.component.html
@@ -22,24 +22,21 @@
           {{ cardDetail.stats.totalDraftTxns }}
         </div>
         <div class="stats--ccc-classified-amount">
-          <span class="stats--expenses-amount-currency">
-            {{ currencySymbol }}
-          </span>
-          <ng-container
+          {{ currencySymbol
+          }}<ng-container
             *ngIf="
               !isSmallScreen &&
                 cardDetail.stats.totalDraftValue > -1000000000 &&
                 cardDetail.stats.totalDraftValue < 1000000000;
               else humanizeDraftAmount
             "
-          >
-            {{
+            >{{
               { value: cardDetail.stats.totalDraftValue, currencyCode: homeCurrency, skipSymbol: true } | exactCurrency
-            }}
-          </ng-container>
-          <ng-template #humanizeDraftAmount>
-            {{ cardDetail.stats.totalDraftValue | humanizeCurrency : homeCurrency : true }}
-          </ng-template>
+            }}</ng-container
+          >
+          <ng-template #humanizeDraftAmount>{{
+            cardDetail.stats.totalDraftValue | humanizeCurrency : homeCurrency : true
+          }}</ng-template>
         </div>
       </div>
       <div class="stats--ccc-stats-title">
@@ -54,25 +51,22 @@
           {{ cardDetail.stats.totalCompleteTxns }}
         </div>
         <div class="stats--ccc-classified-amount">
-          <span class="stats--expenses-amount-currency">
-            {{ currencySymbol }}
-          </span>
-          <ng-container
+          {{ currencySymbol
+          }}<ng-container
             *ngIf="
               !isSmallScreen &&
                 cardDetail.stats.totalCompleteExpensesValue > -1000000000 &&
                 cardDetail.stats.totalCompleteExpensesValue < 1000000000;
               else humanizeTotalAmount
             "
-          >
-            {{
+            >{{
               { value: cardDetail.stats.totalCompleteExpensesValue, currencyCode: homeCurrency, skipSymbol: true }
                 | exactCurrency
-            }}
-          </ng-container>
-          <ng-template #humanizeTotalAmount>
-            {{ cardDetail.stats.totalCompleteExpensesValue | humanizeCurrency : homeCurrency : true }}
-          </ng-template>
+            }}</ng-container
+          >
+          <ng-template #humanizeTotalAmount>{{
+            cardDetail.stats.totalCompleteExpensesValue | humanizeCurrency : homeCurrency : true
+          }}</ng-template>
         </div>
       </div>
       <div class="stats--ccc-stats-title">


### PR DESCRIPTION
## Clickup
[link](https://app.clickup.com/)

## UI Preview
Before
<img width="384" alt="Screenshot 2025-03-05 at 12 02 01 PM" src="https://github.com/user-attachments/assets/69511d3e-f7bd-49b3-8ace-078e725014fd" />

After
<img width="511" alt="Screenshot 2025-03-05 at 12 11 18 PM" src="https://github.com/user-attachments/assets/fb27a789-aabe-4e0b-9da9-87af5a310f03" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - The card details view now features an updated currency display, with symbols rendered directly inline with monetary amounts for improved clarity.
  - The refined layout and adjusted formatting provide a cleaner, more consistent presentation, ensuring that financial details are both easy to read and visually balanced.
  - These enhancements contribute to a more intuitive and engaging user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->