### PR TITLE
fix: cost center visibility updatation on category change inside add-edit exp page

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -2690,7 +2690,7 @@ export class AddEditExpensePage implements OnInit {
       } else {
         categoryControl.clearValidators();
       }
-      categoryControl.updateValueAndValidity();
+      categoryControl.updateValueAndValidity({ emitEvent: false });
     });
   }
 


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cxubfep

Why this change:

- Encountered a RangeError: Maximum call stack size exceeded.
- This issue occurred because the subscription was being called in a recursive loop. Changing the project triggered category validation, but changing the category did not properly update the cost center's visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined the expense form’s validation process to prevent unnecessary update triggers, ensuring a smoother and more consistent user experience when managing expenses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->