### PR TITLE
fix: using absolute tax and expense amount for greater amount comparison

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -2869,7 +2869,7 @@ export class AddEditExpensePage implements OnInit {
         return null;
       }
 
-      const isAmountGreaterThanTaxAmount = this.getAmount() > control.value;
+      const isAmountGreaterThanTaxAmount = Math.abs(this.getAmount()) > Math.abs(control.value as number);
       return isAmountGreaterThanTaxAmount ? null : { taxAmountGreaterThanAmount: true };
     };
   }


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cy5yrv3

fyle-app PR: https://github.com/fylein/fyle-app/pull/10620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced expense validations to accurately compare amounts regardless of sign, ensuring more consistent handling of tax values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->