### PR TITLE
fix: set muted to true

### DIFF
--- a/src/app/auth/sign-in/sign-in.page.html
+++ b/src/app/auth/sign-in/sign-in.page.html
@@ -7,7 +7,6 @@
           width="100%"
           height="auto"
           muted
-          oncanplay="play()"
           poster="../../../assets/images/video-default-background.png"
           loop
           playsinline

--- a/src/app/auth/sign-in/sign-in.page.html
+++ b/src/app/auth/sign-in/sign-in.page.html
@@ -6,7 +6,7 @@
           class="sign-in__video-container__video"
           width="100%"
           height="auto"
-          onloadedmetadata="muted = true"
+          muted="true"
           oncanplay="play()"
           poster="../../../assets/images/video-default-background.png"
           loop

--- a/src/app/auth/sign-in/sign-in.page.html
+++ b/src/app/auth/sign-in/sign-in.page.html
@@ -6,7 +6,7 @@
           class="sign-in__video-container__video"
           width="100%"
           height="auto"
-          muted="true"
+          muted
           oncanplay="play()"
           poster="../../../assets/images/video-default-background.png"
           loop


### PR DESCRIPTION
<!--app.clickup.com-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in page background video now begins muted from initial load, eliminating any brief audio or autoplay-triggered sound; playback behavior is stable and silent across devices (other visual/video settings unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->