### PR TITLE
fix: add the location key to ios-info.js

### DIFF
--- a/hooks/utils/ios-info.js
+++ b/hooks/utils/ios-info.js
@@ -57,6 +57,8 @@ module.exports.getIosInfo = () =>
     <string>Fyle needs location access to calculate distance in your mileage expenses.</string>
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>Fyle needs location access to calculate distance in your mileage expenses.</string>
+    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+    <string>Fyle needs location access to calculate distance in your mileage expenses.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>To Record Audio With Video</string>
     <key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
<!--app.clickup.com-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new iOS permission description for location access, clarifying the app's need for location data both always and when in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->