### PR TITLE
fix: minor fix for pending-gas-charge tag

### DIFF
--- a/src/app/shared/components/pending-gas-charge-info/pending-gas-charge-info.component.scss
+++ b/src/app/shared/components/pending-gas-charge-info/pending-gas-charge-info.component.scss
@@ -10,6 +10,7 @@
   padding: 4px 8px;
   width: fit-content;
   margin-top: 16px;
+  white-space: nowrap;
 
   &--expense-list-view {
     margin-top: 8px;


### PR DESCRIPTION
## Clickup
app.clickup.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the display of pending gas charge information to keep text on a single line, preventing unwanted line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->