### PR TITLE
fix: currency specific rounding off inside split expense

### DIFF
--- a/src/app/core/mock-data/fallback-currency-data.ts
+++ b/src/app/core/mock-data/fallback-currency-data.ts
@@ -1,0 +1,31 @@
+import deepFreeze from 'deep-freeze-strict';
+import { CurrencyConfig } from '../models/currency-config.model';
+
+export const fallbackCurrencies: CurrencyConfig[] = deepFreeze([
+  { code: 'USD', decimalPlaces: 2 },
+  { code: 'EUR', decimalPlaces: 2 },
+  { code: 'GBP', decimalPlaces: 2 },
+  { code: 'INR', decimalPlaces: 2 },
+  { code: 'CAD', decimalPlaces: 2 },
+  { code: 'AUD', decimalPlaces: 2 },
+  { code: 'CNY', decimalPlaces: 2 },
+  { code: 'SGD', decimalPlaces: 2 },
+  { code: 'HKD', decimalPlaces: 2 },
+  { code: 'THB', decimalPlaces: 2 },
+  { code: 'MYR', decimalPlaces: 2 },
+  { code: 'PHP', decimalPlaces: 2 },
+  { code: 'NZD', decimalPlaces: 2 },
+  { code: 'JPY', decimalPlaces: 0 },
+  { code: 'KRW', decimalPlaces: 0 },
+  { code: 'VND', decimalPlaces: 0 },
+  { code: 'IDR', decimalPlaces: 0 },
+  { code: 'CLP', decimalPlaces: 0 },
+  { code: 'OMR', decimalPlaces: 3 },
+  { code: 'KWD', decimalPlaces: 3 },
+  { code: 'BHD', decimalPlaces: 3 },
+  { code: 'IQD', decimalPlaces: 3 },
+  { code: 'TND', decimalPlaces: 3 },
+  { code: 'JOD', decimalPlaces: 3 },
+  { code: 'LYD', decimalPlaces: 3 },
+  { code: 'CLF', decimalPlaces: 4 },
+]);

--- a/src/app/core/models/currency-config.model.ts
+++ b/src/app/core/models/currency-config.model.ts
@@ -1,0 +1,4 @@
+export interface CurrencyConfig {
+  code: string;
+  decimalPlaces: number;
+}

--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -425,12 +425,12 @@ export class SplitExpenseService {
 
     const precision = this.getCurrencyPrecision(currency);
     const threshold = this.getThresholdTolerance(precision);
-    const roundedTargetAmount = parseFloat(targetAmount.toFixed(precision));
+    const roundedTargetAmount = Number.parseFloat(targetAmount.toFixed(precision));
     let totalRoundedAmount = 0;
 
     splitExpensesFormArray.controls.forEach((control) => {
       const currentAmount = (control.get('amount')?.value as number) || 0;
-      const roundedAmount = parseFloat(currentAmount.toFixed(precision));
+      const roundedAmount = Number.parseFloat(currentAmount.toFixed(precision));
 
       control.patchValue(
         {
@@ -443,13 +443,13 @@ export class SplitExpenseService {
       totalRoundedAmount += roundedAmount;
     });
 
-    const difference = parseFloat((roundedTargetAmount - totalRoundedAmount).toFixed(precision + 1));
+    const difference = Number.parseFloat((roundedTargetAmount - totalRoundedAmount).toFixed(precision + 1));
 
     if (Math.abs(difference) > threshold) {
       const lastIndex = splitExpensesFormArray.length - 1;
       const lastControl = splitExpensesFormArray.at(lastIndex);
       const lastAmount = (lastControl.get('amount')?.value as number) || 0;
-      const adjustedAmount = parseFloat((lastAmount + difference).toFixed(precision));
+      const adjustedAmount = Number.parseFloat((lastAmount + difference).toFixed(precision));
 
       lastControl.patchValue(
         {

--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -21,7 +21,6 @@ import { ExpenseCommentService } from './platform/v1/spender/expense-comment.ser
 import { ExpenseComment } from '../models/expense-comment.model';
 import { UntypedFormArray, AbstractControl } from '@angular/forms';
 import { fallbackCurrencies } from '../mock-data/fallback-currency-data';
-import { cloneDeep } from 'lodash';
 
 @Injectable({
   providedIn: 'root',
@@ -472,8 +471,7 @@ export class SplitExpenseService {
       }).resolvedOptions();
       return maximumFractionDigits;
     } catch (_) {
-      const fallbackCurrencyData = cloneDeep(fallbackCurrencies);
-      const currencyConfig = fallbackCurrencyData.find((config) => config.code === currencyCode.toUpperCase());
+      const currencyConfig = fallbackCurrencies.find((config) => config.code === currencyCode.toUpperCase());
       return currencyConfig ? currencyConfig.decimalPlaces : 2;
     }
   }

--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -436,7 +436,9 @@ export class SplitExpenseService {
         {
           amount: roundedAmount,
           percentage:
-            roundedTargetAmount !== 0 ? Number.parseFloat(((roundedAmount / roundedTargetAmount) * 100).toFixed(3)) : 0,
+            roundedTargetAmount !== 0
+              ? Number.parseFloat(((Math.abs(roundedAmount) / Math.abs(roundedTargetAmount)) * 100).toFixed(3))
+              : 0,
         },
         { emitEvent: false }
       );
@@ -457,7 +459,7 @@ export class SplitExpenseService {
           amount: adjustedAmount,
           percentage:
             roundedTargetAmount !== 0
-              ? Number.parseFloat(((adjustedAmount / roundedTargetAmount) * 100).toFixed(3))
+              ? Number.parseFloat(((Math.abs(adjustedAmount) / Math.abs(roundedTargetAmount)) * 100).toFixed(3))
               : 0,
         },
         { emitEvent: false }

--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -435,7 +435,7 @@ export class SplitExpenseService {
       control.patchValue(
         {
           amount: roundedAmount,
-          percentage: targetAmount > 0 ? parseFloat(((roundedAmount / targetAmount) * 100).toFixed(3)) : 0,
+          percentage: targetAmount !== 0 ? Number.parseFloat(((roundedAmount / targetAmount) * 100).toFixed(3)) : 0,
         },
         { emitEvent: false }
       );
@@ -454,7 +454,7 @@ export class SplitExpenseService {
       lastControl.patchValue(
         {
           amount: adjustedAmount,
-          percentage: targetAmount > 0 ? parseFloat(((adjustedAmount / targetAmount) * 100).toFixed(3)) : 0,
+          percentage: targetAmount !== 0 ? Number.parseFloat(((adjustedAmount / targetAmount) * 100).toFixed(3)) : 0,
         },
         { emitEvent: false }
       );

--- a/src/app/core/services/split-expense.service.ts
+++ b/src/app/core/services/split-expense.service.ts
@@ -435,7 +435,8 @@ export class SplitExpenseService {
       control.patchValue(
         {
           amount: roundedAmount,
-          percentage: targetAmount !== 0 ? Number.parseFloat(((roundedAmount / targetAmount) * 100).toFixed(3)) : 0,
+          percentage:
+            roundedTargetAmount !== 0 ? Number.parseFloat(((roundedAmount / roundedTargetAmount) * 100).toFixed(3)) : 0,
         },
         { emitEvent: false }
       );
@@ -445,7 +446,7 @@ export class SplitExpenseService {
 
     const difference = Number.parseFloat((roundedTargetAmount - totalRoundedAmount).toFixed(precision + 1));
 
-    if (Math.abs(difference) > threshold) {
+    if (Math.abs(difference) >= threshold) {
       const lastIndex = splitExpensesFormArray.length - 1;
       const lastControl = splitExpensesFormArray.at(lastIndex);
       const lastAmount = (lastControl.get('amount')?.value as number) || 0;
@@ -454,7 +455,10 @@ export class SplitExpenseService {
       lastControl.patchValue(
         {
           amount: adjustedAmount,
-          percentage: targetAmount !== 0 ? Number.parseFloat(((adjustedAmount / targetAmount) * 100).toFixed(3)) : 0,
+          percentage:
+            roundedTargetAmount !== 0
+              ? Number.parseFloat(((adjustedAmount / roundedTargetAmount) * 100).toFixed(3))
+              : 0,
         },
         { emitEvent: false }
       );

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -195,6 +195,7 @@ describe('SplitExpensePage', () => {
       'handlePolicyAndMissingFieldsCheck',
       'checkIfMissingFieldsExist',
       'transformSplitTo',
+      'normalizeSplitAmounts',
     ]);
     const currencyServiceSpy = jasmine.createSpyObj('CurrencyService', ['getHomeCurrency']);
     const expensesServiceSpy = jasmine.createSpyObj('ExpensesService', ['getExpenseById'], {

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -811,7 +811,7 @@ export class SplitExpensePage implements OnDestroy {
     };
   }
 
-  normalizeSplitAmounts(): void {
+  normalizeSplitAmount(): void {
     this.splitExpenseService.normalizeSplitAmounts(this.splitExpensesFormArray, this.amount, this.currency);
     this.getTotalSplitAmount();
   }
@@ -856,7 +856,7 @@ export class SplitExpensePage implements OnDestroy {
           return;
         }
 
-        this.normalizeSplitAmounts();
+        this.normalizeSplitAmount();
         const generatedSplitEtxn$ = (this.splitExpensesFormArray.value as SplitExpense[]).map((splitExpenseValue) =>
           this.generateSplitEtxnFromFg(splitExpenseValue)
         );

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -818,7 +818,6 @@ export class SplitExpensePage implements OnDestroy {
 
   save(): void {
     if (this.splitExpensesFormArray.valid) {
-      this.normalizeSplitAmounts();
       this.showErrorBlock = false;
       if (this.amount && parseFloat(this.amount.toFixed(3)) !== this.totalSplitAmount) {
         this.showErrorBlock = true;
@@ -857,6 +856,7 @@ export class SplitExpensePage implements OnDestroy {
           return;
         }
 
+        this.normalizeSplitAmounts();
         const generatedSplitEtxn$ = (this.splitExpensesFormArray.value as SplitExpense[]).map((splitExpenseValue) =>
           this.generateSplitEtxnFromFg(splitExpenseValue)
         );

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -811,8 +811,14 @@ export class SplitExpensePage implements OnDestroy {
     };
   }
 
+  normalizeSplitAmounts(): void {
+    this.splitExpenseService.normalizeSplitAmounts(this.splitExpensesFormArray, this.amount, this.currency);
+    this.getTotalSplitAmount();
+  }
+
   save(): void {
     if (this.splitExpensesFormArray.valid) {
+      this.normalizeSplitAmounts();
       this.showErrorBlock = false;
       if (this.amount && parseFloat(this.amount.toFixed(3)) !== this.totalSplitAmount) {
         this.showErrorBlock = true;


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cz7pmjw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automatic normalization of split expense amounts to ensure totals match the original amount with correct currency precision.
  - Split amounts are now accurately rounded and adjusted based on the selected currency.
  - Added support for currency-specific decimal precision in expense splitting.
  - Added support for multiple currencies with predefined decimal places to improve expense accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->