### PR TITLE
feat: make billable optional for mileage and per-diem exp

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -2390,11 +2390,10 @@ export class AddEditExpensePage implements OnInit {
             } else if (
               defaultValueColumn === 'billable' &&
               this.fg.controls.project.value &&
-              this.showBillable &&
               (control.value === null || control.value === undefined) &&
               !control.touched
             ) {
-              control.patchValue(defaultValues[defaultValueColumn]);
+              control.patchValue(this.showBillable ? defaultValues[defaultValueColumn] : false);
             } else if (
               defaultValueColumn === 'tax_group_id' &&
               !control.value &&

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
@@ -379,7 +379,7 @@
                 </ng-container>
 
                 <div
-                  *ngIf="(isProjectsEnabled$|async) && (((isIndividualProjectsEnabled$|async) && (individualProjectIds$|async)?.length > 0) || !(isIndividualProjectsEnabled$|async))"
+                  *ngIf="showBillable && (isProjectsEnabled$|async) && (((isIndividualProjectsEnabled$|async) && (individualProjectIds$|async)?.length > 0) || !(isIndividualProjectsEnabled$|async))"
                 >
                   <div *ngIf="fg.controls.project.value">
                     <mat-checkbox formControlName="billable">

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
@@ -381,7 +381,7 @@
                 <div
                   *ngIf="showBillable && (isProjectsEnabled$|async) && (((isIndividualProjectsEnabled$|async) && (individualProjectIds$|async)?.length > 0) || !(isIndividualProjectsEnabled$|async))"
                 >
-                  <div *ngIf="fg.controls.project.value">
+                  <div *ngIf="fg.controls.project.value" class="add-edit-mileage--billable-block">
                     <mat-checkbox formControlName="billable">
                       <span class="add-edit-mileage--checkbox"> Billable </span>
                     </mat-checkbox>

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.scss
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.scss
@@ -170,7 +170,10 @@
 
   &--project-block {
     flex-grow: 1;
-    margin-right: 26px;
+  }
+
+  &--billable-block {
+    margin-left: 26px;
   }
 
   &--primary-block {

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -218,6 +218,8 @@ export class AddEditMileagePage implements OnInit {
 
   saveAndPrevMileageLoader = false;
 
+  showBillable = false;
+
   clusterDomain: string;
 
   recentlyUsedValues$: Observable<RecentlyUsed>;
@@ -468,7 +470,7 @@ export class AddEditMileagePage implements OnInit {
         if (!this.fg.controls.project.value) {
           this.fg.patchValue({ billable: false });
         } else {
-          this.fg.patchValue({ billable: this.billableDefaultValue });
+          this.fg.patchValue({ billable: this.showBillable ? this.billableDefaultValue : false });
         }
       }),
       startWith(this.fg.controls.project.value),
@@ -564,6 +566,7 @@ export class AddEditMileagePage implements OnInit {
       ),
       map((expenseFieldsMap: Partial<ExpenseFieldsObj>) => {
         if (expenseFieldsMap) {
+          this.showBillable = expenseFieldsMap.billable?.is_enabled;
           for (const tfc of Object.keys(expenseFieldsMap)) {
             const expenseField = expenseFieldsMap[tfc] as ExpenseField;
             const options = expenseField.options as string[];
@@ -626,7 +629,7 @@ export class AddEditMileagePage implements OnInit {
             defaultValueColumn === 'billable' &&
             (control.value === null || control.value === undefined)
           ) {
-            control.patchValue(defaultValues[defaultValueColumn]);
+            control.patchValue(this.showBillable ? defaultValues[defaultValueColumn] : false);
           }
         }
       }

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem-1.page.spec.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem-1.page.spec.ts
@@ -654,6 +654,7 @@ export function TestCases1(getTestBed) {
     it('setupTfcDefaultValues(): should update the form with default expense field values if some fields are empty', () => {
       const fields = ['purpose', 'cost_center_id', 'from_dt', 'to_dt', 'num_days', 'billable'];
       const mockTxnFieldData = cloneDeep(txnFieldsData2);
+      component.showBillable = true;
       expenseFieldsService.getAllMap.and.returnValue(of(expenseFieldsMapResponse));
       spyOn(component, 'getPerDiemCategories').and.returnValue(
         of({

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
@@ -352,7 +352,7 @@
                       </ng-container>
 
                       <div
-                        *ngIf="(isProjectsEnabled$|async) && (((isIndividualProjectsEnabled$|async) && (individualProjectIds$|async)?.length > 0) || !(isIndividualProjectsEnabled$|async))"
+                        *ngIf="showBillable && (isProjectsEnabled$|async) && (((isIndividualProjectsEnabled$|async) && (individualProjectIds$|async)?.length > 0) || !(isIndividualProjectsEnabled$|async))"
                       >
                         <div *ngIf="fg.controls.project.value" class="add-edit-per-diem--internal-block">
                           <mat-checkbox formControlName="billable">

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
@@ -354,7 +354,10 @@
                       <div
                         *ngIf="showBillable && (isProjectsEnabled$|async) && (((isIndividualProjectsEnabled$|async) && (individualProjectIds$|async)?.length > 0) || !(isIndividualProjectsEnabled$|async))"
                       >
-                        <div *ngIf="fg.controls.project.value" class="add-edit-per-diem--internal-block">
+                        <div
+                          *ngIf="fg.controls.project.value"
+                          class="add-edit-per-diem--internal-block add-edit-per-diem--billable-block"
+                        >
                           <mat-checkbox formControlName="billable">
                             <span class="add-edit-per-diem--checkbox"> Billable </span>
                           </mat-checkbox>

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.scss
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.scss
@@ -220,7 +220,10 @@
 
   &--project-block {
     flex-grow: 1;
-    margin-right: 26px;
+  }
+
+  &--billable-block {
+    margin-left: 26px;
   }
 
   &--date-container {

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -235,6 +235,8 @@ export class AddEditPerDiemPage implements OnInit {
 
   billableDefaultValue: boolean;
 
+  showBillable = false;
+
   isRedirectedFromReport = false;
 
   canRemoveFromReport = false;
@@ -531,6 +533,7 @@ export class AddEditPerDiemPage implements OnInit {
       ),
       map((expenseFieldsMap) => {
         if (expenseFieldsMap) {
+          this.showBillable = expenseFieldsMap.billable?.is_enabled;
           for (const tfc of Object.keys(expenseFieldsMap)) {
             const expenseField = expenseFieldsMap[tfc] as ExpenseField;
             const options = expenseField.options as string[];
@@ -589,7 +592,7 @@ export class AddEditPerDiemPage implements OnInit {
             (control.value === undefined || control.value === null) &&
             !control.touched
           ) {
-            control.patchValue(defaultValues[defaultValueColumn]);
+            control.patchValue(this.showBillable ? defaultValues[defaultValueColumn] : false);
           }
         }
       }
@@ -724,7 +727,7 @@ export class AddEditPerDiemPage implements OnInit {
         if (!this.fg.controls.project.value) {
           this.fg.patchValue({ billable: false });
         } else {
-          this.fg.patchValue({ billable: this.billableDefaultValue });
+          this.fg.patchValue({ billable: this.showBillable ? this.billableDefaultValue : false });
         }
       }),
       startWith(this.fg.controls.project.value),


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cybnaxk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of the billable option in expense, mileage, and per diem forms. The default value is now automatically set to false when the option isn’t relevant, ensuring more consistent behavior.

- **New Features**
  - Enhanced the conditions for displaying the billable checkbox in mileage and per diem views, ensuring it appears only when applicable based on your project settings.
  - Introduced a new layout for billable-related elements in mileage and per diem forms, improving the overall user interface.
  - Added a new boolean property `showBillable` to control the visibility of billable options across forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->