### PR TITLE
fix: show correct msg for disabled category

### DIFF
--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -1657,11 +1657,11 @@ describe('SplitExpensePage', () => {
     beforeEach(() => {
       spyOn(component, 'showPopoverModal').and.callThrough();
       component.splitConfig = cloneDeep(splitConfig);
-      component.disableMessage = 'No category is assigned. Please contact admin for further help.';
+      component.categoryDisableMsg = 'No category is assigned. Please contact admin for further help.';
     });
 
     it('should show correct message for category type when msg is empty', () => {
-      component.disableMessage = '';
+      component.categoryDisableMsg = '';
       component.showDisabledMessage('category');
       expect(component.showPopoverModal).toHaveBeenCalledWith('No category is available for the selected project.');
     });

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -1107,8 +1107,7 @@ describe('SplitExpensePage', () => {
       component.splitExpensesFormArray = new UntypedFormArray([splitExpenseForm1, splitExpenseForm2]);
     });
 
-    it('should set the category field mandatory value to false when project is not visible and categories are not present', () => {
-      component.splitConfig.project.is_visible = false;
+    it('should set the category field mandatory value to false when categories are not present ', () => {
       component.splitConfig.category.is_mandatory = true;
 
       spyOn(component.splitExpensesFormArray.at(0), 'get').and.returnValue(formControlSpy);
@@ -1120,20 +1119,6 @@ describe('SplitExpensePage', () => {
 
       expect(formControlSpy.clearValidators).toHaveBeenCalled();
       expect(formControlSpy.updateValueAndValidity).toHaveBeenCalled();
-    });
-
-    it('should not change category field mandatory value when project is visible', () => {
-      component.splitConfig.project.is_visible = true;
-      component.splitConfig.category.is_mandatory = true;
-
-      spyOn(component.splitExpensesFormArray.at(0), 'get').and.returnValue(formControlSpy);
-      spyOn(component.splitExpensesFormArray.at(1), 'get').and.returnValue(formControlSpy);
-
-      component.updateCategoryMandatoryStatus([]);
-
-      expect(component.splitConfig.category.is_mandatory).toBeTrue();
-      expect(formControlSpy.clearValidators).not.toHaveBeenCalled();
-      expect(formControlSpy.updateValueAndValidity).not.toHaveBeenCalled();
     });
 
     it('should not change category field mandatory value when categories are available', () => {
@@ -1151,7 +1136,6 @@ describe('SplitExpensePage', () => {
     });
 
     it('should not change category field mandatory value when the category field mandatory value is already false', () => {
-      component.splitConfig.project.is_visible = false;
       component.splitConfig.category.is_mandatory = false;
 
       spyOn(component.splitExpensesFormArray.at(0), 'get').and.returnValue(formControlSpy);
@@ -1164,8 +1148,7 @@ describe('SplitExpensePage', () => {
       expect(formControlSpy.updateValueAndValidity).not.toHaveBeenCalled();
     });
 
-    it('should initially clear category field required validator for the first 2 splits if cateogy is mandatory and project is not visible and there are no categories available', () => {
-      component.splitConfig.project.is_visible = false;
+    it('should initially clear category field required validator for the first 2 splits if cateogy is mandatory and there are no categories available', () => {
       component.splitConfig.category.is_mandatory = true;
 
       const splitExpenseForm1 = new UntypedFormGroup({
@@ -1674,15 +1657,16 @@ describe('SplitExpensePage', () => {
     beforeEach(() => {
       spyOn(component, 'showPopoverModal').and.callThrough();
       component.splitConfig = cloneDeep(splitConfig);
+      component.disableMessage = 'No category is assigned. Please contact admin for further help.';
     });
 
-    it('should show correct message for category type', () => {
+    it('should show correct message for category type when msg is empty', () => {
+      component.disableMessage = '';
       component.showDisabledMessage('category');
       expect(component.showPopoverModal).toHaveBeenCalledWith('No category is available for the selected project.');
     });
 
-    it('should show correct message when type is category and project is not enabled', () => {
-      component.splitConfig.project.is_visible = false;
+    it('should show correct message when type is category and msg is not empty', () => {
       component.showDisabledMessage('category');
       expect(component.showPopoverModal).toHaveBeenCalledWith(
         'No category is assigned. Please contact admin for further help.'

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -144,6 +144,8 @@ export class SplitExpensePage implements OnDestroy {
 
   isReviewModalOpen = false;
 
+  disableMessage = '';
+
   private splitExpenseData: Subscription;
 
   constructor(
@@ -1028,14 +1030,17 @@ export class SplitExpensePage implements OnDestroy {
   }
 
   updateCategoryMandatoryStatus(categories: OrgCategory[]): void {
-    if (!this.splitConfig.project.is_visible && categories.length === 0 && this.splitConfig.category.is_mandatory) {
-      this.splitConfig.category.is_mandatory = false;
-      for (let i = 0; i < 2; i++) {
-        const control = this.splitExpensesFormArray.at(i);
-        const categoryControl = control?.get('category');
-        if (categoryControl) {
-          categoryControl.clearValidators();
-          categoryControl.updateValueAndValidity();
+    if (categories.length === 0) {
+      this.disableMessage = 'No category is assigned. Please contact admin for further help.';
+      if (this.splitConfig.category.is_mandatory) {
+        this.splitConfig.category.is_mandatory = false;
+        for (let i = 0; i < 2; i++) {
+          const control = this.splitExpensesFormArray.at(i);
+          const categoryControl = control?.get('category');
+          if (categoryControl) {
+            categoryControl.clearValidators();
+            categoryControl.updateValueAndValidity();
+          }
         }
       }
     }
@@ -1412,13 +1417,11 @@ export class SplitExpensePage implements OnDestroy {
   }
 
   showDisabledMessage(type: string): void {
-    let msg = '';
-    if (type === 'category') {
+    let msg = this.disableMessage;
+    if (type === 'category' && !msg) {
       msg = 'No category is available for the selected project.';
-      if (!this.splitConfig.project.is_visible) {
-        msg = 'No category is assigned. Please contact admin for further help.';
-      }
-    } else {
+    }
+    if (type === 'cost center') {
       msg = 'No cost center is available for the selected category.';
     }
     this.showPopoverModal(msg);

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -144,7 +144,7 @@ export class SplitExpensePage implements OnDestroy {
 
   isReviewModalOpen = false;
 
-  disableMessage = '';
+  categoryDisableMsg = '';
 
   private splitExpenseData: Subscription;
 
@@ -1031,7 +1031,7 @@ export class SplitExpensePage implements OnDestroy {
 
   updateCategoryMandatoryStatus(categories: OrgCategory[]): void {
     if (categories.length === 0) {
-      this.disableMessage = 'No category is assigned. Please contact admin for further help.';
+      this.categoryDisableMsg = 'No category is assigned. Please contact admin for further help.';
       if (this.splitConfig.category.is_mandatory) {
         this.splitConfig.category.is_mandatory = false;
         for (let i = 0; i < 2; i++) {
@@ -1417,7 +1417,7 @@ export class SplitExpensePage implements OnDestroy {
   }
 
   showDisabledMessage(type: string): void {
-    let msg = this.disableMessage;
+    let msg = this.categoryDisableMsg;
     if (type === 'category' && !msg) {
       msg = 'No category is available for the selected project.';
     }


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cxubfep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The expense splitting screen now displays clearer, more helpful messages when category or cost center options aren’t available, guiding users on what to do next.
  - Introduced a new message property to provide feedback when no category is assigned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->