### PR TITLE
fix: correct total amount to show inside view-report

### DIFF
--- a/src/app/fyle/view-team-report/view-team-report.page.html
+++ b/src/app/fyle/view-team-report/view-team-report.page.html
@@ -88,7 +88,7 @@
               <div class="view-reports--amount">
                 <span class="view-reports--purpose-amount-block__currency"> {{ reportCurrencySymbol }} </span>
                 <span class="view-reports--purpose-amount-block__amount">
-                  {{ { value: report.amount || 0, currencyCode: report.currency, skipSymbol: true } | exactCurrency }}
+                  {{ { value: approvalAmount || 0, currencyCode: report.currency, skipSymbol: true } | exactCurrency }}
                 </span>
               </div>
             </ion-col>

--- a/src/app/fyle/view-team-report/view-team-report.page.spec.ts
+++ b/src/app/fyle/view-team-report/view-team-report.page.spec.ts
@@ -1039,6 +1039,7 @@ describe('ViewTeamReportPageV2', () => {
   it('should show report information correctly', () => {
     spyOn(component, 'openViewReportInfoModal');
     component.report$ = of(expectedReportsSinglePage[0]);
+    component.approvalAmount = 250.75;
     fixture.detectChanges();
 
     expect(getTextContent(getElementBySelector(fixture, '.view-reports--employee-name__name'))).toEqual(
@@ -1048,7 +1049,7 @@ describe('ViewTeamReportPageV2', () => {
       'Feb 01, 2023'
     );
     expect(getTextContent(getElementBySelector(fixture, '.view-reports--purpose-amount-block__amount'))).toEqual(
-      '100.00'
+      component.approvalAmount.toString()
     );
 
     const openButton = getElementBySelector(fixture, '.view-reports--view-info') as HTMLElement;


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cz1e4xq

## UI Preview

> Previous UI -- 

<img width="320" alt="Screenshot 2025-05-23 at 2 08 19 AM" src="https://github.com/user-attachments/assets/587fe24f-fa53-4789-9323-fb61c2dd24b1" />


> Updated UI --

<img width="338" alt="Screenshot 2025-05-23 at 2 02 33 AM" src="https://github.com/user-attachments/assets/89fe5d4b-c1db-4327-ac47-9a7eece7ac10" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the displayed amount in the team report view to reflect the approval amount instead of the total report amount, ensuring more accurate information is shown to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->