### PR TITLE
fix: Personal card/cash showing when not allowed

### DIFF
--- a/src/app/core/services/accounts.service.spec.ts
+++ b/src/app/core/services/accounts.service.spec.ts
@@ -54,7 +54,7 @@ import { TranslocoService } from '@jsverse/transloco';
 
 const accountsCallResponse1 = [account1Data, account2Data];
 
-fdescribe('AccountsService', () => {
+describe('AccountsService', () => {
   let accountsService: AccountsService;
   let spenderPlatformV1ApiService: jasmine.SpyObj<SpenderPlatformV1ApiService>;
   let fyCurrencyPipe: jasmine.SpyObj<FyCurrencyPipe>;

--- a/src/app/core/services/accounts.service.spec.ts
+++ b/src/app/core/services/accounts.service.spec.ts
@@ -54,7 +54,7 @@ import { TranslocoService } from '@jsverse/transloco';
 
 const accountsCallResponse1 = [account1Data, account2Data];
 
-describe('AccountsService', () => {
+fdescribe('AccountsService', () => {
   let accountsService: AccountsService;
   let spenderPlatformV1ApiService: jasmine.SpyObj<SpenderPlatformV1ApiService>;
   let fyCurrencyPipe: jasmine.SpyObj<FyCurrencyPipe>;
@@ -268,13 +268,14 @@ describe('AccountsService', () => {
   it('should be able to get allowed accounts when current expense payment mode is not allowed', () => {
     const allowedPaymentModes = ['PERSONAL_CORPORATE_CREDIT_CARD_ACCOUNT'];
     expect(
-      accountsService.getAllowedAccountsWithAdvanceWallets(
+      accountsService.getAllowedAccounts(
         multiplePaymentModesWithoutPersonalAccData,
         allowedPaymentModes,
+        false,
         etxnObjWithSourceData,
         false,
       ),
-    ).toEqual(multiplePaymentModesWithPersonalAndCompanyData);
+    ).toEqual(multiplePaymentModesIncPersonalAccData);
   });
 
   it('should be able to return allowed accounts with advance accounts', () => {
@@ -465,6 +466,6 @@ describe('AccountsService', () => {
         etxnObjWithSourceData,
         false,
       ),
-    ).toEqual(multiplePaymentModesWithPersonalAndCompanyData);
+    ).toEqual(multiplePaymentModesIncPersonalAccData);
   });
 });

--- a/src/app/core/services/accounts.service.ts
+++ b/src/app/core/services/accounts.service.ts
@@ -253,11 +253,10 @@ export class AccountsService {
     // Mileage and per diem expenses cannot have PCCC as a payment mode
     if (isMileageOrPerDiemExpense) {
       updatedModes = updatedModes.filter((mode) => mode !== AccountType.CCC);
-    }
-
-    // Only add PERSONAL_CASH_ACCOUNT as fallback if both PERSONAL and COMPANY are not present
-    if (!updatedModes.includes(AccountType.PERSONAL) && !updatedModes.includes(AccountType.COMPANY)) {
-      updatedModes.push(AccountType.PERSONAL);
+      // Only add PERSONAL_CASH_ACCOUNT as fallback if both PERSONAL and COMPANY are not present for mileage and per diem expenses
+      if (!updatedModes.includes(AccountType.PERSONAL) && !updatedModes.includes(AccountType.COMPANY)) {
+        updatedModes.push(AccountType.PERSONAL);
+      }
     }
 
     // Add current expense account to allowedPaymentModes if it's not present


### PR DESCRIPTION
## Clickup
https://app.clickup.com/

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Personal account is now auto-added only for mileage and per diem expenses when neither Personal nor Company accounts exist.
  * Prevents unintended Personal fallback for other expense types.
  * Continues to exclude corporate card accounts for mileage/per diem.

* **Documentation**
  * Updated inline comments to reflect the new conditional scope for the Personal fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->