### PR TITLE
fix: rounding off split expense amount for foreign currency

### DIFF
--- a/src/app/core/services/split-expense.service.spec.ts
+++ b/src/app/core/services/split-expense.service.spec.ts
@@ -305,6 +305,9 @@ describe('SplitExpenseService', () => {
       const mockTxn = cloneDeep(txnData5);
       mockTxn.source = undefined;
       const mockSplitExpenses = cloneDeep(txnList);
+      spyOn(splitExpenseService as any, 'normalizeForeignCurrencySplitAmounts').and.callFake(
+        (sourceTxn, transactions, homeCurrency) => transactions
+      );
       splitExpenseService
         .createTxns(mockTxn, mockSplitExpenses, 100, 'txOJVaaPxo9O', 100, expenseFieldResponse, 'USD')
         .subscribe((expectedTxnRes) => {

--- a/src/app/core/services/split-expense.service.spec.ts
+++ b/src/app/core/services/split-expense.service.spec.ts
@@ -186,7 +186,7 @@ describe('SplitExpenseService', () => {
     spyOn(splitExpenseService, 'createTxns').and.returnValue(of(splitTxn2));
 
     splitExpenseService
-      .createSplitTxns(createSourceTxn, createSourceTxn.amount, splitTxn2, expenseFieldResponse)
+      .createSplitTxns(createSourceTxn, createSourceTxn.amount, splitTxn2, expenseFieldResponse, 'USD')
       .subscribe((res) => {
         expect(res).toEqual(splitTxn2);
         expect(splitExpenseService.createTxns).toHaveBeenCalledOnceWith(
@@ -195,7 +195,8 @@ describe('SplitExpenseService', () => {
           createSourceTxn.split_group_user_amount,
           createSourceTxn.split_group_id,
           splitTxn2.length,
-          expenseFieldResponse
+          expenseFieldResponse,
+          'USD'
         );
         done();
       });
@@ -207,19 +208,22 @@ describe('SplitExpenseService', () => {
 
     const amount = 16428.56;
 
-    splitExpenseService.createSplitTxns(createSourceTxn2, amount, splitTxn2, expenseFieldResponse).subscribe((res) => {
-      expect(res).toEqual(splitTxn2);
-      expect(utilityService.generateRandomString).toHaveBeenCalledOnceWith(10);
-      expect(splitExpenseService.createTxns).toHaveBeenCalledOnceWith(
-        createSourceTxn2,
-        splitTxn2,
-        amount,
-        'tx0AGAoeQfQX',
-        splitTxn2.length,
-        expenseFieldResponse
-      );
-      done();
-    });
+    splitExpenseService
+      .createSplitTxns(createSourceTxn2, amount, splitTxn2, expenseFieldResponse, 'USD')
+      .subscribe((res) => {
+        expect(res).toEqual(splitTxn2);
+        expect(utilityService.generateRandomString).toHaveBeenCalledOnceWith(10);
+        expect(splitExpenseService.createTxns).toHaveBeenCalledOnceWith(
+          createSourceTxn2,
+          splitTxn2,
+          amount,
+          'tx0AGAoeQfQX',
+          splitTxn2.length,
+          expenseFieldResponse,
+          'USD'
+        );
+        done();
+      });
   });
 
   describe('createTxns(): ', () => {
@@ -241,7 +245,7 @@ describe('SplitExpenseService', () => {
       mockSplitExpenses[0].org_category_id = undefined;
       mockSplitExpenses[0].custom_properties = undefined;
       splitExpenseService
-        .createTxns(mockTxn, mockSplitExpenses, 100, 'txOJVaaPxo9O', 100, expenseFieldResponse)
+        .createTxns(mockTxn, mockSplitExpenses, 100, 'txOJVaaPxo9O', 100, expenseFieldResponse, 'USD')
         .subscribe((expectedTxnRes) => {
           expect(expectedTxnRes).toEqual([txnData7, txnData8]);
         });
@@ -271,7 +275,7 @@ describe('SplitExpenseService', () => {
       mockTxn.orig_currency = undefined;
       const mockSplitExpenses = cloneDeep(txnList);
       splitExpenseService
-        .createTxns(mockTxn, mockSplitExpenses, 100, 'txOJVaaPxo9O', 100, expenseFieldResponse)
+        .createTxns(mockTxn, mockSplitExpenses, 100, 'txOJVaaPxo9O', 100, expenseFieldResponse, 'USD')
         .subscribe((expectedTxnRes) => {
           expect(expectedTxnRes).toEqual([txnData9, txnData10]);
         });
@@ -302,7 +306,7 @@ describe('SplitExpenseService', () => {
       mockTxn.source = undefined;
       const mockSplitExpenses = cloneDeep(txnList);
       splitExpenseService
-        .createTxns(mockTxn, mockSplitExpenses, 100, 'txOJVaaPxo9O', 100, expenseFieldResponse)
+        .createTxns(mockTxn, mockSplitExpenses, 100, 'txOJVaaPxo9O', 100, expenseFieldResponse, 'USD')
         .subscribe((expectedTxnRes) => {
           expect(expectedTxnRes).toEqual([txnData11, txnData12]);
         });

--- a/src/app/fyle/split-expense/split-expense.page.spec.ts
+++ b/src/app/fyle/split-expense/split-expense.page.spec.ts
@@ -2524,7 +2524,8 @@ describe('SplitExpensePage', () => {
           component.transaction,
           component.totalSplitAmount,
           splitExpenses,
-          component.expenseFields
+          component.expenseFields,
+          component.homeCurrency
         );
         expect(component.setupCategoryAndProject).toHaveBeenCalledTimes(2);
         expect(component.setupCategoryAndProject).toHaveBeenCalledWith(txnList[0], splitExpenseForm1.value, true);

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -96,6 +96,8 @@ export class SplitExpensePage implements OnDestroy {
 
   remainingAmount: number;
 
+  homeCurrency: string;
+
   categories$: Observable<OrgCategoryListItem[]>;
 
   filteredCategories$: Observable<OrgCategoryListItem[]>;
@@ -526,7 +528,8 @@ export class SplitExpensePage implements OnDestroy {
         this.transaction,
         this.totalSplitAmount,
         splitExpenses,
-        this.expenseFields
+        this.expenseFields,
+        this.homeCurrency
       ),
     };
 
@@ -1067,6 +1070,7 @@ export class SplitExpensePage implements OnDestroy {
   }
 
   setValuesForCCC(currencyObj: CurrencyObj, homeCurrency: string, isCorporateCardsEnabled: boolean): void {
+    this.homeCurrency = homeCurrency;
     this.setAmountAndCurrency(currencyObj, homeCurrency);
 
     let amount1 = this.amount > 0.0001 || isCorporateCardsEnabled ? this.amount * 0.6 : null; // 60% split


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cz7pmjw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved accuracy of split expense amounts when handling foreign currency conversions by dynamically adjusting rounding precision.
- **Bug Fixes**
  - Resolved discrepancies in split transaction totals by normalizing amounts to match expected values after currency conversion and rounding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->