### PR TITLE
fix: design fix for split exp page

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -31,7 +31,7 @@
       </div>
     </ion-title>
 
-    <ion-buttons class="add-edit-expense--header-btn-container" slot="end">
+    <ion-buttons *ngIf="!fromSplitExpenseReview" class="add-edit-expense--header-btn-container" slot="end">
       <ion-button
         *ngIf="reviewList?.length || mode === 'edit'"
         class="add-edit-expense--header-btn-container__btn"

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -338,6 +338,8 @@ export class AddEditExpensePage implements OnInit {
 
   navigateBack = false;
 
+  fromSplitExpenseReview = false;
+
   isExpenseBankTxn = false;
 
   recentCategories: OrgCategoryListItem[];
@@ -3034,6 +3036,7 @@ export class AddEditExpensePage implements OnInit {
     });
 
     this.navigateBack = this.activatedRoute.snapshot.params.navigate_back as boolean;
+    this.fromSplitExpenseReview = this.activatedRoute.snapshot.params.fromSplitExpenseReview as boolean;
     this.expenseStartTime = new Date().getTime();
     this.fg = this.formBuilder.group({
       currencyObj: [, this.currencyObjValidator],

--- a/src/app/fyle/split-expense/split-expense.page.html
+++ b/src/app/fyle/split-expense/split-expense.page.html
@@ -283,12 +283,12 @@
       (click)="add()"
     >
       <mat-icon class="split-expense--add-more-icon" svgIcon="plus-square"></mat-icon>
-      <div class="split-expense--add-more-label">Add Split</div>
+      <div class="split-expense--add-more-label">Add split</div>
     </button>
 
     <button class="btn-outline-secondary split-expense--split-evenly" (click)="splitEvenly()">
       <mat-icon class="split-expense--split-evenly-icon" svgIcon="split"></mat-icon>
-      <div class="split-expense--split-evenly-label">Split Evenly</div>
+      <div class="split-expense--split-evenly-label">Split evenly</div>
     </button>
   </div>
 </ion-footer>

--- a/src/app/fyle/split-expense/split-expense.page.html
+++ b/src/app/fyle/split-expense/split-expense.page.html
@@ -38,11 +38,15 @@
     </div>
     <div class="split-expense--amount-block__label">
       Total amount
-      <div class="split-expense--split-amount">{{ currency }} {{totalSplitAmount}}</div>
+      <div class="split-expense--split-amount">
+        {{ { value: totalSplitAmount, currencyCode: currency } | exactCurrency }}
+      </div>
     </div>
     <div class="split-expense--amount-block__label split-expense--remaining-amount">
       Remaining amount
-      <div class="split-expense--split-amount">{{ currency }} {{remainingAmount }}</div>
+      <div class="split-expense--split-amount">
+        {{ { value: remainingAmount, currencyCode: currency } | exactCurrency }}
+      </div>
     </div>
   </div>
   <div *ngIf="splitExpensesFormArray.controls.length === 30" class="split-expense--error-message-block">

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -703,7 +703,7 @@ describe('SplitExpensePage', () => {
   it('toastWithoutCTA(): should display the toast without CTA', () => {
     const message = 'Your expense was split successfully. All the split expenses were added to the report';
     const toastType = ToastType.SUCCESS;
-    const panelClassData = 'msb-success-with-camera-icon';
+    const panelClassData = 'msb-success-with-camera-icon-for-split-exp';
     component.toastWithoutCTA(message, toastType, panelClassData);
     expect(matSnackBar.openFromComponent).toHaveBeenCalledOnceWith(ToastMessageComponent, {
       ...snackbarProperties.setSnackbarProperties(toastType, { message }),
@@ -723,7 +723,7 @@ describe('SplitExpensePage', () => {
       expect(component.toastWithoutCTA).toHaveBeenCalledOnceWith(
         toastMessage,
         ToastType.SUCCESS,
-        'msb-success-with-camera-icon'
+        'msb-success-with-camera-icon-for-split-exp'
       );
     });
   });
@@ -2638,7 +2638,7 @@ describe('SplitExpensePage', () => {
         expect(component.toastWithoutCTA).toHaveBeenCalledOnceWith(
           'We were unable to split your expense. Please try again later.',
           ToastType.FAILURE,
-          'msb-failure-with-camera-icon'
+          'msb-failure-with-camera-icon-for-split-exp'
         );
         expect(trackingService.splittingExpense).toHaveBeenCalledOnceWith({
           Asset: 'Mobile',
@@ -2711,7 +2711,7 @@ describe('SplitExpensePage', () => {
         expect(component.toastWithoutCTA).toHaveBeenCalledOnceWith(
           'We were unable to split your expense. Please try again later.',
           ToastType.FAILURE,
-          'msb-failure-with-camera-icon'
+          'msb-failure-with-camera-icon-for-split-exp'
         );
         expect(splitExpenseService.postSplitExpenseComments).not.toHaveBeenCalled();
         expect(component.showSuccessToast).not.toHaveBeenCalled();
@@ -2732,7 +2732,7 @@ describe('SplitExpensePage', () => {
         expect(component.toastWithoutCTA).toHaveBeenCalledOnceWith(
           'We were unable to split your expense. Please try again later.',
           ToastType.FAILURE,
-          'msb-failure-with-camera-icon'
+          'msb-failure-with-camera-icon-for-split-exp'
         );
         expect(component.showSuccessToast).not.toHaveBeenCalled();
       }

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -604,7 +604,7 @@ export class SplitExpensePage implements OnDestroy {
   showSuccessToast(): void {
     this.saveSplitExpenseLoading = false;
     const toastMessage = 'Expense split successfully.';
-    this.toastWithoutCTA(toastMessage, ToastType.SUCCESS, 'msb-success-with-camera-icon');
+    this.toastWithoutCTA(toastMessage, ToastType.SUCCESS, 'msb-success-with-camera-icon-for-split-exp');
   }
 
   getAttachedFiles(expenseId: string): Observable<Partial<PlatformFile>[]> {
@@ -720,7 +720,7 @@ export class SplitExpensePage implements OnDestroy {
           this.trackingService.splitExpensePolicyCheckFailed(splitTrackingProps);
 
           const message = 'We were unable to split your expense. Please try again later.';
-          this.toastWithoutCTA(message, ToastType.FAILURE, 'msb-failure-with-camera-icon');
+          this.toastWithoutCTA(message, ToastType.FAILURE, 'msb-failure-with-camera-icon-for-split-exp');
           this.router.navigate(['/', 'enterprise', 'my_expenses']);
           return throwError(errResponse);
         })
@@ -737,7 +737,7 @@ export class SplitExpensePage implements OnDestroy {
             .pipe(
               catchError((err) => {
                 const message = 'We were unable to split your expense. Please try again later.';
-                this.toastWithoutCTA(message, ToastType.FAILURE, 'msb-failure-with-camera-icon');
+                this.toastWithoutCTA(message, ToastType.FAILURE, 'msb-failure-with-camera-icon-for-split-exp');
                 this.router.navigate(['/', 'enterprise', 'my_expenses']);
                 return throwError(err);
               })
@@ -845,7 +845,7 @@ export class SplitExpensePage implements OnDestroy {
               this.trackingService.splitExpensePolicyCheckFailed(splitTrackingProps);
 
               const message = 'We were unable to split your expense. Please try again later.';
-              this.toastWithoutCTA(message, ToastType.FAILURE, 'msb-failure-with-camera-icon');
+              this.toastWithoutCTA(message, ToastType.FAILURE, 'msb-failure-with-camera-icon-for-split-exp');
               return throwError(errResponse);
             }),
             finalize(() => {

--- a/src/app/shared/components/split-expense-policy-violation/split-expense-policy-violation.component.html
+++ b/src/app/shared/components/split-expense-policy-violation/split-expense-policy-violation.component.html
@@ -8,6 +8,10 @@
 </ion-header>
 
 <ion-content>
+  <div *ngIf="isSplitBlocked" class="split-expense-policy-violation--header-msg">
+    <span>Expense cannot be split as it violates policies.</span>
+    <span>Resolve the violations before splitting.</span>
+  </div>
   <ng-container *ngIf="policyViolations && transactionIDs" class="policy-violation--body">
     <ng-container *ngFor="let transaction of transactionIDs; let i = index">
       <div *ngIf="policyViolations[transaction]?.rules?.length > 0" class="split-expense-policy-violation--accordion">
@@ -36,7 +40,7 @@
                   *ngFor="let input of policyViolations[transaction].inputFieldInfo | keyvalue"
                   class="split-expense-policy-violation--placeholder"
                 >
-                  {{ input.key | uppercase }} :
+                  {{ input.key }} :
                   <span class="split-expense-policy-violation--value">{{ input.value }}</span>
                 </div>
               </div>
@@ -69,17 +73,18 @@
                         <div>
                           <p class="split-expense-policy-violation--additional-details-header">
                             Please provide additional details for approval
-                            <span class="split-expense-policy-violation--additional-details-comment-length">
-                              {{ form.value.comments[i].comment.length }}
-                            </span>
                           </p>
                         </div>
                         <textarea
+                          #comment
                           maxlength="500"
                           class="split-expense-policy-violation--textarea"
                           formControlName="comment"
                           placeholder="Enter the details here"
                         ></textarea>
+                        <div class="split-expense-policy-violation--additional-details-comment-length">
+                          {{ form.value.comments[i].comment.length }} / {{ comment.maxLength }}
+                        </div>
                       </div>
                     </div>
                   </form>
@@ -127,7 +132,7 @@
                   *ngFor="let input of missingFieldsViolations[missingField].inputFieldInfo | keyvalue"
                   class="split-expense-policy-violation--placeholder"
                 >
-                  {{ input.key | uppercase }} :
+                  {{ input.key }} :
                   <span class="split-expense-policy-violation--value">{{ input.value }}</span>
                 </div>
               </div>
@@ -167,12 +172,12 @@
 <ion-footer>
   <ion-toolbar mode="md">
     <div *ngIf="!isSplitBlocked" class="fy-footer-cta-container">
-      <ion-button class="fy-footer-cta fy-footer-cta--tertiary-secondary" (click)="cancel()"> Cancel </ion-button>
+      <ion-button class="fy-footer-cta fy-footer-cta--outline-secondary" (click)="cancel()"> Cancel </ion-button>
       <ion-button class="fy-footer-cta fy-footer-cta--primary" (click)="continue()"> Continue </ion-button>
     </div>
 
     <div *ngIf="isSplitBlocked" class="fy-footer-cta-container">
-      <ion-button class="fy-footer-cta fy-footer-cta--primary" (click)="cancel()"> Okay </ion-button>
+      <ion-button class="fy-footer-cta fy-footer-cta--primary" (click)="cancel()"> Got it </ion-button>
     </div>
   </ion-toolbar>
 </ion-footer>

--- a/src/app/shared/components/split-expense-policy-violation/split-expense-policy-violation.component.scss
+++ b/src/app/shared/components/split-expense-policy-violation/split-expense-policy-violation.component.scss
@@ -2,9 +2,10 @@
 
 .split-expense-policy-violation {
   &--accordion {
-    padding: 8px;
-    border-bottom: 1px solid $lavender;
-    margin-bottom: 8px;
+    padding: 14px 4px 4px 4px;
+    margin: 12px;
+    border: 1px solid $border-tertiary;
+    border-radius: 8px;
   }
 
   &--header-slot {
@@ -12,6 +13,14 @@
     align-items: center;
     justify-content: space-between;
     padding: 0px 10px;
+  }
+
+  &--header-msg {
+    margin: 0 12px;
+    padding-top: 12px;
+    span {
+      display: block;
+    }
   }
 
   &--sub-header-slot {
@@ -69,9 +78,10 @@
   }
 
   &--additional-details-comment-length {
-    float: right;
+    text-align: right;
     color: $text-button-grey;
     font-size: 12px;
+    margin-right: 14px;
   }
 
   &--disabled {

--- a/src/global.scss
+++ b/src/global.scss
@@ -913,6 +913,13 @@ ref - https://stackoverflow.com/a/31162426
     --background: transparent;
     --color: #{$black-light};
   }
+
+  &--outline-secondary {
+    --background: transparent;
+    --color: #{$black-light};
+    border: 1px solid #{$grey};
+    border-radius: 4px;
+  }
 }
 
 .footer-ios ion-toolbar:first-of-type {

--- a/src/global.scss
+++ b/src/global.scss
@@ -146,6 +146,22 @@ ion-popover.error-popover {
   padding: 12px 8px !important;
 }
 
+.msb-success-with-camera-icon-for-split-exp {
+  color: $pure-white;
+  background-color: $green;
+  border-radius: 8px !important;
+  margin: 0 16px 24px !important;
+  padding: 12px 8px !important;
+}
+
+.msb-failure-with-camera-icon-for-split-exp {
+  color: $pure-white;
+  background-color: $red;
+  border-radius: 8px !important;
+  margin: 0 16px 24px !important;
+  padding: 12px 8px !important;
+}
+
 .msb-failure-with-camera-icon {
   color: $pure-white;
   background-color: $red;


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cxubdgc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Header actions on the Add/Edit Expense page now display conditionally based on navigation context.
  - The Split Expense page now presents total and remaining amounts using an enhanced currency formatter.

- **Style**
  - Split expense notifications have been visually refined, with distinct styles for success and failure alerts for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->