### PR TITLE
fix: change from Add to report to add to expense report

### DIFF
--- a/src/app/core/mock-data/dashboard-task.data.ts
+++ b/src/app/core/mock-data/dashboard-task.data.ts
@@ -26,7 +26,7 @@ export const dashboardTasksData: DashboardTask[] = deepFreeze([
     subheader: '5 expenses  worth ₹37.04K  can be added to a report',
     amount: '37.04K',
     count: 5,
-    ctas: [{ content: 'Add to report', event: 1 }],
+    ctas: [{ content: 'Add to expense report', event: 1 }],
   },
   {
     icon: TaskIcon.REPORT,

--- a/src/app/core/mock-data/task.data.ts
+++ b/src/app/core/mock-data/task.data.ts
@@ -101,7 +101,7 @@ export const unreportedExpenseTaskSample = deepFreeze({
   icon: TaskIcon.REPORT,
   ctas: [
     {
-      content: 'Add to report',
+      content: 'Add to expense report',
       event: TASKEVENT.expensesAddToReport,
     },
   ],

--- a/src/app/core/services/tasks.service.spec.ts
+++ b/src/app/core/services/tasks.service.spec.ts
@@ -69,7 +69,7 @@ import {
 import { OrgService } from './org.service';
 import { orgData1 } from '../mock-data/org.data';
 import { UtilityService } from './utility.service';
-import { TranslocoTestingModule } from '@jsverse/transloco';
+import { getTranslocoModule } from '../testing/transloco-testing.utils';
 describe('TasksService', () => {
   let tasksService: TasksService;
   let reportService: jasmine.SpyObj<ReportService>;
@@ -110,7 +110,7 @@ describe('TasksService', () => {
     const utilityServiceSpy = jasmine.createSpyObj('UtilityService', ['isUserFromINCluster']);
 
     TestBed.configureTestingModule({
-      imports: [TranslocoTestingModule],
+      imports: [getTranslocoModule()],
       providers: [
         TasksService,
         {

--- a/src/app/core/services/tasks.service.spec.ts
+++ b/src/app/core/services/tasks.service.spec.ts
@@ -69,7 +69,7 @@ import {
 import { OrgService } from './org.service';
 import { orgData1 } from '../mock-data/org.data';
 import { UtilityService } from './utility.service';
-import { TranslocoService } from '@jsverse/transloco';
+import { TranslocoTestingModule } from '@jsverse/transloco';
 describe('TasksService', () => {
   let tasksService: TasksService;
   let reportService: jasmine.SpyObj<ReportService>;
@@ -87,7 +87,6 @@ describe('TasksService', () => {
   let orgSettingsService: jasmine.SpyObj<OrgSettingsService>;
   let orgService: jasmine.SpyObj<OrgService>;
   let utilityService: jasmine.SpyObj<UtilityService>;
-  let translocoService: jasmine.SpyObj<TranslocoService>;
   const mockTaskClearSubject = new Subject();
   const homeCurrency = 'INR';
 
@@ -109,91 +108,9 @@ describe('TasksService', () => {
     const approverReportsServiceSpy = jasmine.createSpyObj('ApproverReportsService', ['getReportsStats']);
     const orgServiceSpy = jasmine.createSpyObj('OrgService', ['getCurrentOrg', 'getPrimaryOrg']);
     const utilityServiceSpy = jasmine.createSpyObj('UtilityService', ['isUserFromINCluster']);
-    const translocoServiceSpy = jasmine.createSpyObj('TranslocoService', ['translate']);
-
-    // Mock translate method to return expected strings
-    translocoServiceSpy.translate.and.callFake((key: string, params?: any) => {
-      const translations: { [key: string]: string } = {
-        'services.tasks.expenses': 'Expenses',
-        'services.tasks.reports': 'Reports',
-        'services.tasks.advances': 'Advances',
-        'services.tasks.incomplete': 'Incomplete',
-        'services.tasks.complete': 'Complete',
-        'services.tasks.duplicate': 'Duplicate',
-        'services.tasks.draft': 'Draft',
-        'services.tasks.sentBack': 'Sent Back',
-        'services.tasks.unapproved': 'Unapproved',
-        'services.tasks.updatePhoneNumberHeader': 'Update phone number',
-        'services.tasks.optInToTextReceiptsHeader': 'Opt in to text receipts',
-        'services.tasks.updatePhoneNumberSubheader':
-          'Update your number to receive reminders for receipts through text messaging.',
-        'services.tasks.optInToTextReceiptsSubheader': 'Enable texting your receipts and instantly submit expenses',
-        'services.tasks.updateAndOptIn': 'Update',
-        'services.tasks.optIn': 'Opt in',
-        'services.tasks.addCorporateCard': 'Add corporate card',
-        'services.tasks.addCorporateCardSubheader': 'Link your corporate card to sync expenses from your card.',
-        'services.tasks.addCard': 'Add Card',
-        'services.tasks.potentialDuplicatesHeader': 'Merge duplicate expenses',
-        'services.tasks.potentialDuplicatesSubheader': 'Merge duplicate expenses present in your account',
-        'services.tasks.review': 'Review',
-        'services.tasks.merge': 'Merge',
-        'services.tasks.worth': 'worth',
-        'services.tasks.reportSentBack': 'Review sent back report',
-        'services.tasks.reportsSentBack': 'Review sent back reports',
-        'services.tasks.sentBackReportSubheader': 'Fix issues in your report to resubmit.',
-        'services.tasks.sentBackReportsSubheader': 'Fix issues in your reports to resubmit.',
-        'services.tasks.viewReport': 'View Report',
-        'services.tasks.viewReports': 'View Reports',
-        'services.tasks.advanceSentBack': 'Review sent back advance',
-        'services.tasks.advancesSentBack': 'Review sent back advances',
-        'services.tasks.sentBackAdvanceSubheader': 'Fix issues in your advance to resubmit.',
-        'services.tasks.sentBackAdvancesSubheader': 'Fix issues in your advances to resubmit.',
-        'services.tasks.viewAdvance': 'View Advance',
-        'services.tasks.viewAdvances': 'View Advances',
-        'services.tasks.unsubmittedReport': 'Submit {count} expense report',
-        'services.tasks.unsubmittedReports': 'Submit {count} expense reports',
-        'services.tasks.unsubmittedReportSubheader': 'Submit report for approval.',
-        'services.tasks.unsubmittedReportsSubheader': 'Submit reports for approval.',
-        'services.tasks.submitReport': 'Submit',
-        'services.tasks.reportToBeApproved': "Approve team's {count} report",
-        'services.tasks.reportsToBeApproved': "Approve team's {count} reports",
-        'services.tasks.teamReportSubheader': 'Approve pending report from your team.',
-        'services.tasks.teamReportsSubheader': 'Approve pending reports from your team.',
-        'services.tasks.approveReport': 'Approve',
-        'services.tasks.incompleteExpense': 'Complete {count} expense',
-        'services.tasks.incompleteExpenses': 'Complete {count} expenses',
-        'services.tasks.draftExpenseSubheader': 'Fill in missing details for incomplete expense',
-        'services.tasks.draftExpensesSubheader': 'Fill in missing details for incomplete expenses',
-        'services.tasks.completeExpense': 'Complete',
-        'services.tasks.expenseReadyToReport': 'Add {count} expense to report',
-        'services.tasks.expensesReadyToReport': 'Add {count} expenses to report',
-        'services.tasks.unreportedExpenseSubheader': 'Add complete expenses to a report and submit.',
-        'services.tasks.addToReport': 'Add to report',
-        'services.tasks.addCommuteDetails': 'Add Commute Details',
-        'services.tasks.addCommuteDetailsSubheader':
-          'Add your Home and Work locations to easily deduct commute distance from your mileage expenses',
-        'services.tasks.add': 'Add',
-      };
-
-      let translation = translations[key] || key;
-
-      // Handle parameter interpolation
-      if (params) {
-        if (params.count !== undefined) {
-          translation = translation.replace(/\{count\}/g, params.count);
-        }
-        if (params.amount !== undefined) {
-          // For amount parameter, replace with the actual amount or empty string if not provided
-          // If amount is provided, it should include a space before it
-          const amountValue = params.amount ? `${params.amount}` : '';
-          translation = translation.replace(/\{amount\}/g, amountValue);
-        }
-      }
-
-      return translation;
-    });
 
     TestBed.configureTestingModule({
+      imports: [TranslocoTestingModule],
       providers: [
         TasksService,
         {
@@ -256,10 +173,6 @@ describe('TasksService', () => {
           provide: UtilityService,
           useValue: utilityServiceSpy,
         },
-        {
-          provide: TranslocoService,
-          useValue: translocoServiceSpy,
-        },
       ],
     });
     tasksService = TestBed.inject(TasksService);
@@ -269,7 +182,7 @@ describe('TasksService', () => {
     authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
     advanceRequestService = TestBed.inject(AdvanceRequestService) as jasmine.SpyObj<AdvanceRequestService>;
     corporateCreditCardExpenseService = TestBed.inject(
-      CorporateCreditCardExpenseService
+      CorporateCreditCardExpenseService,
     ) as jasmine.SpyObj<CorporateCreditCardExpenseService>;
     currencyService = TestBed.inject(CurrencyService) as jasmine.SpyObj<CurrencyService>;
     humanizeCurrencyPipe = TestBed.inject(HumanizeCurrencyPipe) as jasmine.SpyObj<HumanizeCurrencyPipe>;
@@ -283,7 +196,6 @@ describe('TasksService', () => {
     utilityService = TestBed.inject(UtilityService) as jasmine.SpyObj<UtilityService>;
     orgSettingsService.get.and.returnValue(of(orgSettingsPendingRestrictions));
     utilityService.isUserFromINCluster.and.resolveTo(false);
-    translocoService = TestBed.inject(TranslocoService) as jasmine.SpyObj<TranslocoService>;
   });
 
   it('should be created', () => {
@@ -658,7 +570,7 @@ describe('TasksService', () => {
         potentialDuplicates: true,
         teamReports: true,
         sentBackAdvances: true,
-      })
+      }),
     ).toEqual([
       {
         label: 'Expenses',
@@ -686,7 +598,7 @@ describe('TasksService', () => {
         potentialDuplicates: true,
         teamReports: true,
         sentBackAdvances: false,
-      })
+      }),
     ).toEqual([
       {
         label: 'Expenses',
@@ -709,7 +621,7 @@ describe('TasksService', () => {
         potentialDuplicates: true,
         teamReports: true,
         sentBackAdvances: false,
-      })
+      }),
     ).toEqual([
       {
         label: 'Expenses',
@@ -743,7 +655,7 @@ describe('TasksService', () => {
         teamReports: [teamReportTaskSample],
         unreportedExpenses: [unreportedExpenseTaskSample],
         unsubmittedReports: [unsubmittedReportTaskSample],
-      }
+      },
     );
 
     expect(filteredTaskList).toEqual([
@@ -781,7 +693,7 @@ describe('TasksService', () => {
         totalCount: 1,
         totalAmount: totalCount,
       },
-      homeCurrency
+      homeCurrency,
     );
     expect(tasks[0].subheader).toEqual('Add complete expenses to a report and submit.');
   });
@@ -792,7 +704,7 @@ describe('TasksService', () => {
         totalAmount: 0,
         totalCount: 0,
       },
-      homeCurrency
+      homeCurrency,
     );
 
     expect(tasks).toEqual([]);
@@ -802,7 +714,7 @@ describe('TasksService', () => {
         total_amount: 0,
         count: 0,
       } as PlatformReportsStatsResponse,
-      homeCurrency
+      homeCurrency,
     );
 
     expect(tasks2).toEqual([]);
@@ -812,7 +724,7 @@ describe('TasksService', () => {
         total_amount: 0,
         count: 0,
       } as PlatformReportsStatsResponse,
-      homeCurrency
+      homeCurrency,
     );
 
     expect(tasks3).toEqual([]);
@@ -822,7 +734,7 @@ describe('TasksService', () => {
         totalAmount: 0,
         totalCount: 0,
       },
-      homeCurrency
+      homeCurrency,
     );
 
     expect(tasks4).toEqual([]);
@@ -832,7 +744,7 @@ describe('TasksService', () => {
         total_amount: 0,
         count: 0,
       } as PlatformReportsStatsResponse,
-      homeCurrency
+      homeCurrency,
     );
 
     expect(tasks5).toEqual([]);
@@ -842,7 +754,7 @@ describe('TasksService', () => {
         totalCount: 0,
         totalAmount: 0,
       },
-      homeCurrency
+      homeCurrency,
     );
 
     expect(tasks6).toEqual([]);
@@ -957,7 +869,7 @@ describe('TasksService', () => {
     userEventService.onTaskCacheClear.and.callFake((refreshCallback) =>
       mockTaskClearSubject.subscribe(() => {
         refreshCallback();
-      })
+      }),
     );
 
     reportService.getReportAutoSubmissionDetails.and.returnValue(
@@ -965,7 +877,7 @@ describe('TasksService', () => {
         data: {
           next_at: new Date(20, 12, 2022),
         },
-      })
+      }),
     );
 
     setupData();
@@ -977,7 +889,7 @@ describe('TasksService', () => {
     tasksService.totalTaskCount$
       .pipe(
         filter((count) => count === 5),
-        take(1)
+        take(1),
       )
       .subscribe((count) => {
         expect(count).toEqual(5);
@@ -998,7 +910,7 @@ describe('TasksService', () => {
         totalCount: 1,
         totalAmount: sentBackAdvancesResponse.total_amount,
       },
-      homeCurrency
+      homeCurrency,
     );
 
     expect(sentBackAdvanceTask).toEqual([
@@ -1039,7 +951,7 @@ describe('TasksService', () => {
         count: 2,
         total_amount: sentBackResponse[0].aggregates[1].function_value,
       } as PlatformReportsStatsResponse,
-      homeCurrency
+      homeCurrency,
     );
 
     expect(sentBackReportTask).toEqual([
@@ -1077,7 +989,7 @@ describe('TasksService', () => {
         totalCount: 1,
         totalAmount: incompleteExpensesResponse[0].aggregates[1].function_value,
       },
-      homeCurrency
+      homeCurrency,
     );
 
     expect(tasks).toEqual([
@@ -1112,7 +1024,7 @@ describe('TasksService', () => {
         total_amount: unsubmittedReportsResponse[0].aggregates[1].function_value,
         count: 1,
       } as PlatformReportsStatsResponse,
-      homeCurrency
+      homeCurrency,
     );
 
     expect(tasks).toEqual([
@@ -1153,7 +1065,7 @@ describe('TasksService', () => {
         total_amount: teamReportResponse[0].aggregates[1].function_value,
         count: 1,
       } as PlatformReportsStatsResponse,
-      homeCurrency
+      homeCurrency,
     );
 
     expect(tasks).toEqual([
@@ -1178,7 +1090,7 @@ describe('TasksService', () => {
     userEventService.onTaskCacheClear.and.callFake((refreshCallback) =>
       mockTaskClearSubject.subscribe(() => {
         refreshCallback();
-      })
+      }),
     );
 
     reportService.getReportAutoSubmissionDetails.and.returnValue(of(null));
@@ -1192,7 +1104,7 @@ describe('TasksService', () => {
     tasksService.totalTaskCount$
       .pipe(
         filter((count) => count === 7),
-        take(1)
+        take(1),
       )
       .subscribe((count) => {
         expect(count).toEqual(7);
@@ -1244,7 +1156,7 @@ describe('TasksService', () => {
       eou.org.currency = 'CAD';
       authService.getEou.and.resolveTo(eou);
       const mapMobileNumberVerificationTaskSpy = spyOn(tasksService, 'mapMobileNumberVerificationTask').and.returnValue(
-        [addMobileNumberTask]
+        [addMobileNumberTask],
       );
       tasksService.getMobileNumberVerificationTasks().subscribe((res) => {
         expect(authService.getEou).toHaveBeenCalledTimes(1);
@@ -1260,7 +1172,7 @@ describe('TasksService', () => {
       eou.org.currency = 'USD';
       authService.getEou.and.resolveTo(eou);
       const mapMobileNumberVerificationTaskSpy = spyOn(tasksService, 'mapMobileNumberVerificationTask').and.returnValue(
-        [addMobileNumberTask]
+        [addMobileNumberTask],
       );
       tasksService.getMobileNumberVerificationTasks().subscribe((res) => {
         expect(authService.getEou).toHaveBeenCalledTimes(1);

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -1479,7 +1479,7 @@
                 @if (pendingTransactionAllowedToReportAndSplit) {
                   <div class="add-edit-expense--internal-block">
                     <app-fy-add-to-report
-                      [label]="etxn.tx.report_id ? 'Report' : 'Add to report'"
+                      [label]="etxn.tx.report_id ? 'Report' : 'Add to expense report'"
                       [autoSubmissionReportName]="autoSubmissionReportName$ | async"
                       [options]="reports"
                       [isNewReportsFlowEnabled]="isNewReportsFlowEnabled"

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
@@ -715,7 +715,7 @@
                       @if (canRemoveFromReport || !etxn?.tx?.report_id) {
                         <div class="add-edit-mileage--internal-block">
                           <app-fy-add-to-report
-                            [label]="etxn.tx.report_id ? 'Report' : 'Add to report'"
+                            [label]="etxn.tx.report_id ? 'Report' : 'Add to expensereport'"
                             [options]="reports"
                             formControlName="report"
                             [autoSubmissionReportName]="autoSubmissionReportName$ | async"

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
@@ -715,7 +715,7 @@
                       @if (canRemoveFromReport || !etxn?.tx?.report_id) {
                         <div class="add-edit-mileage--internal-block">
                           <app-fy-add-to-report
-                            [label]="etxn.tx.report_id ? 'Report' : 'Add to expensereport'"
+                            [label]="etxn.tx.report_id ? 'Report' : 'Add to expense report'"
                             [options]="reports"
                             formControlName="report"
                             [autoSubmissionReportName]="autoSubmissionReportName$ | async"

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
@@ -743,7 +743,7 @@
                           @if (canRemoveFromReport || !etxn?.tx?.report_id) {
                             <div class="add-edit-per-diem--internal-block">
                               <app-fy-add-to-report
-                                [label]="etxn.tx.report_id ? 'Report' : 'Add to report'"
+                                [label]="etxn.tx.report_id ? 'Report' : 'Add to expense report'"
                                 [options]="reports"
                                 formControlName="report"
                                 [autoSubmissionReportName]="autoSubmissionReportName$ | async"

--- a/src/app/fyle/dashboard/tasks/tasks-card/tasks-card.component.spec.ts
+++ b/src/app/fyle/dashboard/tasks/tasks-card/tasks-card.component.spec.ts
@@ -30,10 +30,14 @@ describe('TasksCardComponent', () => {
       return translations[key] || key;
     });
     TestBed.configureTestingModule({
-    declarations: [TasksCardComponent],
-    imports: [IonicModule.forRoot(), MatRippleModule, MatIconModule, MatIconTestingModule],
-    providers: [{ provide: TranslocoService, useValue: translocoService }, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-}).compileComponents();
+      declarations: [TasksCardComponent],
+      imports: [IonicModule.forRoot(), MatRippleModule, MatIconModule, MatIconTestingModule],
+      providers: [
+        { provide: TranslocoService, useValue: translocoService },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(TasksCardComponent);
     component = fixture.componentInstance;
@@ -47,7 +51,7 @@ describe('TasksCardComponent', () => {
       icon: TaskIcon.REPORT,
       ctas: [
         {
-          content: 'Add to report',
+          content: 'Add to expense report',
           event: TASKEVENT.expensesAddToReport,
         },
       ],

--- a/src/app/fyle/my-create-report/my-create-report.page.html
+++ b/src/app/fyle/my-create-report/my-create-report.page.html
@@ -133,7 +133,7 @@
         (click)="ctaClickedEvent('create_draft_report')"
         appFormButtonValidation
         [loading]="saveDraftReportLoading"
-        [loadingText]="'Saving Report'"
+        [loadingText]="'Saving report'"
         [disabled]="emptyInput"
       >
         Save as draft

--- a/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.spec.ts
+++ b/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.spec.ts
@@ -15,7 +15,7 @@ import { SnakeCaseToSpaceCase } from 'src/app/shared/pipes/snake-case-to-space-c
 import { AddTxnToReportDialogComponent } from './add-txn-to-report-dialog.component';
 import { expectedReportsSinglePage } from 'src/app/core/mock-data/platform-report.data';
 import { ExactCurrencyPipe } from 'src/app/shared/pipes/exact-currency.pipe';
-import { TranslocoService, TranslocoModule } from '@jsverse/transloco';
+import { TranslocoService, TranslocoTestingModule } from '@jsverse/transloco';
 
 describe('AddTxnToReportDialogComponent', () => {
   let component: AddTxnToReportDialogComponent;
@@ -23,42 +23,10 @@ describe('AddTxnToReportDialogComponent', () => {
   let currencyService: jasmine.SpyObj<CurrencyService>;
   let matBottomsheet: jasmine.SpyObj<MatBottomSheet>;
   let router: jasmine.SpyObj<Router>;
-  let translocoService: jasmine.SpyObj<TranslocoService>;
   beforeEach(waitForAsync(() => {
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     const currencyServiceSpy = jasmine.createSpyObj('CurrencyService', ['getHomeCurrency']);
     const matBottomsheetSpy = jasmine.createSpyObj('MatBottomSheet', ['dismiss']);
-    const translocoServiceSpy = jasmine.createSpyObj('TranslocoService', ['translate'], {
-      config: {
-        reRenderOnLangChange: true,
-      },
-      langChanges$: of('en'),
-      _loadDependencies: () => Promise.resolve(),
-    });
-
-    // Mock the translate method
-    translocoServiceSpy.translate.and.callFake((key: any, params?: any) => {
-      const translations: { [key: string]: string } = {
-        'pipes.reportState.draft': 'Draft',
-        'addTxnToReportDialog.title': 'Add to report',
-        'addTxnToReportDialog.expense': 'Expense',
-        'addTxnToReportDialog.expenses': 'Expenses',
-        'addTxnToReportDialog.noReports': 'You have no reports right now',
-        'addTxnToReportDialog.createDraftReportCta':
-          'To create a draft report please click on <ion-icon class="report-list--zero-state__icon" slot="icon-only" src="../../../../../assets/svg/plus-square.svg"></ion-icon>',
-      };
-      let translation = translations[key] || key;
-
-      // Handle parameter interpolation
-      if (params && typeof translation === 'string') {
-        Object.keys(params).forEach((paramKey) => {
-          const placeholder = `{{${paramKey}}}`;
-          translation = translation.replace(placeholder, params[paramKey]);
-        });
-      }
-
-      return translation;
-    });
 
     TestBed.configureTestingModule({
       declarations: [
@@ -69,7 +37,7 @@ describe('AddTxnToReportDialogComponent', () => {
         ReportState,
         SnakeCaseToSpaceCase,
       ],
-      imports: [IonicModule.forRoot(), RouterTestingModule, RouterModule, MatBottomSheetModule, TranslocoModule],
+      imports: [IonicModule.forRoot(), RouterTestingModule, RouterModule, MatBottomSheetModule, TranslocoTestingModule],
       providers: [
         FyCurrencyPipe,
         CurrencyPipe,
@@ -89,10 +57,6 @@ describe('AddTxnToReportDialogComponent', () => {
           provide: MAT_BOTTOM_SHEET_DATA,
           useValue: { openReports: expectedReportsSinglePage, isNewReportsFlowEnabled: true },
         },
-        {
-          provide: TranslocoService,
-          useValue: translocoServiceSpy,
-        },
       ],
     }).compileComponents();
 
@@ -101,7 +65,6 @@ describe('AddTxnToReportDialogComponent', () => {
     router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
     currencyService = TestBed.inject(CurrencyService) as jasmine.SpyObj<CurrencyService>;
     matBottomsheet = TestBed.inject(MatBottomSheet) as jasmine.SpyObj<MatBottomSheet>;
-    translocoService = TestBed.inject(TranslocoService) as jasmine.SpyObj<TranslocoService>;
     currencyService.getHomeCurrency.and.returnValue(of('USD'));
     fixture.detectChanges();
   }));

--- a/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.spec.ts
+++ b/src/app/fyle/my-expenses/add-txn-to-report-dialog/add-txn-to-report-dialog.component.spec.ts
@@ -15,7 +15,7 @@ import { SnakeCaseToSpaceCase } from 'src/app/shared/pipes/snake-case-to-space-c
 import { AddTxnToReportDialogComponent } from './add-txn-to-report-dialog.component';
 import { expectedReportsSinglePage } from 'src/app/core/mock-data/platform-report.data';
 import { ExactCurrencyPipe } from 'src/app/shared/pipes/exact-currency.pipe';
-import { TranslocoService, TranslocoTestingModule } from '@jsverse/transloco';
+import { getTranslocoModule } from 'src/app/core/testing/transloco-testing.utils';
 
 describe('AddTxnToReportDialogComponent', () => {
   let component: AddTxnToReportDialogComponent;
@@ -37,7 +37,7 @@ describe('AddTxnToReportDialogComponent', () => {
         ReportState,
         SnakeCaseToSpaceCase,
       ],
-      imports: [IonicModule.forRoot(), RouterTestingModule, RouterModule, MatBottomSheetModule, TranslocoTestingModule],
+      imports: [IonicModule.forRoot(), RouterTestingModule, RouterModule, MatBottomSheetModule, getTranslocoModule()],
       providers: [
         FyCurrencyPipe,
         CurrencyPipe,

--- a/src/app/fyle/my-expenses/my-expenses.page.spec.ts
+++ b/src/app/fyle/my-expenses/my-expenses.page.spec.ts
@@ -129,7 +129,7 @@ import { apiEouRes } from 'src/app/core/mock-data/extended-org-user.data';
 import { properties } from 'src/app/core/mock-data/modal-properties.data';
 import { ExpensesQueryParams } from 'src/app/core/models/platform/v1/expenses-query-params.model';
 import { Expense } from 'src/app/core/models/platform/v1/expense.model';
-import { TranslocoTestingModule } from '@jsverse/transloco';
+import { getTranslocoModule } from 'src/app/core/testing/transloco-testing.utils';
 import { WalkthroughService } from 'src/app/core/services/walkthrough.service';
 import { FooterState } from 'src/app/shared/components/footer/footer-state.enum';
 
@@ -324,7 +324,7 @@ describe('MyExpensesPage', () => {
     TestBed.configureTestingModule({
       declarations: [MyExpensesPage, ReportState, MaskNumber],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [IonicModule.forRoot(), RouterTestingModule, TranslocoTestingModule],
+      imports: [IonicModule.forRoot(), RouterTestingModule, getTranslocoModule()],
       providers: [
         { provide: TasksService, useValue: tasksServiceSpy },
         { provide: CurrencyService, useValue: currencyServiceSpy },

--- a/src/app/fyle/my-expenses/my-expenses.page.spec.ts
+++ b/src/app/fyle/my-expenses/my-expenses.page.spec.ts
@@ -129,8 +129,7 @@ import { apiEouRes } from 'src/app/core/mock-data/extended-org-user.data';
 import { properties } from 'src/app/core/mock-data/modal-properties.data';
 import { ExpensesQueryParams } from 'src/app/core/models/platform/v1/expenses-query-params.model';
 import { Expense } from 'src/app/core/models/platform/v1/expense.model';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
-import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { TranslocoTestingModule } from '@jsverse/transloco';
 import { WalkthroughService } from 'src/app/core/services/walkthrough.service';
 import { FooterState } from 'src/app/shared/components/footer/footer-state.enum';
 
@@ -169,7 +168,6 @@ describe('MyExpensesPage', () => {
   let utilityService: jasmine.SpyObj<UtilityService>;
   let featureConfigService: jasmine.SpyObj<FeatureConfigService>;
   let authService: jasmine.SpyObj<AuthService>;
-  let translocoService: jasmine.SpyObj<TranslocoService>;
   let walkthroughService: jasmine.SpyObj<WalkthroughService>;
   beforeEach(waitForAsync(() => {
     const tasksServiceSpy = jasmine.createSpyObj('TasksService', ['getReportsTaskCount', 'getExpensesTaskCount']);
@@ -322,123 +320,11 @@ describe('MyExpensesPage', () => {
       'getMyExpensesBlockedStatusPillWalkthroughConfig',
       'getMyExpensesIncompleteStatusPillWalkthroughConfig',
     ]);
-    const translocoServiceSpy = jasmine.createSpyObj('TranslocoService', ['translate'], {
-      config: {
-        reRenderOnLangChange: true,
-      },
-      langChanges$: of('en'),
-      _loadDependencies: () => Promise.resolve(),
-    });
 
-    translocoServiceSpy.translate.and.callFake((key: any, params?: any) => {
-      const translations: { [key: string]: string } = {
-        'myExpensesPage.title': 'My expenses',
-        'myExpensesPage.searchPlaceholder': 'Search',
-        'myExpensesPage.addExpense': 'Add Expense',
-        'myExpensesPage.selectAll': 'Select all',
-        'myExpensesPage.expense': 'expense',
-        'myExpensesPage.expenses': 'expenses',
-        'myExpensesPage.createNewReport': 'Create new report',
-        'myExpensesPage.addToReports': 'Add to reports',
-        'myExpensesPage.startReview': 'Start review',
-        'myExpensesPage.zeroState.noExpenses': 'You have no expenses right now',
-        'myExpensesPage.zeroState.noResultsFound': 'No results found',
-        'myExpensesPage.zeroState.tryDifferentKeyword': 'Try a different keyword',
-        'myExpensesPage.zeroState.noExpensesMatchingFilters': 'You have no expenses matching the applied filters',
-        'myExpensesPage.offline.syncMessage': 'Data will sync once you are connected to internet',
-        'myExpensesPage.offline.offlineHeader': "You're Offline!",
-        'myExpensesPage.offline.offlineMessage': 'Fear not, you can still add expenses offline.',
-        'myExpensesPage.actionSheet.header': 'ADD EXPENSE',
-        'myExpensesPage.actionSheet.captureReceipt': 'Capture receipt',
-        'myExpensesPage.actionSheet.addManually': 'Add manually',
-        'myExpensesPage.actionSheet.addMileage': 'Add mileage',
-        'myExpensesPage.actionSheet.addPerDiem': 'Add per diem',
-        'myExpensesPage.loader.addingExpenseToReport': 'Adding expense to report',
-        'myExpensesPage.filters.cardsEndingIn': 'Cards ending in...',
-        'myExpensesPage.criticalPolicyViolation.excludeAndContinue': 'Exclude and Continue',
-        'myExpensesPage.criticalPolicyViolation.cancel': 'Cancel',
-        'myExpensesPage.errors.selectExpensesToReport': 'Please select one or more expenses to be reported',
-        'myExpensesPage.errors.cantAddExpenses': "Can't add these expenses...",
-        'myExpensesPage.errors.cantAddDraftExpenses': "You can't add draft expenses to a report.",
-        'myExpensesPage.errors.cantAddPolicyViolatedExpenses':
-          "You can't add expenses with critical policy violations to a report.",
-        'myExpensesPage.errors.cantAddPendingTransactions':
-          "You can't add expenses with pending transactions to a report.",
-        'myExpensesPage.errors.cantAddDraftAndPolicyViolated':
-          "You can't add draft expenses & expenses with critical policy violations to a report.",
-        'myExpensesPage.errors.cantAddDraftAndPendingTransactions':
-          "You can't add draft expenses & expenses with pending transactions to a report.",
-        'myExpensesPage.errors.cantAddPolicyViolatedAndPendingTransactions':
-          "You can't add expenses with critical policy violation & pending transactions to a report.",
-        'myExpensesPage.errors.cantAddDraftPolicyViolatedAndPendingTransactions':
-          "You can't add draft expenses and expenses with critical policy violation & pending transactions.",
-        'myExpensesPage.errors.couldNotDeleteExpenses': 'We could not delete the expenses. Please try again',
-        'myExpensesPage.errors.expensesInDraftState': '{{count}} {{expenseText}} in draft state.',
-        'myExpensesPage.errors.expensesWithPendingTransactions': '{{count}} {{expenseText}} with pending transactions.',
-        'myExpensesPage.errors.expensesWithCriticalPolicyViolations':
-          '{{count}} {{expenseText}} with Critical Policy Violations.',
-        'myExpensesPage.unreportableExpenseExceptionHandler.message111':
-          "You can't add draft expenses and expenses with critical policy violation & pending transactions.",
-        'myExpensesPage.unreportableExpenseExceptionHandler.message110':
-          "You can't add draft expenses & expenses with critical policy violations to a report.",
-        'myExpensesPage.unreportableExpenseExceptionHandler.message101':
-          "You can't add draft expenses & expenses with pending transactions to a report.",
-        'myExpensesPage.unreportableExpenseExceptionHandler.message011':
-          "You can't add expenses with critical policy violation & pending transactions to a report.",
-        'myExpensesPage.unreportableExpenseExceptionHandler.message100': "You can't add draft expenses to a report.",
-        'myExpensesPage.unreportableExpenseExceptionHandler.message010':
-          "You can't add expenses with critical policy violations to a report.",
-        'myExpensesPage.unreportableExpenseExceptionHandler.message001':
-          "You can't add expenses with pending transactions to a report.",
-        'myExpensesPage.reportableExpenseDialogHandler.cantAddTheseExpensesTitle': "Can't add these expenses...",
-        'myExpensesPage.reportableExpenseDialogHandler.expensesAre': 'expenses are',
-        'myExpensesPage.reportableExpenseDialogHandler.expenseIs': 'expense is',
-        'myExpensesPage.reportableExpenseDialogHandler.expenses': 'expenses',
-        'myExpensesPage.reportableExpenseDialogHandler.expense': 'expense',
-        'myExpensesPage.reportableExpenseDialogHandler.inDraftState': 'in draft state',
-        'myExpensesPage.reportableExpenseDialogHandler.withPendingTransactions': 'with pending transactions',
-        'myExpensesPage.reportableExpenseDialogHandler.withCriticalPolicyViolations': 'with Critical Policy Violations',
-        'myExpensesPage.openCreateReportWithSelectedIds.pleaseSelectExpensesToBeReported':
-          'Please select one or more expenses to be reported',
-        'myExpensesPage.showAddToReportSuccessToast.viewReport': 'View Report',
-        'myExpensesPage.showOldReportsMatBottomSheet.expensesAddedToExistingDraftReport':
-          'Expenses added to an existing draft report',
-        'myExpensesPage.showOldReportsMatBottomSheet.expensesAddedToReportSuccess':
-          'Expenses added to report successfully',
-        'myExpensesPage.openDeleteExpensesPopover.deleteExpense': 'Delete expense',
-        'myExpensesPage.openDeleteExpensesPopover.excludeAndDelete': 'Exclude and Delete',
-        'myExpensesPage.openDeleteExpensesPopover.delete': 'Delete',
-        'myExpensesPage.openDeleteExpensesPopover.oneExpenseDeleted': '1 expense has been deleted',
-        'myExpensesPage.openDeleteExpensesPopover.expensesDeleted': '{{count}} expenses have been deleted',
-        'myExpensesPage.openDeleteExpensesPopover.couldNotDeleteExpenses':
-          'We could not delete the expenses. Please try again',
-        'myExpensesPage.onHomeClicked.page': 'Expenses',
-        'myExpensesPage.onTaskClicked.from': 'My Expenses',
-        'myExpensesPage.actions.excludeAndContinue': 'Exclude and Continue',
-        'myExpensesPage.actions.cancel': 'Cancel',
-        'myExpensesPage.success.expenseDeleted': '1 expense has been deleted',
-        'myExpensesPage.success.expensesDeleted': '{{count}} expenses have been deleted',
-        'myExpensesPage.success.expensesAddedToExistingDraft': 'Expenses added to an existing draft report',
-        'myExpensesPage.success.expensesAddedToReport': 'Expenses added to report successfully',
-        'myExpensesPage.tracking.page': 'Expenses',
-        'myExpensesPage.tracking.from': 'My Expenses',
-        'myExpensesPage.actionSheet.addExpense': 'ADD EXPENSE',
-      };
-      let translation = translations[key] || key;
-
-      if (params && typeof translation === 'string') {
-        Object.keys(params).forEach((paramKey) => {
-          const placeholder = `{{${paramKey}}}`;
-          translation = translation.replace(placeholder, params[paramKey]);
-        });
-      }
-
-      return translation;
-    });
     TestBed.configureTestingModule({
       declarations: [MyExpensesPage, ReportState, MaskNumber],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [IonicModule.forRoot(), RouterTestingModule, TranslocoModule],
+      imports: [IonicModule.forRoot(), RouterTestingModule, TranslocoTestingModule],
       providers: [
         { provide: TasksService, useValue: tasksServiceSpy },
         { provide: CurrencyService, useValue: currencyServiceSpy },
@@ -547,10 +433,6 @@ describe('MyExpensesPage', () => {
           useValue: authServiceSpy,
         },
         {
-          provide: TranslocoService,
-          useValue: translocoServiceSpy,
-        },
-        {
           provide: WalkthroughService,
           useValue: walkthroughServiceSpy,
         },
@@ -600,7 +482,6 @@ describe('MyExpensesPage', () => {
     utilityService = TestBed.inject(UtilityService) as jasmine.SpyObj<UtilityService>;
     featureConfigService = TestBed.inject(FeatureConfigService) as jasmine.SpyObj<FeatureConfigService>;
     authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
-    translocoService = TestBed.inject(TranslocoService) as jasmine.SpyObj<TranslocoService>;
     walkthroughService = TestBed.inject(WalkthroughService) as jasmine.SpyObj<WalkthroughService>;
     component.loadExpenses$ = new BehaviorSubject({});
   }));

--- a/src/app/fyle/my-view-report/add-expenses-to-report/add-expenses-to-report.component.spec.ts
+++ b/src/app/fyle/my-view-report/add-expenses-to-report/add-expenses-to-report.component.spec.ts
@@ -11,7 +11,7 @@ import { HumanizeCurrencyPipe } from 'src/app/shared/pipes/humanize-currency.pip
 import { ExactCurrencyPipe } from 'src/app/shared/pipes/exact-currency.pipe';
 import { AddExpensesToReportComponent } from './add-expenses-to-report.component';
 import { expenseData } from 'src/app/core/mock-data/platform/v1/expense.data';
-import { TranslocoService, TranslocoModule } from '@jsverse/transloco';
+import { TranslocoTestingModule } from '@jsverse/transloco';
 
 describe('AddExpensesToReportComponent', () => {
   let component: AddExpensesToReportComponent;
@@ -19,7 +19,6 @@ describe('AddExpensesToReportComponent', () => {
   let modalController: jasmine.SpyObj<ModalController>;
   let currencyService: jasmine.SpyObj<CurrencyService>;
   let router: jasmine.SpyObj<Router>;
-  let translocoService: jasmine.SpyObj<TranslocoService>;
   const expense1 = expenseData;
   const expense2 = { ...expenseData, id: 'txcSFe6efB62' };
   const expense3 = { ...expenseData, id: 'txcSFe6efB63' };
@@ -28,16 +27,9 @@ describe('AddExpensesToReportComponent', () => {
     const modalControllerSpy = jasmine.createSpyObj('ModalController', ['dismiss']);
     const currencyServiceSpy = jasmine.createSpyObj('CurrencyService', ['getHomeCurrency']);
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
-    const translocoServiceSpy = jasmine.createSpyObj('TranslocoService', ['translate'], {
-      config: {
-        reRenderOnLangChange: true,
-      },
-      langChanges$: of('en'),
-      _loadDependencies: () => Promise.resolve(),
-    });
     TestBed.configureTestingModule({
       declarations: [AddExpensesToReportComponent, HumanizeCurrencyPipe, ExactCurrencyPipe],
-      imports: [IonicModule.forRoot(), TranslocoModule],
+      imports: [IonicModule.forRoot(), TranslocoTestingModule],
       providers: [
         FyCurrencyPipe,
         CurrencyPipe,
@@ -53,10 +45,6 @@ describe('AddExpensesToReportComponent', () => {
           provide: Router,
           useValue: routerSpy,
         },
-        {
-          provide: TranslocoService,
-          useValue: translocoServiceSpy,
-        },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -66,31 +54,6 @@ describe('AddExpensesToReportComponent', () => {
     modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
     currencyService = TestBed.inject(CurrencyService) as jasmine.SpyObj<CurrencyService>;
     router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
-    translocoService = TestBed.inject(TranslocoService) as jasmine.SpyObj<TranslocoService>;
-    translocoService.translate.and.callFake((key: any, params?: any) => {
-      const translations: { [key: string]: string } = {
-        'addExpensesToReport.addExpenses': 'Add expenses',
-        'addExpensesToReport.expenses': 'Expenses',
-        'addExpensesToReport.expense': 'Expense',
-        'addExpensesToReport.selectAll': 'Select all',
-        'addExpensesToReport.noExpenseInReport': 'No expense in this report',
-        'addExpensesToReport.noCompleteExpenses': 'You have no complete expenses',
-        'addExpensesToReport.clickOnThe': 'Click on the',
-        'addExpensesToReport.toAddNewExpense': 'to add a new expense to this report',
-        'addExpensesToReport.addToReport': 'Add to report',
-      };
-      let translation = translations[key] || key;
-
-      // Handle parameter interpolation
-      if (params && typeof translation === 'string') {
-        Object.keys(params).forEach((paramKey) => {
-          const placeholder = `{{${paramKey}}}`;
-          translation = translation.replace(placeholder, params[paramKey]);
-        });
-      }
-
-      return translation;
-    });
 
     currencyService.getHomeCurrency.and.returnValue(of('USD'));
     component.selectedExpenseIds = ['txCYDX0peUw5', 'txfCdl3TEZ7K'];
@@ -253,7 +216,7 @@ describe('AddExpensesToReportComponent', () => {
     tick();
     fixture.detectChanges();
     expect(getTextContent(getElementBySelector(fixture, '.add-expenses-to-report--zero-state--header'))).toEqual(
-      'You have no complete expenses'
+      'You have no complete expenses',
     );
   }));
 });

--- a/src/app/fyle/my-view-report/add-expenses-to-report/add-expenses-to-report.component.spec.ts
+++ b/src/app/fyle/my-view-report/add-expenses-to-report/add-expenses-to-report.component.spec.ts
@@ -11,7 +11,7 @@ import { HumanizeCurrencyPipe } from 'src/app/shared/pipes/humanize-currency.pip
 import { ExactCurrencyPipe } from 'src/app/shared/pipes/exact-currency.pipe';
 import { AddExpensesToReportComponent } from './add-expenses-to-report.component';
 import { expenseData } from 'src/app/core/mock-data/platform/v1/expense.data';
-import { TranslocoTestingModule } from '@jsverse/transloco';
+import { getTranslocoModule } from 'src/app/core/testing/transloco-testing.utils';
 
 describe('AddExpensesToReportComponent', () => {
   let component: AddExpensesToReportComponent;
@@ -29,7 +29,7 @@ describe('AddExpensesToReportComponent', () => {
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     TestBed.configureTestingModule({
       declarations: [AddExpensesToReportComponent, HumanizeCurrencyPipe, ExactCurrencyPipe],
-      imports: [IonicModule.forRoot(), TranslocoTestingModule],
+      imports: [IonicModule.forRoot(), getTranslocoModule()],
       providers: [
         FyCurrencyPipe,
         CurrencyPipe,

--- a/src/app/shared/components/create-new-report-v2/create-new-report.component.spec.ts
+++ b/src/app/shared/components/create-new-report-v2/create-new-report.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
-import { TranslocoService, TranslocoModule } from '@jsverse/transloco';
+import { TranslocoTestingModule } from '@jsverse/transloco';
 import { IonicModule } from '@ionic/angular';
 import { MatIconModule } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
@@ -11,7 +11,6 @@ import { CurrencyService } from 'src/app/core/services/currency.service';
 import { ExpenseFieldsService } from 'src/app/core/services/expense-fields.service';
 import { CreateNewReportComponent } from './create-new-report.component';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { ExpensesCardComponent } from '../expenses-card/expenses-card.component';
 import { of } from 'rxjs';
 import { orgData1 } from 'src/app/core/mock-data/org.data';
 import { expenseFieldsMapResponse2 } from 'src/app/core/mock-data/expense-fields-map.data';
@@ -30,7 +29,6 @@ describe('CreateNewReportComponent', () => {
   let currencyService: jasmine.SpyObj<CurrencyService>;
   let expenseFieldsService: jasmine.SpyObj<ExpenseFieldsService>;
   let spenderReportsService: jasmine.SpyObj<SpenderReportsService>;
-  let translocoService: jasmine.SpyObj<TranslocoService>;
 
   beforeEach(waitForAsync(() => {
     modalController = jasmine.createSpyObj('ModalController', ['dismiss']);
@@ -46,13 +44,6 @@ describe('CreateNewReportComponent', () => {
     const humanizeCurrencyPipeSpy = jasmine.createSpyObj('HumanizeCurrency', ['transform']);
     const exactCurrencyPipeSpy = jasmine.createSpyObj('ExactCurrency', ['transform']);
     const fyCurrencyPipeSpy = jasmine.createSpyObj('FyCurrencyPipe', ['transform']);
-    const translocoServiceSpy = jasmine.createSpyObj('TranslocoService', ['translate'], {
-      config: {
-        reRenderOnLangChange: true,
-      },
-      langChanges$: of('en'),
-      _loadDependencies: () => Promise.resolve(),
-    });
     TestBed.configureTestingModule({
       declarations: [CreateNewReportComponent, HumanizeCurrencyPipe, ExactCurrencyPipe, FyCurrencyPipe],
       imports: [
@@ -62,7 +53,7 @@ describe('CreateNewReportComponent', () => {
         FormsModule,
         ReactiveFormsModule,
         MatCheckboxModule,
-        TranslocoModule,
+        TranslocoTestingModule,
       ],
       providers: [
         { provide: ModalController, useValue: modalController },
@@ -73,7 +64,6 @@ describe('CreateNewReportComponent', () => {
         { provide: ExactCurrencyPipe, useValue: exactCurrencyPipeSpy },
         { provide: FyCurrencyPipe, useValue: fyCurrencyPipeSpy },
         { provide: SpenderReportsService, useValue: spenderReportsService },
-        { provide: TranslocoService, useValue: translocoServiceSpy },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -83,36 +73,6 @@ describe('CreateNewReportComponent', () => {
     expenseFieldsService = TestBed.inject(ExpenseFieldsService) as jasmine.SpyObj<ExpenseFieldsService>;
     spenderReportsService = TestBed.inject(SpenderReportsService) as jasmine.SpyObj<SpenderReportsService>;
     modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
-    translocoService = TestBed.inject(TranslocoService) as jasmine.SpyObj<TranslocoService>;
-    translocoService.translate.and.callFake((key: any, params?: any) => {
-      const translations: { [key: string]: string } = {
-        'createNewReport.title': 'Create new report',
-        'createNewReport.expenseSingular': 'expense',
-        'createNewReport.expensePlural': 'expenses',
-        'createNewReport.reportNameLabel': 'Expense report name',
-        'createNewReport.reportNamePlaceholder': 'Enter expense report name',
-        'createNewReport.reportNameError': 'Please enter expense report name.',
-        'createNewReport.expensesHeading': 'Expenses',
-        'createNewReport.selectAll': 'Select all',
-        'createNewReport.savingReport': 'Saving Report',
-        'createNewReport.saveAsDraft': 'Save as draft',
-        'createNewReport.submittingReport': 'Submitting Report',
-        'createNewReport.submitReport': 'Submit report',
-        'createNewReport.draftSuccessMessage': 'Expenses added to a new report',
-        'createNewReport.submitSuccessMessage': 'Expenses submitted for approval',
-      };
-      let translation = translations[key] || key;
-
-      // Handle parameter interpolation
-      if (params && typeof translation === 'string') {
-        Object.keys(params).forEach((paramKey) => {
-          const placeholder = `{{${paramKey}}}`;
-          translation = translation.replace(placeholder, params[paramKey]);
-        });
-      }
-
-      return translation;
-    });
     currencyService.getHomeCurrency.and.returnValue(of(orgData1[0].currency));
     expenseFieldsService.getAllMap.and.returnValue(of(expenseFieldsMapResponse2));
     spenderReportsService.createDraft.and.returnValue(of(expectedReportsSinglePage[0]));

--- a/src/app/shared/components/create-new-report-v2/create-new-report.component.spec.ts
+++ b/src/app/shared/components/create-new-report-v2/create-new-report.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
-import { TranslocoTestingModule } from '@jsverse/transloco';
 import { IonicModule } from '@ionic/angular';
 import { MatIconModule } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
@@ -20,6 +19,7 @@ import { CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA } from '@angular/core';
 import { apiExpenses1, nonReimbursableExpense } from 'src/app/core/mock-data/platform/v1/expense.data';
 import { SpenderReportsService } from 'src/app/core/services/platform/v1/spender/reports.service';
 import { expectedReportsSinglePage } from 'src/app/core/mock-data/platform-report.data';
+import { getTranslocoModule } from 'src/app/core/testing/transloco-testing.utils';
 
 describe('CreateNewReportComponent', () => {
   let component: CreateNewReportComponent;
@@ -53,7 +53,7 @@ describe('CreateNewReportComponent', () => {
         FormsModule,
         ReactiveFormsModule,
         MatCheckboxModule,
-        TranslocoTestingModule,
+        getTranslocoModule(),
       ],
       providers: [
         { provide: ModalController, useValue: modalController },

--- a/src/app/shared/components/fy-add-to-report/fy-add-to-report-modal/fy-add-to-report-modal.component.spec.ts
+++ b/src/app/shared/components/fy-add-to-report/fy-add-to-report-modal/fy-add-to-report-modal.component.spec.ts
@@ -14,7 +14,7 @@ import { SnakeCaseToSpaceCase } from 'src/app/shared/pipes/snake-case-to-space-c
 import { MatIconModule } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { click, getAllElementsBySelector, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
-import { TranslocoTestingModule } from '@jsverse/transloco';
+import { getTranslocoModule } from 'src/app/core/testing/transloco-testing.utils';
 
 describe('FyAddToReportModalComponent', () => {
   let component: FyAddToReportModalComponent;
@@ -29,7 +29,7 @@ describe('FyAddToReportModalComponent', () => {
 
     TestBed.configureTestingModule({
       declarations: [FyAddToReportModalComponent, HumanizeCurrencyPipe, ReportState, SnakeCaseToSpaceCase],
-      imports: [IonicModule.forRoot(), MatIconModule, MatIconTestingModule, TranslocoTestingModule],
+      imports: [IonicModule.forRoot(), MatIconModule, MatIconTestingModule, getTranslocoModule()],
       providers: [
         FyCurrencyPipe,
         CurrencyPipe,

--- a/src/app/shared/components/fy-add-to-report/fy-add-to-report-modal/fy-add-to-report-modal.component.spec.ts
+++ b/src/app/shared/components/fy-add-to-report/fy-add-to-report-modal/fy-add-to-report-modal.component.spec.ts
@@ -14,7 +14,7 @@ import { SnakeCaseToSpaceCase } from 'src/app/shared/pipes/snake-case-to-space-c
 import { MatIconModule } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { click, getAllElementsBySelector, getElementBySelector, getTextContent } from 'src/app/core/dom-helpers';
-import { TranslocoService, TranslocoModule } from '@jsverse/transloco';
+import { TranslocoTestingModule } from '@jsverse/transloco';
 
 describe('FyAddToReportModalComponent', () => {
   let component: FyAddToReportModalComponent;
@@ -22,47 +22,14 @@ describe('FyAddToReportModalComponent', () => {
   let modalController: jasmine.SpyObj<ModalController>;
   let cdr: jasmine.SpyObj<ChangeDetectorRef>;
   let currencyService: jasmine.SpyObj<CurrencyService>;
-  let translocoService: jasmine.SpyObj<TranslocoService>;
   beforeEach(waitForAsync(() => {
     const modalControllerSpy = jasmine.createSpyObj('ModalController', ['dismiss']);
     const cdrSpy = jasmine.createSpyObj('ChangeDetectorRef', ['detectChanges']);
     const currencyServiceSpy = jasmine.createSpyObj('CurrencyService', ['getHomeCurrency']);
-    const translocoServiceSpy = jasmine.createSpyObj('TranslocoService', ['translate'], {
-      config: {
-        reRenderOnLangChange: true,
-      },
-      langChanges$: of('en'),
-      _loadDependencies: () => Promise.resolve(),
-    });
-
-    // Mock the translate method
-    translocoServiceSpy.translate.and.callFake((key: any, params?: any) => {
-      const translations: { [key: string]: string } = {
-        'pipes.humanizeCurrency.kiloSuffix': 'K',
-        'fyAddToReportModal.title': 'Add to report',
-        'fyAddToReportModal.none': 'None',
-        'fyAddToReportModal.expense': 'Expense',
-        'fyAddToReportModal.expenses': 'Expenses',
-        'fyAddToReportModal.noReports': 'You have no reports right now',
-        'fyAddToReportModal.createNewReport': 'To create a draft report please click on',
-        'fyAddToReportModal.zeroStateAlt': 'No reports found',
-      };
-      let translation = translations[key] || key;
-
-      // Handle parameter interpolation
-      if (params && typeof translation === 'string') {
-        Object.keys(params).forEach((paramKey) => {
-          const placeholder = `{{${paramKey}}}`;
-          translation = translation.replace(placeholder, params[paramKey]);
-        });
-      }
-
-      return translation;
-    });
 
     TestBed.configureTestingModule({
       declarations: [FyAddToReportModalComponent, HumanizeCurrencyPipe, ReportState, SnakeCaseToSpaceCase],
-      imports: [IonicModule.forRoot(), MatIconModule, MatIconTestingModule, TranslocoModule],
+      imports: [IonicModule.forRoot(), MatIconModule, MatIconTestingModule, TranslocoTestingModule],
       providers: [
         FyCurrencyPipe,
         CurrencyPipe,
@@ -78,10 +45,6 @@ describe('FyAddToReportModalComponent', () => {
           provide: CurrencyService,
           useValue: currencyServiceSpy,
         },
-        {
-          provide: TranslocoService,
-          useValue: translocoServiceSpy,
-        },
       ],
     }).compileComponents();
     fixture = TestBed.createComponent(FyAddToReportModalComponent);
@@ -89,7 +52,6 @@ describe('FyAddToReportModalComponent', () => {
     modalController = TestBed.inject(ModalController) as jasmine.SpyObj<ModalController>;
     cdr = TestBed.inject(ChangeDetectorRef) as jasmine.SpyObj<ChangeDetectorRef>;
     currencyService = TestBed.inject(CurrencyService) as jasmine.SpyObj<CurrencyService>;
-    translocoService = TestBed.inject(TranslocoService) as jasmine.SpyObj<TranslocoService>;
     component.currentSelection = optionData1[0].value;
     component.options = optionData1;
     currencyService.getHomeCurrency.and.returnValue(of('USD'));
@@ -190,11 +152,11 @@ describe('FyAddToReportModalComponent', () => {
     tick();
     fixture.detectChanges();
     expect(getTextContent(reportCards[0].getElementsByClassName('report-list--purpose')[0])).toEqual(
-      optionData1[0].value.purpose
+      optionData1[0].value.purpose,
     );
 
     expect(getTextContent(reportCards[0].getElementsByClassName('report-list--count')[0])).toEqual(
-      `${optionData1[0].value.num_expenses} Expense${optionData1[0].value.num_expenses > 1 ? 's' : ''}`
+      `${optionData1[0].value.num_expenses} Expense${optionData1[0].value.num_expenses > 1 ? 's' : ''}`,
     );
 
     expect(getTextContent(reportCards[0].getElementsByClassName('report-list--currency')[0])).toEqual('$');

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -206,7 +206,6 @@
       "expenseReadyToReport": "Add {{count}} expense to report",
       "expensesReadyToReport": "Add {{count}} expenses to report",
       "unreportedExpenseSubheader": "Add complete expenses to a report and submit.",
-      "addToReport": "Add to report",
       "addCommuteDetails": "Add Commute Details",
       "addCommuteDetailsSubheader": "Add your Home and Work locations to easily deduct commute distance from your mileage expenses",
       "add": "Add"
@@ -759,7 +758,7 @@
     "mobileNumberLabel": "Mobile number"
   },
   "fyAddToReportModal": {
-    "title": "Add to report",
+    "title": "Add to expense report",
     "none": "None",
     "expense": "Expense",
     "expenses": "Expenses",
@@ -1344,7 +1343,7 @@
     "successfullyMatched": "Successfully matched the expense."
   },
   "addTxnToReportDialog": {
-    "title": "Add to report",
+    "title": "Add to expense report",
     "expense": "Expense",
     "expenses": "Expenses",
     "noReports": "You have no reports right now",
@@ -1440,7 +1439,7 @@
     "noCompleteExpenses": "You have no complete expenses",
     "clickOnThe": "Click on the",
     "toAddNewExpense": "to add a new expense to this report",
-    "addToReport": "Add to report"
+    "addToReport": "Add to expense report"
   },
   "dateRangeModal": {
     "dateRange": "Date range",
@@ -1557,7 +1556,7 @@
     "selectCustomFieldHeader": "Select {{fieldName}}",
     "enterValidCustomFieldError": "Please enter {{fieldName}}.",
     "reportLabel": "Report",
-    "addToReportLabel": "Add to report",
+    "addToReportLabel": "Add to expense report",
     "hideMoreFieldsButton": "Hide more fields",
     "showMoreFieldsButton": "Show more fields",
     "savingText": "Saving",


### PR DESCRIPTION
## Clickup
https://app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Updated UI copy from “Add to report” to “Add to expense report” across dashboard tasks, add/edit expense, mileage, per diem, modals and dialogs.
  - Standardized button text: “Saving Report” → “Saving report.”
  - Updated translations to reflect new wording.

- Tests
  - Simplified translation setup in multiple specs by adopting a shared transloco testing module, removing manual translation mocks.
  - Minor test formatting cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->