### PR TITLE
fix: audit trail timestamp font size

### DIFF
--- a/src/app/shared/components/comments-history/audit-history/audit-history.component.scss
+++ b/src/app/shared/components/comments-history/audit-history/audit-history.component.scss
@@ -32,6 +32,7 @@
   &--timestamp {
     margin: -20px 0 16px 30px;
     color: colors.$sage-text-tertiary;
+    font-size: 12px;
   }
 
   &--comment-block {


### PR DESCRIPTION
## Clickup
app.clickup.com

## Code Coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Reduced the timestamp text size in the audit history to 12px for a more compact, polished look.
  * Improves visual hierarchy and scanability by de-emphasizing metadata relative to comment content.
  * Preserves existing spacing and color, with no layout or behavioral changes.
  * Enhances readability in dense threads without affecting functionality or interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->