### PR TITLE
fix: hide the info msg when report is already approved

### DIFF
--- a/src/app/fyle/view-team-report/view-team-report.page.html
+++ b/src/app/fyle/view-team-report/view-team-report.page.html
@@ -23,7 +23,7 @@
 <ion-content class="view-reports--container">
   <div class="view-reports--body" *ngIf="report$|async as report">
     <div>
-      <div *ngIf="showApprovalInfoMessage" class="view-reports--info-msg-container">
+      <div *ngIf="showApprovalInfoMessage && canApproveReport" class="view-reports--info-msg-container">
         <div *ngIf="!showExpansionPanel" class="view-reports--info-message-simple-panel">
           <mat-icon class="view-reports--info-icon" svgIcon="info-circle-fill"></mat-icon>
           <div>

--- a/src/app/fyle/view-team-report/view-team-report.page.spec.ts
+++ b/src/app/fyle/view-team-report/view-team-report.page.spec.ts
@@ -1143,6 +1143,7 @@ describe('ViewTeamReportPageV2', () => {
       mockReport.currency = 'USD';
       mockReport.num_expenses = 3;
       component.approvalAmount = 300;
+      component.canApproveReport = true;
 
       component.setApproverInfoMessage(expenseResponseData, mockReport);
 
@@ -1163,6 +1164,7 @@ describe('ViewTeamReportPageV2', () => {
       mockReport.currency = 'USD';
       mockReport.num_expenses = 3;
       component.approvalAmount = 300;
+      component.canApproveReport = true;
 
       component.setApproverInfoMessage(expenseResponseData, mockReport);
 
@@ -1181,6 +1183,7 @@ describe('ViewTeamReportPageV2', () => {
       mockReport.currency = 'USD';
       mockReport.num_expenses = expenseResponseData.length;
       component.approvalAmount = 300;
+      component.canApproveReport = true;
 
       component.setApproverInfoMessage(expenseResponseData, mockReport);
       expect(component.showApprovalInfoMessage).toBeFalse();

--- a/src/app/fyle/view-team-report/view-team-report.page.ts
+++ b/src/app/fyle/view-team-report/view-team-report.page.ts
@@ -148,6 +148,8 @@ export class ViewTeamReportPage {
 
   helpLink = '';
 
+  canApproveReport = false;
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private reportService: ReportService,
@@ -357,6 +359,10 @@ export class ViewTeamReportPage {
     this.canEdit$ = this.permissions$.pipe(map((permissions) => permissions.can_edit));
     this.canDelete$ = this.permissions$.pipe(map((permissions) => permissions.can_delete));
     this.canResubmitReport$ = this.permissions$.pipe(map((permissions) => permissions.can_resubmit));
+
+    this.permissions$.subscribe((permissions) => {
+      this.canApproveReport = permissions.can_approve;
+    });
 
     forkJoin({
       expenses: this.expenses$,
@@ -644,19 +650,31 @@ export class ViewTeamReportPage {
       this.showExpansionPanel = true;
       this.helpLink = 'https://help.fylehq.com/en/articles/1205138-view-and-approve-expense-reports#h_4d7cb8ac1f';
 
-      let message = `You are reviewing ${this.formatCurrency(this.approvalAmount, report.currency)} in expenses requiring your approval. `;
+      let message = `You are reviewing ${this.formatCurrency(
+        this.approvalAmount,
+        report.currency
+      )} in expenses requiring your approval. `;
       message += `The total report amount is ${this.formatCurrency(report.amount, report.currency)}, `;
 
       const noOfExpNotRequireApproval = report.num_expenses - expenses.length;
       const totalAmountOfExpNotRequireApproval = report.amount - this.approvalAmount;
       const expenseText = noOfExpNotRequireApproval > 1 ? 'expenses' : 'expense';
 
-      message += `including ${noOfExpNotRequireApproval} other ${expenseText} totalling ${this.formatCurrency(totalAmountOfExpNotRequireApproval, report.currency)} (credits included) that do not require your approval.`;
+      message += `including ${noOfExpNotRequireApproval} other ${expenseText} totalling ${this.formatCurrency(
+        totalAmountOfExpNotRequireApproval,
+        report.currency
+      )} (credits included) that do not require your approval.`;
       this.approvalInfoMessage = message;
     } else if (this.approvalAmount < report.amount) {
       this.showExpansionPanel = false;
       this.helpLink = 'https://help.fylehq.com/en/articles/1205138-view-and-approve-expense-reports#h_1672226e87';
-      this.approvalInfoMessage = `The total report amount is ${this.formatCurrency(report.amount, report.currency)}, but only ${this.formatCurrency(this.approvalAmount, report.currency)} needs your approval as per the policy set up by your admin.`;
+      this.approvalInfoMessage = `The total report amount is ${this.formatCurrency(
+        report.amount,
+        report.currency
+      )}, but only ${this.formatCurrency(
+        this.approvalAmount,
+        report.currency
+      )} needs your approval as per the policy set up by your admin.`;
     } else {
       this.showApprovalInfoMessage = false;
     }


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cyzxw6j


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Approval info messages are now visible only to users with approval permissions.
- **Bug Fixes**
  - Improved accuracy of approval info message display based on user permissions.
- **Tests**
  - Updated tests to reflect new approval permission requirements for displaying approval info messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->