### PR TITLE
fix: remove timeout in my expenses polling

### DIFF
--- a/src/app/fyle/my-expenses/my-expenses.page.ts
+++ b/src/app/fyle/my-expenses/my-expenses.page.ts
@@ -679,13 +679,11 @@ export class MyExpensesPage implements OnInit {
         if (dEincompleteExpenseIds.length === 0) {
           return of(expenses); // All scans are completed
         } else {
-          return this.pollDEIncompleteExpenses(dEincompleteExpenseIds, expenses).pipe(
-            startWith(expenses),
-            timeout(30000),
-          );
+          return this.pollDEIncompleteExpenses(dEincompleteExpenseIds, expenses).pipe(startWith(expenses));
         }
       }),
       shareReplay(1),
+      takeUntil(this.onPageExit$),
     );
 
     this.count$ = this.loadExpenses$.pipe(


### PR DESCRIPTION
## Clickup
https://app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

https://fylein.slack.com/archives/C07FSVDTHFZ/p1755157033986589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - My Expenses now continuously updates incomplete per-diem expenses without stopping after a short period, reducing stale information.
  - Polling stops automatically when leaving the page, improving stability and preventing unnecessary background activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->