### PR TITLE
fix: show secondary apporver info msg inside team view

### DIFF
--- a/src/app/fyle/view-team-report/view-team-report.module.ts
+++ b/src/app/fyle/view-team-report/view-team-report.module.ts
@@ -8,6 +8,7 @@ import { MatRippleModule } from '@angular/material/core';
 import { SharedModule } from 'src/app/shared/shared.module';
 import { MatLegacyFormFieldModule as MatFormFieldModule } from '@angular/material/legacy-form-field';
 import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
+import { MatExpansionModule } from '@angular/material/expansion';
 import { ViewTeamReportPage } from './view-team-report.page';
 import { ViewTeamReportPageRoutingModule } from './view-team-report-routing.module';
 import { ShareReportComponent } from './share-report/share-report.component';
@@ -24,6 +25,7 @@ import { ShareReportComponent } from './share-report/share-report.component';
     SharedModule,
     MatFormFieldModule,
     MatSnackBarModule,
+    MatExpansionModule,
   ],
   declarations: [ViewTeamReportPage, ShareReportComponent],
 })

--- a/src/app/fyle/view-team-report/view-team-report.page.html
+++ b/src/app/fyle/view-team-report/view-team-report.page.html
@@ -199,34 +199,31 @@
         <!-- Expenses Section -->
         <div *ngIf="isExpensesView">
           <app-fy-loading-screen *ngIf="isExpensesLoading"></app-fy-loading-screen>
-
-          <ng-container *ngIf="report$|async as report">
-            <div *ngIf="!isExpensesLoading && report.num_expenses > 0">
-              <div class="view-reports--divider"></div>
-              <div class="view-reports-expense-card-block">
-                <div *ngFor="let expense of expenses$|async as list; let i = index;">
-                  <app-expense-card-v2
-                    [expense]="expense"
-                    [expenseIndex]="i"
-                    [previousExpenseTxnDate]="list[i-1]?.spent_at"
-                    [previousExpenseCreatedAt]="list[i-1]?.created_at"
-                    (goToTransaction)="goToTransaction($event)"
-                    [isFromReports]="true"
-                    [isFromViewReports]="true"
-                  >
-                  </app-expense-card-v2>
-                </div>
-              </div>
-              <ng-template #ExpensesLoader>
-                <ion-spinner name="crescent"></ion-spinner>
-              </ng-template>
-            </div>
-            <div class="view-reports--expenses-zero-state" *ngIf="!isExpensesLoading && report.num_expenses === 0">
-              <div class="text-center">
-                <img src="../../../assets/images/zero-states/new-expenses.png" alt="No expense in this report" />
+          <div *ngIf="!isExpensesLoading && report.num_expenses > 0">
+            <div class="view-reports--divider"></div>
+            <div class="view-reports-expense-card-block">
+              <div *ngFor="let expense of expenses$|async as list; let i = index;">
+                <app-expense-card-v2
+                  [expense]="expense"
+                  [expenseIndex]="i"
+                  [previousExpenseTxnDate]="list[i-1]?.spent_at"
+                  [previousExpenseCreatedAt]="list[i-1]?.created_at"
+                  (goToTransaction)="goToTransaction($event)"
+                  [isFromReports]="true"
+                  [isFromViewReports]="true"
+                >
+                </app-expense-card-v2>
               </div>
             </div>
-          </ng-container>
+            <ng-template #ExpensesLoader>
+              <ion-spinner name="crescent"></ion-spinner>
+            </ng-template>
+          </div>
+          <div class="view-reports--expenses-zero-state" *ngIf="!isExpensesLoading && report.num_expenses === 0">
+            <div class="text-center">
+              <img src="../../../assets/images/zero-states/new-expenses.png" alt="No expense in this report" />
+            </div>
+          </div>
         </div>
 
         <!-- Comments section -->

--- a/src/app/fyle/view-team-report/view-team-report.page.html
+++ b/src/app/fyle/view-team-report/view-team-report.page.html
@@ -26,7 +26,15 @@
       <div *ngIf="showApprovalInfoMessage" class="view-reports--info-msg-container">
         <div *ngIf="!showExpansionPanel" class="view-reports--info-message-simple-panel">
           <mat-icon class="view-reports--info-icon" svgIcon="info-circle-fill"></mat-icon>
-          <div>{{approvalInfoMessage}}</div>
+          <div>
+            {{approvalInfoMessage}}
+            <a [href]="helpLink" class="view-reports--article-link">
+              <span>
+                Learn more
+                <mat-icon class="view-reports--link-icon" svgIcon="open-in-new-tab"></mat-icon>
+              </span>
+            </a>
+          </div>
         </div>
 
         <div *ngIf="showExpansionPanel">
@@ -34,7 +42,15 @@
             <mat-expansion-panel-header>
               <div class="info-text-container">
                 <mat-icon class="info-icon" svgIcon="info-circle-fill"></mat-icon>
-                <span [innerHTML]="approvalInfoMessage"></span>
+                <span>
+                  {{approvalInfoMessage}}
+                  <a [href]="helpLink" class="view-reports--article-link">
+                    <span>
+                      Learn more
+                      <mat-icon class="view-reports--link-icon" svgIcon="open-in-new-tab"></mat-icon>
+                    </span>
+                  </a>
+                </span>
               </div>
             </mat-expansion-panel-header>
           </mat-expansion-panel>

--- a/src/app/fyle/view-team-report/view-team-report.page.html
+++ b/src/app/fyle/view-team-report/view-team-report.page.html
@@ -23,6 +23,24 @@
 <ion-content class="view-reports--container">
   <div class="view-reports--body" *ngIf="report$|async as report">
     <div>
+      <div *ngIf="showApprovalInfoMessage" class="view-reports--info-msg-container">
+        <div *ngIf="!showExpansionPanel" class="view-reports--info-message-simple-panel">
+          <mat-icon class="view-reports--info-icon" svgIcon="info-circle-fill"></mat-icon>
+          <div>{{approvalInfoMessage}}</div>
+        </div>
+
+        <div *ngIf="showExpansionPanel">
+          <mat-expansion-panel class="view-reports--info-message-expansion-panel" style="box-shadow: none !important">
+            <mat-expansion-panel-header>
+              <div class="info-text-container">
+                <mat-icon class="info-icon" svgIcon="info-circle-fill"></mat-icon>
+                <span [innerHTML]="approvalInfoMessage"></span>
+              </div>
+            </mat-expansion-panel-header>
+          </mat-expansion-panel>
+        </div>
+      </div>
+
       <div class="view-reports--card">
         <ion-grid>
           <ion-row class="view-reports--purpose-state">
@@ -181,31 +199,34 @@
         <!-- Expenses Section -->
         <div *ngIf="isExpensesView">
           <app-fy-loading-screen *ngIf="isExpensesLoading"></app-fy-loading-screen>
-          <div *ngIf="!isExpensesLoading && report.num_expenses > 0">
-            <div class="view-reports--divider"></div>
-            <div class="view-reports-expense-card-block">
-              <div *ngFor="let expense of expenses$|async as list; let i = index;">
-                <app-expense-card-v2
-                  [expense]="expense"
-                  [expenseIndex]="i"
-                  [previousExpenseTxnDate]="list[i-1]?.spent_at"
-                  [previousExpenseCreatedAt]="list[i-1]?.created_at"
-                  (goToTransaction)="goToTransaction($event)"
-                  [isFromReports]="true"
-                  [isFromViewReports]="true"
-                >
-                </app-expense-card-v2>
+
+          <ng-container *ngIf="report$|async as report">
+            <div *ngIf="!isExpensesLoading && report.num_expenses > 0">
+              <div class="view-reports--divider"></div>
+              <div class="view-reports-expense-card-block">
+                <div *ngFor="let expense of expenses$|async as list; let i = index;">
+                  <app-expense-card-v2
+                    [expense]="expense"
+                    [expenseIndex]="i"
+                    [previousExpenseTxnDate]="list[i-1]?.spent_at"
+                    [previousExpenseCreatedAt]="list[i-1]?.created_at"
+                    (goToTransaction)="goToTransaction($event)"
+                    [isFromReports]="true"
+                    [isFromViewReports]="true"
+                  >
+                  </app-expense-card-v2>
+                </div>
+              </div>
+              <ng-template #ExpensesLoader>
+                <ion-spinner name="crescent"></ion-spinner>
+              </ng-template>
+            </div>
+            <div class="view-reports--expenses-zero-state" *ngIf="!isExpensesLoading && report.num_expenses === 0">
+              <div class="text-center">
+                <img src="../../../assets/images/zero-states/new-expenses.png" alt="No expense in this report" />
               </div>
             </div>
-            <ng-template #ExpensesLoader>
-              <ion-spinner name="crescent"></ion-spinner>
-            </ng-template>
-          </div>
-          <div class="view-reports--expenses-zero-state" *ngIf="!isExpensesLoading && report.num_expenses === 0">
-            <div class="text-center">
-              <img src="../../../assets/images/zero-states/new-expenses.png" alt="No expense in this report" />
-            </div>
-          </div>
+          </ng-container>
         </div>
 
         <!-- Comments section -->

--- a/src/app/fyle/view-team-report/view-team-report.page.scss
+++ b/src/app/fyle/view-team-report/view-team-report.page.scss
@@ -462,6 +462,22 @@ $sent-back-color: #da1e28;
       }
     }
   }
+
+  &--article-link {
+    text-decoration: none;
+    font-size: 12px;
+    color: $blue-4;
+    white-space: nowrap;
+  }
+
+  &--link-icon {
+    width: 12px;
+    height: 12px;
+
+    &::ng-deep svg path {
+      fill: $blue-4 !important;
+    }
+  }
 }
 
 .view-comment {

--- a/src/app/fyle/view-team-report/view-team-report.page.scss
+++ b/src/app/fyle/view-team-report/view-team-report.page.scss
@@ -382,6 +382,86 @@ $sent-back-color: #da1e28;
       opacity: 0.5;
     }
   }
+
+  &--info-msg-container {
+    margin: 4px;
+  }
+
+  &--info-message-simple-panel {
+    border-radius: 4px;
+    border: 1px solid $grey-lighter;
+    background-color: $pure-white;
+    padding: 8px 12px;
+    display: flex;
+    justify-content: start;
+    align-items: start;
+    gap: 12px;
+    font-size: 12px;
+    line-height: 18px;
+    color: $blue-black;
+  }
+
+  &--info-icon {
+    color: $highlight-blue;
+    font-size: 18px;
+    height: 18px;
+    width: 18px;
+    flex-shrink: 0;
+  }
+
+  &--info-message-expansion-panel {
+    border-radius: 4px;
+    border: 1px solid $grey-lighter;
+    background-color: $pure-white;
+
+    ::ng-deep .mat-expansion-panel-header {
+      padding: 8px 12px 0 12px;
+      height: auto;
+    }
+
+    ::ng-deep .mat-expansion-panel-body {
+      padding: 0;
+    }
+
+    ::ng-deep .mat-expansion-indicator {
+      align-self: flex-start;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 20px;
+      width: 20px;
+    }
+
+    .info-icon {
+      margin-right: 12px;
+      color: $highlight-blue;
+      font-size: 18px;
+      height: 18px;
+      width: 18px;
+      flex-shrink: 0;
+      align-self: flex-start;
+    }
+
+    .info-text-container {
+      display: flex;
+      color: $blue-black;
+      font-size: 12px;
+      line-height: 18px;
+      padding: 0 16px 8px 0;
+    }
+
+    &:not(.mat-expanded) {
+      .info-text-container {
+        span {
+          display: -webkit-box;
+          -webkit-line-clamp: 3;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
+    }
+  }
 }
 
 .view-comment {

--- a/src/app/fyle/view-team-report/view-team-report.page.ts
+++ b/src/app/fyle/view-team-report/view-team-report.page.ts
@@ -146,6 +146,8 @@ export class ViewTeamReportPage {
 
   showExpansionPanel = false;
 
+  helpLink = '';
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private reportService: ReportService,
@@ -640,6 +642,7 @@ export class ViewTeamReportPage {
     this.showApprovalInfoMessage = true;
     if (this.approvalAmount > report.amount) {
       this.showExpansionPanel = true;
+      this.helpLink = 'https://help.fylehq.com/en/articles/1205138-view-and-approve-expense-reports#h_4d7cb8ac1f';
 
       let message = `You are reviewing ${this.formatCurrency(
         this.approvalAmount,
@@ -659,8 +662,9 @@ export class ViewTeamReportPage {
         report.currency
       )} (includes credits).`;
       this.approvalInfoMessage = message;
-    } else if (report.amount > this.approvalAmount) {
+    } else if (this.approvalAmount < report.amount) {
       this.showExpansionPanel = false;
+      this.helpLink = 'https://help.fylehq.com/en/articles/1205138-view-and-approve-expense-reports#h_1672226e87';
       this.approvalInfoMessage = `The total report amount is ${this.formatCurrency(
         report.amount,
         report.currency

--- a/src/app/fyle/view-team-report/view-team-report.page.ts
+++ b/src/app/fyle/view-team-report/view-team-report.page.ts
@@ -138,6 +138,14 @@ export class ViewTeamReportPage {
 
   approverToShow: ReportApprovals;
 
+  approvalAmount: number;
+
+  showApprovalInfoMessage = false;
+
+  approvalInfoMessage = '';
+
+  showExpansionPanel = false;
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private reportService: ReportService,
@@ -368,6 +376,13 @@ export class ViewTeamReportPage {
       if (this.showViewApproverModal) {
         this.approvals.sort((a, b) => a.approver_order - b.approver_order);
         this.setupApproverToShow(report);
+      }
+
+      if (this.expensesAmountSum$) {
+        this.expensesAmountSum$.pipe(take(1)).subscribe((sum) => {
+          this.approvalAmount = sum;
+          this.setApproverInfoMessage(expenses, report);
+        });
       }
     });
 
@@ -619,5 +634,50 @@ export class ViewTeamReportPage {
           this.updateReportName(newReportName);
         }
       });
+  }
+
+  setApproverInfoMessage(expenses: Expense[], report: Report): void {
+    this.showApprovalInfoMessage = true;
+    if (this.approvalAmount > report.amount) {
+      this.showExpansionPanel = true;
+
+      let message = `You are reviewing ${this.formatCurrency(
+        this.approvalAmount,
+        report.currency
+      )} in expenses requiring your approval. `;
+      message += `The total report amount is ${this.formatCurrency(
+        report.amount,
+        report.currency
+      )}, including other expenses not requiring your approval: `;
+
+      const noOfExpNotRequireApproval = report.num_expenses - expenses.length;
+      const totalAmountOfExpNotRequireApproval = report.amount - this.approvalAmount;
+      const expenseText = noOfExpNotRequireApproval > 1 ? 'expenses' : 'expense';
+
+      message += `${noOfExpNotRequireApproval} ${expenseText} totalling ${this.formatCurrency(
+        totalAmountOfExpNotRequireApproval,
+        report.currency
+      )} (includes credits).`;
+      this.approvalInfoMessage = message;
+    } else if (report.amount > this.approvalAmount) {
+      this.showExpansionPanel = false;
+      this.approvalInfoMessage = `The total report amount is ${this.formatCurrency(
+        report.amount,
+        report.currency
+      )}, but only ${this.formatCurrency(
+        this.approvalAmount,
+        report.currency
+      )} needs your approval as per the policy set up by your admin.`;
+    } else {
+      this.showApprovalInfoMessage = false;
+    }
+  }
+
+  private formatCurrency(amount: number, currencyCode: string): string {
+    return this.exactCurrency.transform({
+      value: amount,
+      currencyCode,
+      skipSymbol: false,
+    });
   }
 }


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cyzxw6j

## UI Preview

### Approver Amount < Report Amount
<img width="451" alt="Screenshot 2025-05-20 at 12 54 26 AM" src="https://github.com/user-attachments/assets/27fc77fa-323b-431a-b21d-bcf73a85b4ed" />


> ### Small Dimension
 
<img width="451" alt="Screenshot 2025-05-20 at 12 51 37 AM" src="https://github.com/user-attachments/assets/d1688b36-3064-459f-a698-c7f3aaeaf1f7" />

<img width="451" alt="Screenshot 2025-05-20 at 12 54 19 AM" src="https://github.com/user-attachments/assets/c3f78aa5-b208-453d-802e-1c0ab33be351" />


### Approver Amount > Report Amount

<img width="451" alt="Screenshot 2025-05-20 at 12 56 12 AM" src="https://github.com/user-attachments/assets/2bf663ed-e419-43aa-9372-d4cf39bf8bd2" />

<img width="451" alt="Screenshot 2025-05-20 at 12 56 20 AM" src="https://github.com/user-attachments/assets/843c8461-5d72-4faf-b09f-91863fda5771" />

> ### Small Dimension

<img width="451" alt="Screenshot 2025-05-20 at 12 57 29 AM" src="https://github.com/user-attachments/assets/4b0c195f-c7e0-48fb-a994-c76cca34cd1d" />
<img width="451" alt="Screenshot 2025-05-20 at 12 57 35 AM" src="https://github.com/user-attachments/assets/4b2517e5-7a59-4c81-a56e-918a2cf0a77c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a conditional approval information message above the report card, which can display as either a simple info message or an expandable panel with detailed information, depending on the approval amounts.
  - Enhanced the expenses section to ensure data is fully loaded before displaying expenses and related UI elements.

- **Style**
  - Introduced new styles for informational message panels, including both simple and expandable panel variants, for improved visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->