### PR TITLE
fix: fixed the duplicate custom fields in merge payload

### DIFF
--- a/src/app/core/mock-data/generated-form-properties.data.ts
+++ b/src/app/core/mock-data/generated-form-properties.data.ts
@@ -60,7 +60,6 @@ export const generatedFormPropertiesData2: GeneratedFormProperties = deepFreeze(
       value: 'Cost Code 1',
     },
     ...dependentCustomProperties,
-    ...dependentCustomProperties,
   ],
   started_at: undefined,
   ended_at: undefined,

--- a/src/app/fyle/merge-expense/merge-expense.page.ts
+++ b/src/app/fyle/merge-expense/merge-expense.page.ts
@@ -622,6 +622,10 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
     }
     const projectDependantFieldValues = dependentFieldsMapping[this.genericFieldsFormValues.project] || [];
     const costCenterDependentFieldValues = dependentFieldsMapping[this.genericFieldsFormValues.costCenter] || [];
+    // In case of project and cost center have same value, we need to remove the duplicate dependent fields
+    const uniqueDependentFieldValues = [
+      ...new Set([...projectDependantFieldValues, ...costCenterDependentFieldValues]),
+    ];
 
     return {
       source_account_id: sourceExpense?.tx_source_account_id,
@@ -638,8 +642,7 @@ export class MergeExpensePage implements OnInit, AfterViewChecked {
       file_ids: this.selectedReceiptsId,
       custom_fields: [
         ...(Array.isArray(this.customInputsFormValues?.fields) ? this.customInputsFormValues.fields : []),
-        ...projectDependantFieldValues,
-        ...costCenterDependentFieldValues,
+        ...uniqueDependentFieldValues,
       ],
       started_at: this.categoryDependentFieldsFormValues.from_dt,
       ended_at: this.categoryDependentFieldsFormValues.to_dt,


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cz9bh1z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where duplicate custom fields could appear when merging expenses with overlapping project and cost center fields. Now, only unique custom fields are shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->