### PR TITLE
fix: Fyle advances use filepicker input

### DIFF
--- a/src/app/fyle/add-edit-advance-request/add-edit-advance-request-2.page.spec.ts
+++ b/src/app/fyle/add-edit-advance-request/add-edit-advance-request-2.page.spec.ts
@@ -132,11 +132,11 @@ export function TestCases2(getTestBed) {
     it('fileAttachments(): should return file attachments if ids are absent in fileObject', (done) => {
       const mockFileObjects = cloneDeep(advanceRequestFileUrlData2);
       component.dataUrls = mockFileObjects;
-      
+
       // Mock the fileUpload service to return different results for each call
       const mockFile1 = { ...cloneDeep(fileObject9[0]), id: 'file1' };
       const mockFile2 = { ...cloneDeep(fileObject9[0]), id: 'file2' };
-      
+
       let callCount = 0;
       transactionsOutboxService.fileUpload.and.callFake(() => {
         callCount++;
@@ -146,7 +146,7 @@ export function TestCases2(getTestBed) {
           return Promise.resolve(mockFile2);
         }
       });
-      
+
       component.fileAttachments().subscribe((res) => {
         expect(transactionsOutboxService.fileUpload).toHaveBeenCalledTimes(2);
         expect(res).toEqual(['file1', 'file2']);
@@ -175,7 +175,6 @@ export function TestCases2(getTestBed) {
       tick(100);
 
       expect(event.stopPropagation).toHaveBeenCalledTimes(1);
-      expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(popoverController.create).toHaveBeenCalledOnceWith({
         component: CameraOptionsPopupComponent,
         cssClass: 'camera-options-popover',
@@ -193,7 +192,7 @@ export function TestCases2(getTestBed) {
 
     it('viewAttachments(): should show the attachments as preview', fakeAsync(() => {
       component.dataUrls = cloneDeep(advanceRequestFileUrlData2);
-      
+
       let callCount = 0;
       transactionsOutboxService.fileUpload.and.callFake(() => {
         callCount++;
@@ -211,9 +210,9 @@ export function TestCases2(getTestBed) {
       const expectedAttachmentsWithIds = cloneDeep(advanceRequestFileUrlData2).map((attachment, index) => ({
         ...attachment,
         id: `file${index + 1}`,
-        type: attachment.type === 'application/pdf' || attachment.type === 'pdf' ? 'pdf' : 'image'
+        type: attachment.type === 'application/pdf' || attachment.type === 'pdf' ? 'pdf' : 'image',
       }));
-      
+
       // Check that the modal was created with the correct parameters
       expect(modalController.create).toHaveBeenCalledOnceWith({
         ...modalControllerParams4,

--- a/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.html
+++ b/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.html
@@ -50,6 +50,9 @@
           @if (dataUrls && dataUrls.length === 0) {
             <div class="add-edit-advance-request--receipt text-center">
               <div class="add-edit-advance-request--receipt-image" (click)="addAttachments($event)">
+                @if (isIos) {
+                  <input type="file" #fileUpload accept="application/pdf,image/*" class="d-none" />
+                }
                 <img class="add-edit-advance-request--receipt-image-icon" src="../../../assets/svg/list-plus.svg" />
               </div>
             </div>
@@ -78,6 +81,9 @@
             (viewAttachments)="viewAttachments()"
             [canEdit]="true"
           >
+            @if (isIos) {
+              <input type="file" #fileUpload accept="application/pdf,image/*" class="d-none" />
+            }
           </app-receipt-preview-thumbnail>
         }
 
@@ -337,7 +343,7 @@
             [loading]="saveAdvanceLoading"
             [disabled]="saveDraftAdvanceLoading || saveAdvanceLoading"
           >
-            {{ (from === 'TEAM_ADVANCE' && mode === 'edit') ? 'Save request' : 'Submit request' }}
+            {{ from === 'TEAM_ADVANCE' && mode === 'edit' ? 'Save request' : 'Submit request' }}
           </ion-button>
         }
       </ion-buttons>

--- a/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.setup.spec.ts
+++ b/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.setup.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { IonicModule, ModalController, PopoverController } from '@ionic/angular';
+import { IonicModule, ModalController, Platform, PopoverController } from '@ionic/angular';
 
 import { AddEditAdvanceRequestPage } from './add-edit-advance-request.page';
 import { AdvanceRequestService } from 'src/app/core/services/advance-request.service';
@@ -69,7 +69,7 @@ describe('AddEditAdvanceRequestPage', () => {
       'generateUrls',
       'generateUrlsBulk',
       'downloadFile',
-      'attachToAdvance'
+      'attachToAdvance',
     ]);
     const approverFileServiceSpyObj = jasmine.createSpyObj('ApproverFileService', [
       'createFile',
@@ -78,8 +78,10 @@ describe('AddEditAdvanceRequestPage', () => {
       'generateUrlsBulk',
       'downloadFile',
       'deleteFilesBulk',
-      'attachToAdvance'
+      'attachToAdvance',
     ]);
+
+    const platformSpyObj = jasmine.createSpyObj('Platform', ['is']);
 
     TestBed.configureTestingModule({
       declarations: [AddEditAdvanceRequestPage],
@@ -105,6 +107,7 @@ describe('AddEditAdvanceRequestPage', () => {
         { provide: Router, useValue: routerSpyObj },
         { provide: SpenderFileService, useValue: spenderFileServiceSpyObj },
         { provide: ApproverFileService, useValue: approverFileServiceSpyObj },
+        { provide: Platform, useValue: platformSpyObj },
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.setup.spec.ts
+++ b/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.setup.spec.ts
@@ -53,6 +53,7 @@ describe('AddEditAdvanceRequestPage', () => {
       'getImageTypeFromDataUrl',
       'downloadUrl',
       'findByAdvanceRequestId',
+      'readFile',
     ]);
     const orgSettingsServiceSpyObj = jasmine.createSpyObj('OrgSettingsService', ['get']);
     const networkServiceSpyObj = jasmine.createSpyObj('NetworkService', ['connectivityWatcher', 'isOnline']);

--- a/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.ts
+++ b/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostListener, OnInit, ViewChild, inject } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostListener, OnInit, ViewChild, inject, viewChild } from '@angular/core';
 import {
   AbstractControl,
   UntypedFormArray,
@@ -8,9 +8,9 @@ import {
   Validators,
 } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ModalController, PopoverController } from '@ionic/angular';
-import { concat, forkJoin, from, iif, noop, Observable, of } from 'rxjs';
-import { concatMap, finalize, map, reduce, shareReplay, switchMap } from 'rxjs/operators';
+import { ModalController, Platform, PopoverController } from '@ionic/angular';
+import { concat, forkJoin, from, iif, noop, Observable, of, timer } from 'rxjs';
+import { concatMap, finalize, map, raceWith, reduce, shareReplay, switchMap } from 'rxjs/operators';
 import { AdvanceRequestService } from 'src/app/core/services/advance-request.service';
 
 import { AuthService } from 'src/app/core/services/auth.service';
@@ -39,7 +39,6 @@ import { AdvanceRequestActions } from 'src/app/core/models/advance-request-actio
 import { CurrencyObj } from 'src/app/core/models/currency-obj.model';
 import { AdvanceRequestFile } from 'src/app/core/models/advance-request-file.model';
 import { AdvanceRequestsCustomFields } from 'src/app/core/models/advance-requests-custom-fields.model';
-import { File } from 'src/app/core/models/file.model';
 import { AdvanceRequestCustomFieldValues } from 'src/app/core/models/advance-request-custom-field-values.model';
 import { AdvanceRequestDeleteParams } from 'src/app/core/models/advance-request-delete-params.model';
 import { PlatformEmployeeSettingsService } from 'src/app/core/services/platform/v1/spender/employee-settings.service';
@@ -93,7 +92,11 @@ export class AddEditAdvanceRequestPage implements OnInit {
 
   private approverFileService = inject(ApproverFileService);
 
+  private platform = inject(Platform);
+
   @ViewChild('formContainer') formContainer: ElementRef;
+
+  readonly fileUpload = viewChild<ElementRef<HTMLInputElement>>('fileUpload');
 
   isConnected$: Observable<boolean>;
 
@@ -112,6 +115,8 @@ export class AddEditAdvanceRequestPage implements OnInit {
   customFields$: Observable<AdvanceRequestsCustomFields[]>;
 
   dataUrls: FileObject[];
+
+  isIos = false;
 
   customFieldValues: AdvanceRequestCustomFieldValues[];
 
@@ -340,32 +345,32 @@ export class AddEditAdvanceRequestPage implements OnInit {
           if (!advanceReqPlatform || !advanceReqPlatform.user?.id) {
             return of<string[]>([]);
           }
-          
+
           return from(this.authService.getEou()).pipe(
             switchMap((eou) => {
               if (!eou || !eou.ou || !eou.ou.org_id) {
                 return of<string[]>([]);
               }
-              
+
               const fileUploadObservables: Observable<string>[] = [];
-              
+
               this.dataUrls.forEach((dataUrl) => {
                 dataUrl.type = dataUrl.type === 'application/pdf' || dataUrl.type === 'pdf' ? 'pdf' : 'image';
-                
+
                 if (!dataUrl.id) {
                   fileUploadObservables.push(
-                    from(this.transactionsOutboxService.fileUpload(
-                      dataUrl.url, 
-                      dataUrl.type, 
-                      { userId: advanceReqPlatform.user.id, orgId: advanceReqPlatform.org_id },
-                      true
-                    )).pipe(
-                      map((fileObj: FileObject) => fileObj.id || ''),
-                    ),
+                    from(
+                      this.transactionsOutboxService.fileUpload(
+                        dataUrl.url,
+                        dataUrl.type,
+                        { userId: advanceReqPlatform.user.id, orgId: advanceReqPlatform.org_id },
+                        true,
+                      ),
+                    ).pipe(map((fileObj: FileObject) => fileObj.id || '')),
                   );
                 }
               });
-              
+
               return iif(() => fileUploadObservables.length !== 0, forkJoin(fileUploadObservables), of<string[]>([]));
             }),
           );
@@ -373,10 +378,10 @@ export class AddEditAdvanceRequestPage implements OnInit {
       );
     } else {
       const fileUploadObservables: Observable<string>[] = [];
-      
+
       this.dataUrls.forEach((dataUrl) => {
         dataUrl.type = dataUrl.type === 'application/pdf' || dataUrl.type === 'pdf' ? 'pdf' : 'image';
-        
+
         if (!dataUrl.id) {
           fileUploadObservables.push(
             from(this.transactionsOutboxService.fileUpload(dataUrl.url, dataUrl.type)).pipe(
@@ -385,70 +390,108 @@ export class AddEditAdvanceRequestPage implements OnInit {
           );
         }
       });
-      
+
       return iif(() => fileUploadObservables.length !== 0, forkJoin(fileUploadObservables), of<string[]>([]));
     }
   }
 
+  async uploadFileCallback(file: Blob): Promise<void> {
+    let fileData: { type: string; url: string; thumbnail: string };
+    if (file) {
+      const fileRead$ = from(this.fileService.readFile(file));
+      const delayedLoader$ = timer(300).pipe(
+        switchMap(() => from(this.loaderService.showLoader('Please wait...', 5000))),
+        switchMap(() => fileRead$), // switch to fileRead$ after showing loader
+      );
+      // Use race to show loader only if fileRead$ takes more than 300ms.
+      fileRead$
+        .pipe(
+          raceWith(delayedLoader$),
+          map((dataUrl) => {
+            fileData = {
+              type: file.type,
+              url: dataUrl,
+              thumbnail: dataUrl,
+            };
+            this.dataUrls.push(fileData);
+          }),
+          finalize(() => this.loaderService.hideLoader()),
+        )
+        .subscribe();
+    }
+  }
+
+  async onChangeCallback(nativeElement: HTMLInputElement): Promise<void> {
+    const file = nativeElement.files[0];
+    this.uploadFileCallback(file);
+  }
+
   async addAttachments(event: Event): Promise<void> {
     event.stopPropagation();
-    event.preventDefault();
 
-    const cameraOptionsPopup = await this.popoverController.create({
-      component: CameraOptionsPopupComponent,
-      cssClass: 'camera-options-popover',
-    });
-
-    await cameraOptionsPopup.present();
-
-    let { data: receiptDetails } = await cameraOptionsPopup.onWillDismiss<{
-      dataUrl: string;
-      type: string;
-      option?: string;
-    }>();
-
-    if (receiptDetails && receiptDetails.option === 'camera') {
-      const captureReceiptModal = await this.modalController.create({
-        component: CaptureReceiptComponent,
-        componentProps: {
-          isModal: true,
-          allowGalleryUploads: false,
-          allowBulkFyle: false,
-        },
-        cssClass: 'hide-modal',
+    if (this.platform.is('ios')) {
+      const nativeElement = this.fileUpload().nativeElement;
+      nativeElement.onchange = async (): Promise<void> => {
+        this.onChangeCallback(nativeElement);
+      };
+      nativeElement.click();
+    } else {
+      const cameraOptionsPopup = await this.popoverController.create({
+        component: CameraOptionsPopupComponent,
+        cssClass: 'camera-options-popover',
       });
-      await captureReceiptModal.present();
-      this.isCameraPreviewStarted = true;
 
-      const { data } = await captureReceiptModal.onWillDismiss<{ dataUrl: string }>();
-      this.isCameraPreviewStarted = false;
+      await cameraOptionsPopup.present();
 
-      if (data && data.dataUrl) {
-        receiptDetails = { ...data, type: this.fileService.getImageTypeFromDataUrl(data.dataUrl) };
+      let { data: receiptDetails } = await cameraOptionsPopup.onWillDismiss<{
+        dataUrl: string;
+        type: string;
+        option?: string;
+      }>();
+
+      if (receiptDetails && receiptDetails.option === 'camera') {
+        const captureReceiptModal = await this.modalController.create({
+          component: CaptureReceiptComponent,
+          componentProps: {
+            isModal: true,
+            allowGalleryUploads: false,
+            allowBulkFyle: false,
+          },
+          cssClass: 'hide-modal',
+        });
+        await captureReceiptModal.present();
+        this.isCameraPreviewStarted = true;
+
+        const { data } = await captureReceiptModal.onWillDismiss<{ dataUrl: string }>();
+        this.isCameraPreviewStarted = false;
+
+        if (data && data.dataUrl) {
+          receiptDetails = { ...data, type: this.fileService.getImageTypeFromDataUrl(data.dataUrl) };
+        }
       }
-    }
-    if (receiptDetails && receiptDetails.dataUrl) {
-      this.dataUrls.push({
-        type: receiptDetails.type,
-        url: receiptDetails.dataUrl,
-        thumbnail: receiptDetails.dataUrl,
-      });
+      if (receiptDetails && receiptDetails.dataUrl) {
+        this.dataUrls.push({
+          type: receiptDetails.type,
+          url: receiptDetails.dataUrl,
+          thumbnail: receiptDetails.dataUrl,
+        });
+      }
     }
   }
 
   async viewAttachments(): Promise<void> {
     this.attachmentUploadInProgress = true;
-    
+
     const fileIds = await this.fileAttachments().toPromise();
-    
+
     if (fileIds && fileIds.length > 0) {
       let fileIdIndex = 0;
-      this.dataUrls = this.dataUrls.map(attachment => {
+      this.dataUrls = this.dataUrls.map((attachment) => {
         if (!attachment.id && fileIdIndex < fileIds.length) {
           return {
             ...attachment,
             id: fileIds[fileIdIndex++],
-            type: attachment.type === 'application/pdf' || attachment.type === 'pdf' ? 'pdf' : 'image'
+            type: attachment.type === 'application/pdf' || attachment.type === 'pdf' ? 'pdf' : 'image',
           };
         }
         return attachment;
@@ -458,14 +501,17 @@ export class AddEditAdvanceRequestPage implements OnInit {
       if (this.id) {
         if (this.from === 'TEAM_ADVANCE') {
           // For team advances, use approver service
-          await this.advanceRequestService.getApproverAdvanceRequestRaw(this.id).pipe(
-            switchMap((advanceReqPlatform) => {
-              if (advanceReqPlatform?.user?.id) {
-                return this.approverFileService.attachToAdvance(this.id, fileIds, advanceReqPlatform.user.id);
-              }
-              return of(null);
-            })
-          ).toPromise();
+          await this.advanceRequestService
+            .getApproverAdvanceRequestRaw(this.id)
+            .pipe(
+              switchMap((advanceReqPlatform) => {
+                if (advanceReqPlatform?.user?.id) {
+                  return this.approverFileService.attachToAdvance(this.id, fileIds, advanceReqPlatform.user.id);
+                }
+                return of(null);
+              }),
+            )
+            .toPromise();
         } else {
           // For regular advances, use spender service
           await this.spenderFileService.attachToAdvance(this.id, fileIds).toPromise();
@@ -617,6 +663,7 @@ export class AddEditAdvanceRequestPage implements OnInit {
   }
 
   ionViewWillEnter(): void {
+    this.isIos = this.platform.is('ios');
     this.mode = (this.activatedRoute.snapshot.params.id as string) ? 'edit' : 'add';
     const orgSettings$ = this.orgSettingsService.get();
     this.homeCurrency$ = this.currencyService.getHomeCurrency();
@@ -726,7 +773,7 @@ export class AddEditAdvanceRequestPage implements OnInit {
             switchMap((advanceReqPlatform) => {
               const orgId = advanceReqPlatform.ou.org_id;
               return this.advanceRequestService.getCustomFieldsForApprover(orgId);
-            })
+            }),
           )
         : this.advanceRequestService.getCustomFieldsForSpender()
     ).pipe(

--- a/src/app/fyle/my-profile/verify-number-popover/verify-number-popover.component.spec.ts
+++ b/src/app/fyle/my-profile/verify-number-popover/verify-number-popover.component.spec.ts
@@ -104,13 +104,12 @@ describe('VerifyNumberPopoverComponent', () => {
   });
 
   it('ngAfterViewInit(): should focus on input element on init', fakeAsync(() => {
-    const inputElement = getElementBySelector(fixture, 'input') as HTMLInputElement;
-    component.inputEl.nativeElement = inputElement;
     component.error = null;
+    spyOn(component.inputEl.nativeElement, 'focus');
     component.ngAfterViewInit();
     tick(200);
 
-    expect(document.activeElement).toEqual(inputElement);
+    expect(component.inputEl.nativeElement.focus).toHaveBeenCalledOnceWith();
   }));
 
   it('validateInput(): should set error message if input is invalid', () => {

--- a/src/app/shared/components/capture-receipt/capture-receipt.component.html
+++ b/src/app/shared/components/capture-receipt/capture-receipt.component.html
@@ -1,5 +1,4 @@
 <app-camera-preview
-  class="camer-preview-component"
   #cameraPreview
   [isBulkMode]="isBulkMode"
   [isOffline]="isOffline$ | async"

--- a/src/app/shared/components/capture-receipt/capture-receipt.component.scss
+++ b/src/app/shared/components/capture-receipt/capture-receipt.component.scss
@@ -1,3 +1,0 @@
-.camer-preview-component {
-  height: 100%;
-}


### PR DESCRIPTION
## Clickup
https://app.clickup.com

## Code Coverage
Please add code coverage here

## UI Preview
Please add screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS users can attach receipts/files (images & PDFs) via the native file picker in advance requests; camera capture remains on other platforms.

* **Style**
  * Receipt capture/preview layout adjusted for better fit and flexible height.

* **Tests**
  * Added platform-aware tests to cover the iOS attachment flow and file upload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->