### PR TITLE
fix: Add approval filter to restrict secondary approvers from seeing unapproved reports

### DIFF
--- a/src/app/core/mock-data/api-params.data.ts
+++ b/src/app/core/mock-data/api-params.data.ts
@@ -7,6 +7,7 @@ export const getTeamReportsParams1: ReportApiParams = deepFreeze({
   limit: 10,
   state: 'in.(APPROVER_PENDING)',
   next_approver_user_ids: 'cs.[usvKA4X8Ugcr]',
+  or: '',
   order: 'created_at.desc,id.desc',
 });
 
@@ -15,5 +16,6 @@ export const getTeamReportsParams2: ReportApiParams = deepFreeze({
   limit: 10,
   state: 'in.(APPROVER_PENDING)',
   next_approver_user_ids: 'cs.[usvKA4X8Ugcr]',
+  or: '',
   order: 'created_at.desc,id.desc',
 });

--- a/src/app/core/models/get-tasks-query-params-with-filters.model.ts
+++ b/src/app/core/models/get-tasks-query-params-with-filters.model.ts
@@ -6,4 +6,5 @@ export interface GetTasksQueryParamsWithFilters {
   sortParam: string;
   sortDir: string;
   searchString: string;
+  and?: string;
 }

--- a/src/app/fyle/team-reports/team-reports-1.page.spec.ts
+++ b/src/app/fyle/team-reports/team-reports-1.page.spec.ts
@@ -28,6 +28,7 @@ import { expectedReportsSinglePage } from 'src/app/core/mock-data/platform-repor
 import { ApproverReportsService } from 'src/app/core/services/platform/v1/approver/reports.service';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { apiEouRes } from 'src/app/core/mock-data/extended-org-user.data';
+import { LaunchDarklyService } from '../../core/services/launch-darkly.service';
 
 export function TestCases1(getTestBed) {
   return describe('test cases set 1', () => {
@@ -48,6 +49,7 @@ export function TestCases1(getTestBed) {
     let approverReportsService: jasmine.SpyObj<ApproverReportsService>;
     let authService: jasmine.SpyObj<AuthService>;
     let inputElement: HTMLInputElement;
+    let launchDarklyService: jasmine.SpyObj<LaunchDarklyService>;
 
     beforeEach(waitForAsync(() => {
       const TestBed = getTestBed();
@@ -67,6 +69,8 @@ export function TestCases1(getTestBed) {
       orgSettingsService = TestBed.inject(OrgSettingsService) as jasmine.SpyObj<OrgSettingsService>;
       approverReportsService = TestBed.inject(ApproverReportsService) as jasmine.SpyObj<ApproverReportsService>;
       authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+      launchDarklyService = TestBed.inject(LaunchDarklyService) as jasmine.SpyObj<LaunchDarklyService>;
+      launchDarklyService.getVariation.and.returnValue(of(false));
       component.eou$ = of(apiEouRes);
     }));
 
@@ -203,26 +207,30 @@ export function TestCases1(getTestBed) {
         expect(component.currentPageNumber).toBe(1);
       }));
 
-      it('should call approverReporsService.getReportsByParams and update acc', (done) => {
+      it('should call approverReporsService.getReportsByParams and update acc', fakeAsync(() => {
         mockAddNewFiltersToParams.and.returnValue(tasksQueryParamsWithFiltersData2);
+        orgSettingsService.get.and.returnValue(of(orgSettingsParamsWithSimplifiedReport));
+        launchDarklyService.getVariation.and.returnValue(of(false));
+        component.eou$ = of(apiEouRes);
         extendQueryParamsService.extendQueryParamsForTextSearch.and.returnValue({
           state: 'in.(APPROVER_PENDING)',
           next_approver_user_ids: 'cs.[usvKA4X8Ugcr]',
         });
         component.ionViewWillEnter();
+        tick();
         component.eou$.subscribe((eou) => {
           expect(eou).toEqual(apiEouRes);
-          expect(approverReportsService.getReportsByParams).toHaveBeenCalledTimes(2);
+          expect(approverReportsService.getReportsByParams).toHaveBeenCalledTimes(1);
           expect(approverReportsService.getReportsByParams).toHaveBeenCalledWith(getTeamReportsParams1);
           expect(approverReportsService.getReportsByParams).toHaveBeenCalledWith(getTeamReportsParams2);
-          expect(component.isLoadingDataInInfiniteScroll).toBeTrue();
+          expect(component.isLoadingDataInInfiniteScroll).toBeFalse();
           expect(component.acc).toEqual(expectedReportsSinglePage);
           component.teamReports$.subscribe((teamReports) => {
             expect(teamReports).toEqual(expectedReportsSinglePage);
-            done();
           });
         });
-      });
+        tick(500);
+      }));
 
       it('should set count$ and isInfiniteScrollRequired$ and navigate relative to activatedRoute', (done) => {
         mockAddNewFiltersToParams.and.returnValue({

--- a/src/app/fyle/team-reports/team-reports.page.setup.spec.ts
+++ b/src/app/fyle/team-reports/team-reports.page.setup.spec.ts
@@ -19,6 +19,7 @@ import { TestCases3 } from './team-reports-3.page.spec';
 import { TestCases4 } from './team-reports-4.page.spec';
 import { ApproverReportsService } from 'src/app/core/services/platform/v1/approver/reports.service';
 import { AuthService } from 'src/app/core/services/auth.service';
+import { LaunchDarklyService } from '../../core/services/launch-darkly.service';
 
 describe('TeamReportsPage', () => {
   const getTestBed = () => {
@@ -56,7 +57,7 @@ describe('TeamReportsPage', () => {
       'getReportsCount',
     ]);
     const authServiceSpy = jasmine.createSpyObj('AuthService', ['getEou']);
-
+    const launchDarklyServiceSpy = jasmine.createSpyObj('LaunchDarklyService', ['getVariation']);
     TestBed.configureTestingModule({
       declarations: [TeamReportsPage, ReportState],
       imports: [IonicModule.forRoot()],
@@ -75,6 +76,7 @@ describe('TeamReportsPage', () => {
         { provide: OrgSettingsService, useValue: orgSettingsServiceSpy },
         { provide: ApproverReportsService, useValue: approverReportsServiceSpy },
         { provide: AuthService, useValue: authServiceSpy },
+        { provide: LaunchDarklyService, useValue: launchDarklyServiceSpy },
         ReportState,
       ],
       schemas: [NO_ERRORS_SCHEMA],


### PR DESCRIPTION
<!--app.clickup.com-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced team reports now support multi-stage approval filtering. This improvement refines report visibility by dynamically applying approval conditions based on organizational settings, ensuring you see data aligned with your role and permissions.
  - The update significantly enhances report filtering capabilities, delivering a smoother, more accurate reporting experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->